### PR TITLE
fix: add nix pkgs for building on x86 mac

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -608,11 +608,11 @@
         "nixpkgs": "nixpkgs_11"
       },
       "locked": {
-        "lastModified": 1707444620,
-        "narHash": "sha256-P8kRkiJLFttN+hbAOlm11wPxUrQZqKle+QtVCqFiGXY=",
+        "lastModified": 1707963067,
+        "narHash": "sha256-1vmNGzAIenei+keS8vIUNYVkEGwEwF+3FR7/bXU/r18=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "78503e9199010a4df714f29a4f9c00eb2ccae071",
+        "rev": "23f224428779539eb4dc13f6a77c97ffe4680d74",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,8 @@
           pkgs.libusb
           pkgs.pkg-config
           pkgs.wasm-bindgen-cli
+          pkgs.libiconv
+          pkgs.gettext
         ] ++ (pkgs.lib.optionals pkgs.stdenv.isDarwin [
           pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
           pkgs.darwin.apple_sdk.frameworks.AppKit
@@ -57,6 +59,8 @@
           pkgs.gtk3
           pkgs.libsoup
           pkgs.librsvg
+          pkgs.libiconv
+          pkgs.gettext
         ]
         ++ (pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [
           # This is probably needed but is is marked as broken in nixpkgs
@@ -243,6 +247,8 @@
             pkgs.dbus
             pkgs.openssl_3
             pkgs.librsvg
+            pkgs.libiconv
+            pkgs.gettext
           ]
           ++ (pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [
             # This is probably needed but is is marked as broken in nixpkgs


### PR DESCRIPTION
I still get the same error when launching binaries on mac x86  built in the tauri-shell on mac x86 