### PR TITLE
revert: setting LD_LIBRARY_PATH & cleanup debugging scratch

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -256,20 +256,12 @@
           ++ (pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [
             # This is probably needed but is is marked as broken in nixpkgs
             pkgs.webkitgtk
-            # pkgs.glibc
           ]);
         in pkgs.mkShell {
           packages = sol-build-inputs ++ rust-build-inputs ++ node-build-inputs ++ tauri-build-inputs;
-          # nativeBuildInputs = [pkgs.pkg-config];
-          # buildInputs = [ pkgs.gtk3 pkgs.glib ];
-          # buildInputs = tauri-libraries;
           buildInputs = [pkgs.pkg-config];
           shellHook =
             ''
-              echo "pkg config path"
-              echo $PKG_CONFIG_PATH
-              export PATH="/usr/bin:$PATH"
-              export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath tauri-libraries}:$LD_LIBRARY_PATH
               export WEBKIT_DISABLE_COMPOSITING_MODE=1
               export XDG_DATA_DIRS=${pkgs.gsettings-desktop-schemas}/share/gsettings-schemas/${pkgs.gsettings-desktop-schemas.name}:${pkgs.gtk3}/share/gsettings-schemas/${pkgs.gtk3.name}:$XDG_DATA_DIRS
             '';

--- a/flake.nix
+++ b/flake.nix
@@ -262,6 +262,7 @@
           buildInputs = [pkgs.pkg-config];
           shellHook =
             ''
+              export PATH="/usr/bin:$PATH"
               export WEBKIT_DISABLE_COMPOSITING_MODE=1
               export XDG_DATA_DIRS=${pkgs.gsettings-desktop-schemas}/share/gsettings-schemas/${pkgs.gsettings-desktop-schemas.name}:${pkgs.gtk3}/share/gsettings-schemas/${pkgs.gtk3.name}:$XDG_DATA_DIRS
             '';


### PR DESCRIPTION
I think we tried a bunch of changes trying to debug mac builds that weren't actually useful. One of them broke linux builds. This reverts that change and cleans up the commented out debugging work.

**todo**
- [x] run a mac build locally off this branch to confirm they still build & run properly.