### PR TITLE
2024 03 17 add glib-networking

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -282,6 +282,7 @@
               export PATH="$TMP_BASE64_PATH:$PATH:/usr/bin"
               export WEBKIT_DISABLE_COMPOSITING_MODE=1
               export XDG_DATA_DIRS=${pkgs.gsettings-desktop-schemas}/share/gsettings-schemas/${pkgs.gsettings-desktop-schemas.name}:${pkgs.gtk3}/share/gsettings-schemas/${pkgs.gtk3.name}:$XDG_DATA_DIRS
+              export GIO_MODULE_DIR="${pkgs.glib-networking}/lib/gio/modules/";
             '';
         };
       }

--- a/flake.nix
+++ b/flake.nix
@@ -66,6 +66,7 @@
           pkgs.librsvg
           pkgs.gettext
           pkgs.libiconv
+          pkgs.glib-networking
         ]
         ++ (pkgs.lib.optionals (!pkgs.stdenv.isDarwin) [
           # This is probably needed but is is marked as broken in nixpkgs


### PR DESCRIPTION
This is a requirement for the tauri app to have walletconnect on linux.

I confirmed it doesn't change the libraries required by mac binaries. The env variable is GTK-specific so should not impact mac os.