### PR TITLE
fix tauri cli to v1

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -116,7 +116,7 @@
         };
 
         tauri-build-inputs = [
-          pkgs.cargo-tauri
+          pkgs.cargo-tauri_1
           pkgs.curl
           pkgs.wget
           pkgs.pkg-config
@@ -139,7 +139,7 @@
           # Currently we don't use the tauri build inputs as above because
           # it doesn't seem to be totally supported by the github action, even
           # though the above is as documented by tauri.
-          paths = [pkgs.cargo-tauri] ++ rust-build-inputs ++ node-build-inputs;
+          paths = [pkgs.cargo-tauri_1] ++ rust-build-inputs ++ node-build-inputs;
         };
 
         # https://ertt.ca/nix/shell-scripts/


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation
after flake update, the default `cargo-tauri` bin is reserved for tauri cli v2 and we get error for building tauri app  because raindex tauri app is using v1, which is now under `cargo-tauri_1`,

<img width="1205" alt="Screenshot 2025-03-05 at 4 24 55 PM" src="https://github.com/user-attachments/assets/8e33495c-b90f-41d4-9fb8-4153b67ce0a7" />

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [ ] made this PR as small as possible
- [ ] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)
