### PR TITLE
configure rust analyzer

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,7 @@
         rust-version = "1.79.0";
         rust-toolchain = pkgs.rust-bin.stable.${rust-version}.default.override (previous: {
           targets = previous.targets ++ [ "wasm32-unknown-unknown" ];
+          extensions = previous.extensions ++ [ "rust-src" ];
         });
 
         rust-build-inputs = [
@@ -361,7 +362,9 @@
         };
 
         devShells.default = pkgs.mkShell {
-          buildInputs = sol-build-inputs ++ rust-build-inputs ++ node-build-inputs ++ rainix-tasks ++ subgraph-tasks ++ [ the-graph goldsky ];
+          buildInputs =
+            sol-build-inputs ++ rust-build-inputs ++ node-build-inputs
+            ++ rainix-tasks ++ subgraph-tasks ++ [ the-graph goldsky pkgs.rust-analyzer ];
           shellHook =
           ''
           ${source-dotenv}
@@ -390,7 +393,10 @@
             pkgs.webkitgtk
           ]);
         in pkgs.mkShell {
-          buildInputs = sol-build-inputs ++ rust-build-inputs ++ node-build-inputs ++ tauri-build-inputs;
+          buildInputs =
+            sol-build-inputs ++ rust-build-inputs ++ node-build-inputs
+            ++ tauri-build-inputs ++ [ pkgs.rust-analyzer ];
+
           shellHook =
             ''
               ${source-dotenv}


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

From yesterday's conversation:

> we all use vscode so use rust analyzer via the extension
> 
> 
> 0xgleb, [19 Mar 2025 at 02:26:10 (19 Mar 2025 at 02:26:39)]:
> I'm using Cursor, which is a vscode fork, and for me rust-analyzer always breaks if Rust is set up with Nix and rust-analyzer isn't 🤷‍♂️
> 
> 
> thedavidmeister, [19 Mar 2025 at 02:39:50]:
> @dianov if you put up a PR to rainix i can merge tomorrow
> 
> 
> josh | rainlang.xyz, [19 Mar 2025 at 03:09:34]:
> ah yeah, we've had issues actually
> 
> 
> i use cursor too
> 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

1. Enable `rust-src` extension for `rust-toolchain`
2. Add `rust-analyzer` to dev shells

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Checks
<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [X] made this PR as small as possible
- [ ] unit-tested any new functionality
- [ ] linked any relevant issues or PRs
- [ ] included screenshots (if this involves a front-end change)
