### PR TITLE
Add prettier pre-commit hook for Svelte/TS/JS/JSON

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,3 @@
 {
-  "recommendations": [
-    "jnoortheen.nix-ide"
-  ]
+  "recommendations": ["jnoortheen.nix-ide"]
 }

--- a/flake.nix
+++ b/flake.nix
@@ -446,6 +446,17 @@
               pass_filenames = false;
             };
 
+            # Svelte/JS/TS
+            prettier = {
+              enable = true;
+              types_or = [
+                "svelte"
+                "ts"
+                "javascript"
+                "json"
+              ];
+            };
+
             # Misc
             denofmt = {
               enable = true;
@@ -453,6 +464,7 @@
                 ".*\\.ts$"
                 ".*\\.js$"
                 ".*\\.json$"
+                ".*\\.svelte$"
               ];
             };
             yamlfmt.enable = true;

--- a/test/fixture/subgraph/src/mapping.ts
+++ b/test/fixture/subgraph/src/mapping.ts
@@ -2,7 +2,9 @@ import { SetNumber as SetNumberEvent } from "../generated/Counter/Counter";
 import { SetNumber } from "../generated/schema";
 
 export function handleSetNumber(event: SetNumberEvent): void {
-  let entity = new SetNumber(event.transaction.hash.concatI32(event.logIndex.toI32()));
+  let entity = new SetNumber(
+    event.transaction.hash.concatI32(event.logIndex.toI32()),
+  );
   entity.newNumber = event.params.newNumber;
   entity.save();
 }


### PR DESCRIPTION
## Summary
- Add prettier pre-commit hook targeting svelte, ts, js, and json files
- Exclude .svelte from denofmt to avoid formatter conflicts
- Closes #51

## Test plan
- [x] Hook skips correctly in repos without matching files
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added/updated pre-commit formatting hooks to enforce consistent formatting for Svelte/TypeScript/JavaScript/JSON and adjusted exclusions for formatter runs.
  * Reformatted editor recommendations configuration without changing recommended extensions.
* **Tests**
  * Minor formatting change in a test fixture to improve readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->