### PR TITLE
fix(prettier): use consumer's pinned prettier so plugin chain stays in sync

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -393,6 +393,7 @@
           body = ''
             bats test/bats/devshell/default/solc.test.bats
             bats test/bats/devshell/default/gh.test.bats
+            bats test/bats/devshell/default/prettier-svelte.test.bats
             bats test/bats/task/skip-simulation.test.bats
             bats test/bats/task/subgraph-build.test.bats
             bats test/bats/task/subgraph-deploy-version.test.bats
@@ -446,9 +447,25 @@
               pass_filenames = false;
             };
 
-            # Svelte/JS/TS
+            # Svelte/JS/TS — prefer the consumer's pinned prettier from
+            # node_modules so prettier core stays in sync with whatever
+            # plugins the consumer pins (e.g. prettier-plugin-svelte +
+            # prettier-plugin-tailwindcss together corrupt embedded TS in
+            # `<script lang="ts">` blocks under nixpkgs prettier 3.6.2).
+            # Falls back to nixpkgs prettier when no node_modules exists,
+            # which keeps the hook useful for plain JSON/JS in flakes that
+            # don't ship a package.json (rainix itself).
             prettier = {
               enable = true;
+              entry = toString (
+                pkgs.writeShellScript "prettier-conditional" ''
+                  set -e
+                  if [ -x node_modules/.bin/prettier ]; then
+                    exec node_modules/.bin/prettier --ignore-unknown --list-different --write "$@"
+                  fi
+                  exec ${pkgs.prettier}/bin/prettier --ignore-unknown --list-different --write "$@"
+                ''
+              );
               types_or = [
                 "svelte"
                 "ts"

--- a/test/bats/devshell/default/prettier-svelte.test.bats
+++ b/test/bats/devshell/default/prettier-svelte.test.bats
@@ -1,0 +1,49 @@
+@test "prettier hook preserves TypeScript enum bodies in Svelte files when consumer pins prettier" {
+	tmpdir="$(mktemp -d)"
+
+	cat > "$tmpdir/package.json" <<'PJSON'
+{ "name": "fixture", "version": "0.0.0", "private": true }
+PJSON
+
+	# Mirrors the cyclo.site .prettierrc: the bug requires BOTH the svelte
+	# plugin and the tailwindcss plugin to be loaded — the tailwindcss
+	# plugin's wrapping of the formatter, combined with nixpkgs prettier
+	# 3.6.2, is what corrupts the embedded TS in `<script lang="ts">`.
+	cat > "$tmpdir/.prettierrc" <<'PCFG'
+{
+	"plugins": ["prettier-plugin-svelte", "prettier-plugin-tailwindcss"],
+	"overrides": [{ "files": "*.svelte", "options": { "parser": "svelte" } }]
+}
+PCFG
+
+	cat > "$tmpdir/Lock.svelte" <<'SVELTE'
+<script lang="ts">
+	enum ButtonStatus {
+		READY = 'LOCK'
+	}
+</script>
+SVELTE
+
+	cd "$tmpdir"
+	npm install --no-save --silent --no-audit --no-fund \
+		prettier@3.1.1 \
+		prettier-plugin-svelte@3.1.2 \
+		prettier-plugin-tailwindcss@0.5.14 \
+		svelte@4.2.7
+
+	# .pre-commit-config.yaml has leading comment lines added by git-hooks.nix;
+	# strip them so jq can parse the JSON body.
+	prettier_entry="$(grep -v '^#' "${BATS_TEST_DIRNAME}/../../../../.pre-commit-config.yaml" | jq -r '.repos[0].hooks[] | select(.name == "prettier") | .entry')"
+
+	bash -c "$prettier_entry Lock.svelte"
+
+	actual="$(cat "$tmpdir/Lock.svelte")"
+
+	rm -rf "$tmpdir"
+
+	# The bug strips the enum body, leaving the syntactically invalid
+	# `enum ButtonStatus` (no `{ ... }`). Prettier may reformat the
+	# enum body's whitespace/quoting, so assert the body opening brace
+	# survives rather than byte-equality.
+	echo "$actual" | grep -q 'enum ButtonStatus {'
+}


### PR DESCRIPTION
## Summary

- Switch the pre-commit prettier hook from nixpkgs prettier 3.6.2 to a wrapper that prefers `node_modules/.bin/prettier`, falling back to nixpkgs prettier when no consumer prettier is installed.
- Add a bats test reproducing the bug — fails on the unfixed hook, passes on the fixed hook (mutation tested).
- Wire the new test into `default-shell-test`.

The bug requires both `prettier-plugin-svelte` and `prettier-plugin-tailwindcss` to be loaded; their combined plugin chain under nixpkgs prettier 3.6.2 strips TypeScript `enum` bodies inside `<script lang="ts">` blocks of `.svelte` files, producing syntactically invalid output that the hook writes back to disk. With the consumer's pinned prettier in charge, plugin chain and core stay version-aligned and the corruption doesn't fire.

Closes #117.

## Test plan

- [x] `bats test/bats/devshell/default/prettier-svelte.test.bats` fails on `main` (unfixed)
- [x] same test passes on this branch
- [x] mutation: revert just the wrapper in `flake.nix` → test fails again; restore → passes
- [x] `nix develop -c bash -c 'bats test/bats/devshell/default/*.test.bats'` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added test verifying the prettier hook correctly handles TypeScript enums in Svelte files with custom configurations.

* **Chores**
  * Enhanced prettier pre-commit hook with improved fallback behavior for version resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->