### PR TITLE
feat(prettier): rainix-curated prettier bundle with no-consumer-prettier guard

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+test/fixture/
+prettier-bundle/

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -6,6 +6,7 @@ path = [
   "flake.lock",
   ".gitignore",
   ".gitmodules",
+  ".prettierignore",
   "REUSE.toml",
   "CLAUDE.md",
   "README.md",
@@ -15,6 +16,7 @@ path = [
   "lib/**/",
   "test/**/",
   "audit/**/",
+  "prettier-bundle/**/",
 ]
 SPDX-FileCopyrightText = "Copyright (c) 2020 thedavidmeister"
 SPDX-License-Identifier = "LicenseRef-DCL-1.0"

--- a/flake.nix
+++ b/flake.nix
@@ -134,6 +134,28 @@
           '';
         };
 
+        # rainix-curated prettier bundle: a single nix-built node_modules
+        # tree containing prettier + the standardized plugins, plus a
+        # .prettierrc.json picked up via PRETTIER_BUNDLE_DIR. Consumers
+        # MUST NOT ship their own prettier or prettier-plugin-* packages —
+        # the no-consumer-prettier pre-commit hook below enforces that.
+        prettier-bundle = pkgs.buildNpmPackage {
+          pname = "rainix-prettier-bundle";
+          version = "0.0.0";
+          src = ./prettier-bundle;
+          npmDepsHash = "sha256-64dISGPfTPK7LUSL43CKoHM5SPZYqx6Ngg2dBgsqIyg=";
+          dontNpmBuild = true;
+          installPhase = ''
+            runHook preInstall
+            mkdir -p $out
+            cp -r node_modules $out/
+            cp .prettierrc.json $out/
+            mkdir -p $out/bin
+            ln -s $out/node_modules/.bin/prettier $out/bin/prettier
+            runHook postInstall
+          '';
+        };
+
         tauri-build-inputs = [
           pkgs.cargo-tauri_1
           pkgs.curl
@@ -393,6 +415,7 @@
           body = ''
             bats test/bats/devshell/default/solc.test.bats
             bats test/bats/devshell/default/gh.test.bats
+            bats test/bats/devshell/default/prettier-bundle.test.bats
             bats test/bats/task/skip-simulation.test.bats
             bats test/bats/task/subgraph-build.test.bats
             bats test/bats/task/subgraph-deploy-version.test.bats
@@ -446,15 +469,69 @@
               pass_filenames = false;
             };
 
-            # Svelte/JS/TS
+            # Svelte/JS/TS — use the rainix-curated prettier bundle so all
+            # consumers run identical prettier core + plugin versions AND
+            # identical formatting rules. `no-consumer-prettier` below blocks
+            # consumers from shipping their own prettier, plugins, or
+            # prettierrc, so the bundle is the only prettier in play.
             prettier = {
               enable = true;
+              entry = toString (
+                pkgs.writeShellScript "prettier-rainix-bundled" ''
+                  set -e
+                  exec ${prettier-bundle}/bin/prettier \
+                    --config=${prettier-bundle}/.prettierrc.json \
+                    --plugin=${prettier-bundle}/node_modules/prettier-plugin-svelte/plugin.js \
+                    --plugin=${prettier-bundle}/node_modules/prettier-plugin-tailwindcss/dist/index.mjs \
+                    --ignore-unknown --list-different --write "$@"
+                ''
+              );
               types_or = [
                 "svelte"
                 "ts"
                 "javascript"
                 "json"
               ];
+            };
+
+            # Block consumers from shipping their own prettier, prettier
+            # plugins, or prettierrc. The rainix bundle is the canonical
+            # source; any consumer-side prettier setup either reintroduces
+            # the version-skew bug (#117) or lets formatting drift from the
+            # rainix standard.
+            no-consumer-prettier = {
+              enable = true;
+              name = "no-consumer-prettier";
+              entry = toString (
+                pkgs.writeShellScript "no-consumer-prettier" ''
+                  set -e
+                  if [ -f package.json ]; then
+                    forbidden="$(${pkgs.jq}/bin/jq -r '
+                      [.dependencies // {}, .devDependencies // {}]
+                      | add // {}
+                      | keys[]
+                      | select(. == "prettier" or startswith("prettier-plugin-"))
+                    ' package.json)"
+                    if [ -n "$forbidden" ]; then
+                      echo "ERROR: package.json must not declare prettier or prettier-plugin-*." >&2
+                      echo "rainix supplies these via the pre-commit hook bundle." >&2
+                      echo "Forbidden packages found:" >&2
+                      printf '  - %s\n' $forbidden >&2
+                      exit 1
+                    fi
+                  fi
+                  for cfg in .prettierrc .prettierrc.json .prettierrc.yaml .prettierrc.yml .prettierrc.toml .prettierrc.js .prettierrc.cjs .prettierrc.mjs prettier.config.js prettier.config.cjs prettier.config.mjs; do
+                    if [ -e "$cfg" ]; then
+                      echo "ERROR: $cfg is present in the repo." >&2
+                      echo "rainix supplies the canonical prettier config via the bundle." >&2
+                      echo "Delete $cfg." >&2
+                      exit 1
+                    fi
+                  done
+                ''
+              );
+              files = "(^package\\.json$|^\\.prettierrc(\\.[a-z]+)?$|^prettier\\.config\\.[a-z]+$)";
+              pass_filenames = false;
             };
 
             # Misc
@@ -499,6 +576,7 @@
             rainix-rs-test
             rainix-rs-artifacts
             tauri-release-env
+            prettier-bundle
             ;
         };
 

--- a/flake.nix
+++ b/flake.nix
@@ -506,21 +506,44 @@
                 pkgs.writeShellScript "no-consumer-prettier" ''
                   set -e
                   if [ -f package.json ]; then
-                    forbidden="$(${pkgs.jq}/bin/jq -r '
-                      [.dependencies // {}, .devDependencies // {}]
+                    forbidden_deps="$(${pkgs.jq}/bin/jq -r '
+                      [.dependencies // {}, .devDependencies // {}, .optionalDependencies // {}, .peerDependencies // {}]
                       | add // {}
                       | keys[]
                       | select(. == "prettier" or startswith("prettier-plugin-"))
                     ' package.json)"
-                    if [ -n "$forbidden" ]; then
+                    if [ -n "$forbidden_deps" ]; then
                       echo "ERROR: package.json must not declare prettier or prettier-plugin-*." >&2
                       echo "rainix supplies these via the pre-commit hook bundle." >&2
                       echo "Forbidden packages found:" >&2
-                      printf '  - %s\n' $forbidden >&2
+                      printf '  - %s\n' $forbidden_deps >&2
+                      exit 1
+                    fi
+                    if ${pkgs.jq}/bin/jq -e 'has("prettier")' package.json > /dev/null 2>&1; then
+                      echo "ERROR: package.json must not contain a top-level \"prettier\" key." >&2
+                      echo "Prettier config inlined in package.json drifts from the rainix canon; delete the key." >&2
                       exit 1
                     fi
                   fi
-                  for cfg in .prettierrc .prettierrc.json .prettierrc.yaml .prettierrc.yml .prettierrc.toml .prettierrc.js .prettierrc.cjs .prettierrc.mjs prettier.config.js prettier.config.cjs prettier.config.mjs; do
+                  for cfg in \
+                    .prettierrc \
+                    .prettierrc.json \
+                    .prettierrc.json5 \
+                    .prettierrc.yaml \
+                    .prettierrc.yml \
+                    .prettierrc.toml \
+                    .prettierrc.js \
+                    .prettierrc.cjs \
+                    .prettierrc.mjs \
+                    .prettierrc.ts \
+                    .prettierrc.cts \
+                    .prettierrc.mts \
+                    prettier.config.js \
+                    prettier.config.cjs \
+                    prettier.config.mjs \
+                    prettier.config.ts \
+                    prettier.config.cts \
+                    prettier.config.mts; do
                     if [ -e "$cfg" ]; then
                       echo "ERROR: $cfg is present in the repo." >&2
                       echo "rainix supplies the canonical prettier config via the bundle." >&2
@@ -530,7 +553,11 @@
                   done
                 ''
               );
-              files = "(^package\\.json$|^\\.prettierrc(\\.[a-z]+)?$|^prettier\\.config\\.[a-z]+$)";
+              # always_run so the check fires on every commit, not just commits
+              # that happen to stage package.json or a prettierrc. A consumer
+              # could otherwise sneak in a forbidden file in one commit and
+              # introduce drift in the next.
+              always_run = true;
               pass_filenames = false;
             };
 

--- a/prettier-bundle/.prettierrc.json
+++ b/prettier-bundle/.prettierrc.json
@@ -1,0 +1,5 @@
+{
+  "useTabs": false,
+  "tabWidth": 2,
+  "overrides": [{ "files": "*.svelte", "options": { "parser": "svelte" } }]
+}

--- a/prettier-bundle/package-lock.json
+++ b/prettier-bundle/package-lock.json
@@ -1,0 +1,322 @@
+{
+	"name": "rainix-prettier-bundle",
+	"version": "0.0.0",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "rainix-prettier-bundle",
+			"version": "0.0.0",
+			"dependencies": {
+				"prettier": "3.6.2",
+				"prettier-plugin-svelte": "3.5.1",
+				"prettier-plugin-tailwindcss": "0.6.14",
+				"svelte": "4.2.7"
+			}
+		},
+		"node_modules/@ampproject/remapping": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+			"integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/gen-mapping": {
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+			"integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.0",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			}
+		},
+		"node_modules/@jridgewell/resolve-uri": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+			"license": "MIT"
+		},
+		"node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.31",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+			"integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.1.0",
+				"@jridgewell/sourcemap-codec": "^1.4.14"
+			}
+		},
+		"node_modules/@types/estree": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+			"license": "MIT"
+		},
+		"node_modules/acorn": {
+			"version": "8.16.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+			"license": "MIT",
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/aria-query": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+			"integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/axobject-query": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.4.tgz",
+			"integrity": "sha512-aPTElBrbifBU1krmZxGZOlBkslORe7Ll7+BDnI50Wy4LgOt69luMgevkDfTq1O/ZgprooPCtWpjCwKSZw/iZ4A==",
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/code-red": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/code-red/-/code-red-1.0.4.tgz",
+			"integrity": "sha512-7qJWqItLA8/VPVlKJlFXU+NBlo/qyfs39aJcuMT/2ere32ZqvF5OSxgdM5xOfJJ7O429gg2HM47y8v9P+9wrNw==",
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.4.15",
+				"@types/estree": "^1.0.1",
+				"acorn": "^8.10.0",
+				"estree-walker": "^3.0.3",
+				"periscopic": "^3.1.0"
+			}
+		},
+		"node_modules/css-tree": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+			"integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+			"license": "MIT",
+			"dependencies": {
+				"mdn-data": "2.0.30",
+				"source-map-js": "^1.0.1"
+			},
+			"engines": {
+				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+			}
+		},
+		"node_modules/estree-walker": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
+		"node_modules/is-reference": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
+			"integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.6"
+			}
+		},
+		"node_modules/locate-character": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
+			"integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
+			"license": "MIT"
+		},
+		"node_modules/magic-string": {
+			"version": "0.30.21",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+			"integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.5.5"
+			}
+		},
+		"node_modules/mdn-data": {
+			"version": "2.0.30",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+			"integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
+			"license": "CC0-1.0"
+		},
+		"node_modules/periscopic": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.1.0.tgz",
+			"integrity": "sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"estree-walker": "^3.0.0",
+				"is-reference": "^3.0.0"
+			}
+		},
+		"node_modules/prettier": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+			"integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+			"license": "MIT",
+			"bin": {
+				"prettier": "bin/prettier.cjs"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/prettier/prettier?sponsor=1"
+			}
+		},
+		"node_modules/prettier-plugin-svelte": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-3.5.1.tgz",
+			"integrity": "sha512-65+fr5+cgIKWKiqM1Doum4uX6bY8iFCdztvvp2RcF+AJoieaw9kJOFMNcJo/bkmKYsxFaM9OsVZK/gWauG/5mg==",
+			"license": "MIT",
+			"peerDependencies": {
+				"prettier": "^3.0.0",
+				"svelte": "^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0"
+			}
+		},
+		"node_modules/prettier-plugin-tailwindcss": {
+			"version": "0.6.14",
+			"resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.14.tgz",
+			"integrity": "sha512-pi2e/+ZygeIqntN+vC573BcW5Cve8zUB0SSAGxqpB4f96boZF4M3phPVoOFCeypwkpRYdi7+jQ5YJJUwrkGUAg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.21.3"
+			},
+			"peerDependencies": {
+				"@ianvs/prettier-plugin-sort-imports": "*",
+				"@prettier/plugin-hermes": "*",
+				"@prettier/plugin-oxc": "*",
+				"@prettier/plugin-pug": "*",
+				"@shopify/prettier-plugin-liquid": "*",
+				"@trivago/prettier-plugin-sort-imports": "*",
+				"@zackad/prettier-plugin-twig": "*",
+				"prettier": "^3.0",
+				"prettier-plugin-astro": "*",
+				"prettier-plugin-css-order": "*",
+				"prettier-plugin-import-sort": "*",
+				"prettier-plugin-jsdoc": "*",
+				"prettier-plugin-marko": "*",
+				"prettier-plugin-multiline-arrays": "*",
+				"prettier-plugin-organize-attributes": "*",
+				"prettier-plugin-organize-imports": "*",
+				"prettier-plugin-sort-imports": "*",
+				"prettier-plugin-style-order": "*",
+				"prettier-plugin-svelte": "*"
+			},
+			"peerDependenciesMeta": {
+				"@ianvs/prettier-plugin-sort-imports": {
+					"optional": true
+				},
+				"@prettier/plugin-hermes": {
+					"optional": true
+				},
+				"@prettier/plugin-oxc": {
+					"optional": true
+				},
+				"@prettier/plugin-pug": {
+					"optional": true
+				},
+				"@shopify/prettier-plugin-liquid": {
+					"optional": true
+				},
+				"@trivago/prettier-plugin-sort-imports": {
+					"optional": true
+				},
+				"@zackad/prettier-plugin-twig": {
+					"optional": true
+				},
+				"prettier-plugin-astro": {
+					"optional": true
+				},
+				"prettier-plugin-css-order": {
+					"optional": true
+				},
+				"prettier-plugin-import-sort": {
+					"optional": true
+				},
+				"prettier-plugin-jsdoc": {
+					"optional": true
+				},
+				"prettier-plugin-marko": {
+					"optional": true
+				},
+				"prettier-plugin-multiline-arrays": {
+					"optional": true
+				},
+				"prettier-plugin-organize-attributes": {
+					"optional": true
+				},
+				"prettier-plugin-organize-imports": {
+					"optional": true
+				},
+				"prettier-plugin-sort-imports": {
+					"optional": true
+				},
+				"prettier-plugin-style-order": {
+					"optional": true
+				},
+				"prettier-plugin-svelte": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/source-map-js": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/svelte": {
+			"version": "4.2.7",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.7.tgz",
+			"integrity": "sha512-UExR1KS7raTdycsUrKLtStayu4hpdV3VZQgM0akX8XbXgLBlosdE/Sf3crOgyh9xIjqSYB3UEBuUlIQKRQX2hg==",
+			"license": "MIT",
+			"dependencies": {
+				"@ampproject/remapping": "^2.2.1",
+				"@jridgewell/sourcemap-codec": "^1.4.15",
+				"@jridgewell/trace-mapping": "^0.3.18",
+				"acorn": "^8.9.0",
+				"aria-query": "^5.3.0",
+				"axobject-query": "^3.2.1",
+				"code-red": "^1.0.3",
+				"css-tree": "^2.3.1",
+				"estree-walker": "^3.0.3",
+				"is-reference": "^3.0.1",
+				"locate-character": "^3.0.0",
+				"magic-string": "^0.30.4",
+				"periscopic": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		}
+	}
+}

--- a/prettier-bundle/package.json
+++ b/prettier-bundle/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "rainix-prettier-bundle",
+	"version": "0.0.0",
+	"private": true,
+	"description": "Prettier + standardized plugins shipped by rainix. Consumers must NOT ship their own prettier or prettier plugins; the rainix pre-commit hook enforces this.",
+	"dependencies": {
+		"prettier": "3.6.2",
+		"prettier-plugin-svelte": "3.5.1",
+		"prettier-plugin-tailwindcss": "0.6.14",
+		"svelte": "4.2.7"
+	}
+}

--- a/test/bats/devshell/default/prettier-bundle.test.bats
+++ b/test/bats/devshell/default/prettier-bundle.test.bats
@@ -1,0 +1,84 @@
+setup() {
+  pcc="$(grep -v '^#' "$BATS_TEST_DIRNAME/../../../../.pre-commit-config.yaml")"
+  prettier_entry="$(echo "$pcc" | jq -r '.repos[0].hooks[] | select(.name == "prettier") | .entry')"
+  no_consumer_prettier_entry="$(echo "$pcc" | jq -r '.repos[0].hooks[] | select(.name == "no-consumer-prettier") | .entry')"
+  fixtures="$BATS_TEST_DIRNAME/../../../fixture/prettier-bundle"
+}
+
+@test "rainix-bundled prettier formats Svelte files with TS enums" {
+  tmpdir="$(mktemp -d)"
+  cp "$fixtures/svelte-with-enum/Lock.svelte" "$tmpdir/"
+  cd "$tmpdir"
+
+  bash -c "$prettier_entry Lock.svelte"
+
+  actual="$(cat Lock.svelte)"
+  rm -rf "$tmpdir"
+
+  # Enum body intact (the original #117 bug stripped it) AND the script was
+  # reformatted to canonical double quotes (proves the svelte plugin ran;
+  # without it, prettier --ignore-unknown skips .svelte and the source's
+  # single quotes survive).
+  echo "$actual" | grep -q 'enum ButtonStatus {'
+  echo "$actual" | grep -q 'READY = "LOCK"'
+}
+
+@test "rainix-bundled prettier reformats to rainix canon: 2-space indent and double quotes" {
+  tmpdir="$(mktemp -d)"
+  cp "$fixtures/canon-style/sample.ts" "$tmpdir/"
+  cd "$tmpdir"
+
+  bash -c "$prettier_entry sample.ts"
+
+  actual="$(cat sample.ts)"
+  rm -rf "$tmpdir"
+
+  echo "$actual" | grep -qE '^  console\.log\("hello"\);$'
+}
+
+@test "no-consumer-prettier blocks package.json that declares prettier" {
+  tmpdir="$(mktemp -d)"
+  cp "$fixtures/blocked-prettier-dep/package.json" "$tmpdir/"
+  cd "$tmpdir"
+
+  run bash -c "$no_consumer_prettier_entry"
+  rm -rf "$tmpdir"
+
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -q "must not declare prettier"
+}
+
+@test "no-consumer-prettier blocks package.json that declares prettier-plugin-*" {
+  tmpdir="$(mktemp -d)"
+  cp "$fixtures/blocked-plugin-dep/package.json" "$tmpdir/"
+  cd "$tmpdir"
+
+  run bash -c "$no_consumer_prettier_entry"
+  rm -rf "$tmpdir"
+
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -q "prettier-plugin-svelte"
+}
+
+@test "no-consumer-prettier blocks the presence of any consumer .prettierrc" {
+  tmpdir="$(mktemp -d)"
+  cp "$fixtures/blocked-prettierrc/.prettierrc.json" "$tmpdir/"
+  cd "$tmpdir"
+
+  run bash -c "$no_consumer_prettier_entry"
+  rm -rf "$tmpdir"
+
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -q ".prettierrc.json is present"
+}
+
+@test "no-consumer-prettier passes when package.json is clean and there is no .prettierrc" {
+  tmpdir="$(mktemp -d)"
+  cp "$fixtures/clean/package.json" "$tmpdir/"
+  cd "$tmpdir"
+
+  run bash -c "$no_consumer_prettier_entry"
+  rm -rf "$tmpdir"
+
+  [ "$status" -eq 0 ]
+}

--- a/test/bats/devshell/default/prettier-bundle.test.bats
+++ b/test/bats/devshell/default/prettier-bundle.test.bats
@@ -1,7 +1,7 @@
 setup() {
-  pcc="$(grep -v '^#' "$BATS_TEST_DIRNAME/../../../../.pre-commit-config.yaml")"
-  prettier_entry="$(echo "$pcc" | jq -r '.repos[0].hooks[] | select(.name == "prettier") | .entry')"
-  no_consumer_prettier_entry="$(echo "$pcc" | jq -r '.repos[0].hooks[] | select(.name == "no-consumer-prettier") | .entry')"
+  pcc="$BATS_TEST_DIRNAME/../../../../.pre-commit-config.yaml"
+  prettier_entry="$(yq '.repos[0].hooks[] | select(.name == "prettier") | .entry' "$pcc")"
+  no_consumer_prettier_entry="$(yq '.repos[0].hooks[] | select(.name == "no-consumer-prettier") | .entry' "$pcc")"
   fixtures="$BATS_TEST_DIRNAME/../../../fixture/prettier-bundle"
 }
 
@@ -60,6 +60,30 @@ setup() {
   echo "$output" | grep -q "prettier-plugin-svelte"
 }
 
+@test "no-consumer-prettier blocks prettier in optionalDependencies" {
+  tmpdir="$(mktemp -d)"
+  cp "$fixtures/blocked-optional-dep/package.json" "$tmpdir/"
+  cd "$tmpdir"
+
+  run bash -c "$no_consumer_prettier_entry"
+  rm -rf "$tmpdir"
+
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -q "prettier-plugin-tailwindcss"
+}
+
+@test "no-consumer-prettier blocks top-level \"prettier\" key in package.json" {
+  tmpdir="$(mktemp -d)"
+  cp "$fixtures/blocked-prettier-key/package.json" "$tmpdir/"
+  cd "$tmpdir"
+
+  run bash -c "$no_consumer_prettier_entry"
+  rm -rf "$tmpdir"
+
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -q 'top-level "prettier" key'
+}
+
 @test "no-consumer-prettier blocks the presence of any consumer .prettierrc" {
   tmpdir="$(mktemp -d)"
   cp "$fixtures/blocked-prettierrc/.prettierrc.json" "$tmpdir/"
@@ -72,6 +96,18 @@ setup() {
   echo "$output" | grep -q ".prettierrc.json is present"
 }
 
+@test "no-consumer-prettier blocks .prettierrc.ts (TypeScript variant)" {
+  tmpdir="$(mktemp -d)"
+  cp "$fixtures/blocked-prettierrc-ts/.prettierrc.ts" "$tmpdir/"
+  cd "$tmpdir"
+
+  run bash -c "$no_consumer_prettier_entry"
+  rm -rf "$tmpdir"
+
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -q ".prettierrc.ts is present"
+}
+
 @test "no-consumer-prettier passes when package.json is clean and there is no .prettierrc" {
   tmpdir="$(mktemp -d)"
   cp "$fixtures/clean/package.json" "$tmpdir/"
@@ -81,4 +117,9 @@ setup() {
   rm -rf "$tmpdir"
 
   [ "$status" -eq 0 ]
+}
+
+@test "no-consumer-prettier hook is configured with always_run = true" {
+  always_run="$(yq '.repos[0].hooks[] | select(.name == "no-consumer-prettier") | .always_run' "$pcc")"
+  [ "$always_run" = "true" ]
 }

--- a/test/fixture/prettier-bundle/blocked-optional-dep/package.json
+++ b/test/fixture/prettier-bundle/blocked-optional-dep/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "fixture-blocked-optional-dep",
+  "version": "0.0.0",
+  "private": true,
+  "optionalDependencies": {
+    "prettier-plugin-tailwindcss": "^0.6.0"
+  }
+}

--- a/test/fixture/prettier-bundle/blocked-plugin-dep/package.json
+++ b/test/fixture/prettier-bundle/blocked-plugin-dep/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "fixture-blocked-plugin-dep",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "prettier-plugin-svelte": "^3.0.0"
+  }
+}

--- a/test/fixture/prettier-bundle/blocked-prettier-dep/package.json
+++ b/test/fixture/prettier-bundle/blocked-prettier-dep/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "fixture-blocked-prettier-dep",
+  "version": "0.0.0",
+  "private": true,
+  "devDependencies": {
+    "prettier": "^3.0.0"
+  }
+}

--- a/test/fixture/prettier-bundle/blocked-prettier-key/package.json
+++ b/test/fixture/prettier-bundle/blocked-prettier-key/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "fixture-blocked-prettier-key",
+  "version": "0.0.0",
+  "private": true,
+  "prettier": {
+    "useTabs": true
+  }
+}

--- a/test/fixture/prettier-bundle/blocked-prettierrc-ts/.prettierrc.ts
+++ b/test/fixture/prettier-bundle/blocked-prettierrc-ts/.prettierrc.ts
@@ -1,0 +1,1 @@
+export default { useTabs: true };

--- a/test/fixture/prettier-bundle/blocked-prettierrc/.prettierrc.json
+++ b/test/fixture/prettier-bundle/blocked-prettierrc/.prettierrc.json
@@ -1,0 +1,3 @@
+{
+  "useTabs": true
+}

--- a/test/fixture/prettier-bundle/canon-style/sample.ts
+++ b/test/fixture/prettier-bundle/canon-style/sample.ts
@@ -1,0 +1,3 @@
+function greet() {
+	console.log('hello');
+}

--- a/test/fixture/prettier-bundle/clean/package.json
+++ b/test/fixture/prettier-bundle/clean/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "fixture-clean",
+  "version": "0.0.0",
+  "private": true,
+  "devDependencies": {
+    "vite": "^5.0.0"
+  }
+}

--- a/test/fixture/prettier-bundle/svelte-with-enum/Lock.svelte
+++ b/test/fixture/prettier-bundle/svelte-with-enum/Lock.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	enum ButtonStatus {
+		READY = 'LOCK'
+	}
+</script>


### PR DESCRIPTION
## Summary

- New `prettier-bundle` derivation: a nix-built node_modules tree containing a fixed prettier + plugin set (prettier 3.6.2, prettier-plugin-svelte 3.5.1, prettier-plugin-tailwindcss 0.6.14, svelte 4.2.7) plus a canonical `.prettierrc.json` (2-space indent, parser=svelte override). Exposed at `packages.<system>.prettier-bundle`.
- Pre-commit `prettier` hook now invokes the bundle's prettier with explicit `--plugin` paths and `--config` pointed at the bundle's `.prettierrc.json`. Consumer node_modules is never consulted, so the two-prettier-cores-in-one-process skew that caused #117 cannot happen.
- New `no-consumer-prettier` pre-commit hook errors if `package.json` declares `prettier` or any `prettier-plugin-*` package, or if any `.prettierrc` / `prettier.config.*` file exists in the consumer repo.
- New `.prettierignore` excludes `prettier-bundle/` (npm-managed) and `test/fixture/` (deliberately non-canonical).

## Test plan

Six bats tests in `test/bats/devshell/default/prettier-bundle.test.bats`, wired into `default-shell-test`:

- [x] rainix-bundled prettier formats Svelte files with TS enums (asserts both enum body intact and source flipped to canonical double-quotes — proves the svelte plugin loaded)
- [x] rainix-bundled prettier reformats to rainix canon: 2-space indent and double quotes
- [x] no-consumer-prettier blocks `package.json` that declares `prettier`
- [x] no-consumer-prettier blocks `package.json` that declares `prettier-plugin-*`
- [x] no-consumer-prettier blocks the presence of any consumer `.prettierrc`
- [x] no-consumer-prettier passes when `package.json` is clean and there is no `.prettierrc`
- [x] mutation: reverting the prettier wrapper to default git-hooks-nix entry fails test 1
- [x] mutation: removing the no-consumer-prettier hook fails tests 3-5
- [ ] CI green

## Consumer impact

Downstream consumers must drop `prettier` and `prettier-plugin-*` from their `package.json` and remove any `.prettierrc` / `prettier.config.*` from their repo. Their code will be reformatted to the rainix canon (2-space indent, double quotes, prettier 3.x defaults otherwise). Tracking the cyclo.site bump separately.

Closes #117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a standardized Prettier bundle with pre-configured settings (2-space indentation, double quotes) and built-in Svelte and Tailwind CSS plugins
  * Added pre-commit validation to prevent custom Prettier configurations and dependencies in projects

* **Tests**
  * Added comprehensive test suite validating bundled Prettier formatting and configuration enforcement

<!-- end of auto-generated comment: release notes by coderabbit.ai -->