### PR TITLE
add chromium to dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -437,6 +437,7 @@
           body = ''
             bats test/bats/devshell/default/solc.test.bats
             bats test/bats/devshell/default/gh.test.bats
+            bats test/bats/devshell/default/chromium.test.bats
             bats test/bats/devshell/default/prettier-bundle.test.bats
             bats test/bats/task/skip-simulation.test.bats
             bats test/bats/task/subgraph-build.test.bats

--- a/flake.nix
+++ b/flake.nix
@@ -134,6 +134,28 @@
           '';
         };
 
+        # Cross-platform `chromium` binary for headless rendering inside the dev
+        # shell (e.g. dumping rendered DOM of a deployed SPA preview to debug
+        # JS-side errors). On Linux, defer to the nixpkgs chromium build. On
+        # Darwin, nixpkgs has no chromium, so wrap the system Chrome.app — fails
+        # at invocation time with a clear message when Chrome is not installed.
+        chromium = pkgs.writeShellScriptBin "chromium" (
+          if pkgs.stdenv.isDarwin then
+            ''
+              chrome="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+              if [ ! -x "$chrome" ]; then
+                echo "rainix chromium wrapper: Google Chrome.app not found at $chrome" >&2
+                echo "Install Chrome (https://www.google.com/chrome/) or use a Linux dev shell." >&2
+                exit 127
+              fi
+              exec "$chrome" "$@"
+            ''
+          else
+            ''
+              exec ${pkgs.chromium}/bin/chromium "$@"
+            ''
+        );
+
         # rainix-curated prettier bundle: a single nix-built node_modules
         # tree containing prettier + the standardized plugins, plus a
         # .prettierrc.json picked up via PRETTIER_BUNDLE_DIR. Consumers
@@ -617,6 +639,7 @@
             ++ [
               the-graph
               goldsky
+              chromium
               pkgs.sqlite
               pkgs.yq-go
               pkgs.gh

--- a/test/bats/devshell/default/chromium.test.bats
+++ b/test/bats/devshell/default/chromium.test.bats
@@ -1,0 +1,4 @@
+@test "chromium should be available on PATH" {
+  run chromium --version
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Closes #121.

## Summary
- Linux gets \`pkgs.chromium\` directly.
- Darwin wraps the system Chrome.app at \`/Applications/Google Chrome.app/Contents/MacOS/Google Chrome\`. Wrapper exits 127 with a clear message if Chrome is not installed (nixpkgs has no Darwin chromium).
- Adds the wrapper to \`devShells.default.buildInputs\` so \`nix develop -c chromium --version\` works on every supported host.

## Test plan
- [x] \`nix develop -c chromium --version\` on aarch64-darwin reports the system Chrome (\`Google Chrome 147.0.7727.138\` locally).
- [ ] Same on x86_64-linux via CI.
- [ ] Smoke test: \`nix develop -c chromium --headless=new --dump-dom https://example.com\` returns rendered HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)