### PR TITLE
feat: add age to dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -644,6 +644,7 @@
               pkgs.sqlite
               pkgs.yq-go
               pkgs.gh
+              pkgs.age
               default-shell-test
               pkgs.pre-commit
             ]

--- a/flake.nix
+++ b/flake.nix
@@ -437,6 +437,7 @@
           body = ''
             bats test/bats/devshell/default/solc.test.bats
             bats test/bats/devshell/default/gh.test.bats
+            bats test/bats/devshell/default/age.test.bats
             bats test/bats/devshell/default/chromium.test.bats
             bats test/bats/devshell/default/prettier-bundle.test.bats
             bats test/bats/task/skip-simulation.test.bats

--- a/test/bats/devshell/default/age.test.bats
+++ b/test/bats/devshell/default/age.test.bats
@@ -1,0 +1,20 @@
+@test "age should be available on PATH" {
+  run age --version
+  [ "$status" -eq 0 ]
+}
+
+@test "age-keygen should be available on PATH" {
+  run age-keygen --help
+  [ "$status" -eq 0 ]
+}
+
+@test "age round-trips a payload through a generated identity" {
+  tmpdir=$(mktemp -d)
+  age-keygen -o "$tmpdir/key.txt" 2>/dev/null
+  recipient=$(grep "public key:" "$tmpdir/key.txt" | sed 's/.*public key: //')
+  printf 'hello world' | age --recipient "$recipient" --output "$tmpdir/out.age"
+  run age --decrypt --identity "$tmpdir/key.txt" "$tmpdir/out.age"
+  [ "$status" -eq 0 ]
+  [ "$output" = "hello world" ]
+  rm -rf "$tmpdir"
+}


### PR DESCRIPTION
Closes #124.

Adds `age` to the rainix dev shell. Verified with `nix develop -c age --version` → `v1.3.1`.

Surfaced when extracting a `secrets.PRIVATE_KEY` from a GitHub Actions secret for backup-before-rotation: the encrypt-then-artifact pattern is much cleaner with age than with GPG (no keyring, single binary, modern primitives). Downstream workflows can now `nix develop -c age --recipient age1... --output backup.age` without a separate install step.
