### PR TITLE
flake: stop leaking rust + nodejs into sol-shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -443,6 +443,7 @@
             bats test/bats/devshell/sol-shell/gh.test.bats
             bats test/bats/devshell/sol-shell/sol-tasks.test.bats
             bats test/bats/devshell/sol-shell/slim.test.bats
+            bats test/bats/devshell/sol-shell/closure.test.bats
           '';
           additionalBuildInputs = [ pkgs.bats ] ++ sol-build-inputs;
         };
@@ -501,15 +502,30 @@
             # identical formatting rules. `no-consumer-prettier` below blocks
             # consumers from shipping their own prettier, plugins, or
             # prettierrc, so the bundle is the only prettier in play.
-            prettier = {
+            #
+            # The bundle is resolved via $RAINIX_PRETTIER_BUNDLE_DIR rather
+            # than nix-store interpolation. Default shell exports the var;
+            # sol-shell does not, and the hook silently no-ops there. This
+            # keeps prettier-bundle (which transitively brings nodejs) out
+            # of the sol-shell closure for consumers that have no JS to
+            # format.
+            # Custom hook name (rather than overriding the built-in
+            # `prettier` hook) so git-hooks.nix does not splice its default
+            # `package = pkgs.nodePackages.prettier` into enabledPackages —
+            # that default is what kept nodejs in sol-shell's closure.
+            prettier-rainix = {
               enable = true;
+              name = "prettier-rainix";
               entry = toString (
                 pkgs.writeShellScript "prettier-rainix-bundled" ''
                   set -e
-                  exec ${prettier-bundle}/bin/prettier \
-                    --config=${prettier-bundle}/.prettierrc.json \
-                    --plugin=${prettier-bundle}/node_modules/prettier-plugin-svelte/plugin.js \
-                    --plugin=${prettier-bundle}/node_modules/prettier-plugin-tailwindcss/dist/index.mjs \
+                  if [ -z "''${RAINIX_PRETTIER_BUNDLE_DIR:-}" ]; then
+                    exit 0
+                  fi
+                  exec "$RAINIX_PRETTIER_BUNDLE_DIR/bin/prettier" \
+                    --config="$RAINIX_PRETTIER_BUNDLE_DIR/.prettierrc.json" \
+                    --plugin="$RAINIX_PRETTIER_BUNDLE_DIR/node_modules/prettier-plugin-svelte/plugin.js" \
+                    --plugin="$RAINIX_PRETTIER_BUNDLE_DIR/node_modules/prettier-plugin-tailwindcss/dist/index.mjs" \
                     --ignore-unknown --list-different --write "$@"
                 ''
               );
@@ -664,6 +680,7 @@
                 default-shell-test
               ];
             shellHook = ''
+              export RAINIX_PRETTIER_BUNDLE_DIR=${prettier-bundle}
               ${pre-commit.shellHook}
               ${source-dotenv}
 
@@ -684,6 +701,7 @@
               ++ [ pkgs.pre-commit ]
               ++ pre-commit.enabledPackages;
             shellHook = ''
+              export RAINIX_PRETTIER_BUNDLE_DIR=${prettier-bundle}
               ${pre-commit.shellHook}
               ${source-dotenv}
 

--- a/flake.nix
+++ b/flake.nix
@@ -478,15 +478,18 @@
 
             # Rust
             taplo.enable = true;
-            # Conditional rustfmt - only runs if Cargo.toml exists
+            # Conditional rustfmt — runs only if there is rust source AND
+            # cargo-fmt is on PATH. Resolving cargo-fmt via PATH at runtime
+            # (instead of nix-store interpolation) keeps rust-toolchain out
+            # of the hook's nix closure, so consumers of sol-shell — which
+            # have no rust to format — do not pull the rust toolchain in.
             rustfmt-conditional = {
               enable = true;
               name = "rustfmt";
               entry = "${pkgs.writeShellScript "rustfmt-conditional" ''
+                command -v cargo-fmt >/dev/null 2>&1 || exit 0
                 if [ -f Cargo.toml ] || [ -f */Cargo.toml ]; then
-                  exec ${rust-toolchain}/bin/cargo-fmt fmt
-                else
-                  exit 0
+                  exec cargo-fmt fmt
                 fi
               ''}";
               files = "\\.rs$";

--- a/test/bats/devshell/sol-shell/closure.test.bats
+++ b/test/bats/devshell/sol-shell/closure.test.bats
@@ -1,0 +1,62 @@
+# Closure-level slim assertion.
+#
+# Runtime-PATH checks (slim.test.bats) miss leaks where a heavy package
+# is interpolated into a script string — the script does not appear on
+# PATH, but its referenced store paths are still in sol-shell's nix
+# closure and are downloaded/built every time CI evaluates the shell.
+#
+# This file inspects sol-shell's full closure (`nix-store -q
+# --requisites`) and fails if any rust toolchain component shows up.
+# It exists specifically to pin the rustfmt-conditional fix: the hook
+# previously referenced ${rust-toolchain}/bin/cargo-fmt which dragged
+# rustc, rust-src, rust-std-wasm32, rust-analyzer, clippy, and rustfmt
+# into every consumer of sol-shell.
+#
+# Skips when `nix` is not on PATH (e.g. running the bats files under a
+# stripped sandbox); CI invokes via nix and so always exercises this.
+
+setup() {
+  if ! command -v nix >/dev/null 2>&1; then
+    skip "nix not on PATH"
+  fi
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../../../.." && pwd)"
+  SYSTEM="$(nix eval --raw --impure --expr 'builtins.currentSystem')"
+  # Realise the shell so we can query its runtime closure (the drv-level
+  # closure is full of build-time bootstrap deps that never appear in the
+  # realized environment, which produces noisy false positives).
+  SOL_SHELL_OUT="$(nix build --no-link --print-out-paths "$REPO_ROOT#devShells.$SYSTEM.sol-shell")"
+  CLOSURE="$(nix-store -q --requisites "$SOL_SHELL_OUT")"
+}
+
+@test "sol-shell closure has no rust toolchain" {
+  # Match rust toolchain packages by their version-suffixed names so we
+  # do not match arbitrary scripts that happen to contain the word
+  # "rustfmt" (e.g. our rustfmt-conditional gating script).
+  local hits
+  hits="$(echo "$CLOSURE" | grep -E '/nix/store/[^/]*-(rust-default-[0-9]|rustc-[0-9]|rust-src-[0-9]|rust-std-[0-9]|rust-analyzer-[0-9]|rust-docs-[0-9]|rustfmt-[0-9]|clippy-[0-9])' || true)"
+  if [ -n "$hits" ]; then
+    echo "FAIL: sol-shell closure references rust toolchain components:" >&2
+    echo "$hits" >&2
+    return 1
+  fi
+}
+
+@test "sol-shell closure has no node/npm" {
+  local hits
+  hits="$(echo "$CLOSURE" | grep -E '/nix/store/[^/]*-(nodejs-|nodejs_|npm-)' || true)"
+  if [ -n "$hits" ]; then
+    echo "FAIL: sol-shell closure references nodejs:" >&2
+    echo "$hits" >&2
+    return 1
+  fi
+}
+
+@test "sol-shell closure has no chromium" {
+  local hits
+  hits="$(echo "$CLOSURE" | grep -E '/nix/store/[^/]*-chromium-' || true)"
+  if [ -n "$hits" ]; then
+    echo "FAIL: sol-shell closure references chromium:" >&2
+    echo "$hits" >&2
+    return 1
+  fi
+}


### PR DESCRIPTION
## Summary

- Stop leaking `rust-toolchain` into `sol-shell` via `rustfmt-conditional` pre-commit hook.
- Stop leaking `nodejs` into `sol-shell` via the `prettier` pre-commit hook (renamed to `prettier-rainix` so git-hooks.nix's default `package = pkgs.nodePackages.prettier` does not splice in).
- Add `test/bats/devshell/sol-shell/closure.test.bats` — a runtime-closure regression test for sol-shell. Mutation-tested both fixes.

## Why this matters

`rain.solmem`'s `Publish to Soldeer` workflow (and any other sol-only consumer of sol-shell) was building the full Rust 1.94 stable toolchain (rustc, rust-src, rust-std-x86_64, rust-std-wasm32, rust-analyzer, clippy, rustfmt) plus nodejs-24.13 / nodejs-24.14 on every cold cache, even though no rust or JS code is ever compiled in those repos. The hook scripts had `${rust-toolchain}/bin/cargo-fmt` and `${prettier-bundle}/bin/prettier` baked in as nix-store interpolations, which placed both packages in the script's runtime closure and therefore in `pre-commit.enabledPackages`, which is in `common-shell-inputs`, which is in `sol-shell.buildInputs`.

Fix: resolve both binaries at runtime from PATH (`cargo-fmt`) or env var (`$RAINIX_PRETTIER_BUNDLE_DIR`). Default shell exports the env var and has cargo-fmt on PATH, so default behaviour is unchanged. Sol-shell has neither, so the hooks silently exit 0.

## Test plan
- [x] `bats test/bats/devshell/sol-shell/closure.test.bats` passes — three assertions: no rust, no node/npm, no chromium in sol-shell's realised runtime closure.
- [x] Mutation 1: revert rustfmt fix → rust assertion fails. Restore → green.
- [x] Mutation 2: rename `prettier-rainix` → `prettier` → node assertion fails. Restore → green.
- [ ] Re-run `rain.solmem`'s soldeer publish workflow against this rainix to confirm zero rust / node builds on a cold cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new test to validate build closure integrity.

* **Chores**
  * Updated developer shell environment configuration.
  * Updated pre-commit hook behavior for code formatting tools.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rainlanguage/rainix/pull/134)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->