### PR TITLE
ci: reusable publish-soldeer workflow

### DIFF
--- a/.github/workflows/publish-soldeer.yaml
+++ b/.github/workflows/publish-soldeer.yaml
@@ -1,0 +1,46 @@
+name: Publish to Soldeer
+on:
+  workflow_call:
+    inputs:
+      package_name:
+        type: string
+        required: false
+        description: |
+          Soldeer registry package name. Defaults to the GitHub repo name
+          with `.` replaced by `-` (e.g. rain.solmem -> rain-solmem),
+          which works for every rain.* repo. Override only if the
+          registry name diverges from the repo name.
+    secrets:
+      SOLDEER_API_TOKEN:
+        required: true
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: nixbuild/nix-quick-install-action@v30
+        with:
+          nix_conf: |
+            keep-env-derivations = true
+            keep-outputs = true
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 1G
+      - name: Push to Soldeer
+        env:
+          SOLDEER_API_TOKEN: ${{ secrets.SOLDEER_API_TOKEN }}
+          INPUT_PACKAGE_NAME: ${{ inputs.package_name }}
+        run: |
+          if [ -n "$INPUT_PACKAGE_NAME" ]; then
+            PACKAGE="$INPUT_PACKAGE_NAME"
+          else
+            PACKAGE="${GITHUB_REPOSITORY##*/}"
+            PACKAGE="${PACKAGE//./-}"
+          fi
+          VERSION="${GITHUB_REF_NAME#v}"
+          nix develop -c forge soldeer push "${PACKAGE}~${VERSION}"

--- a/README.md
+++ b/README.md
@@ -57,6 +57,32 @@ Downstream flakes can compose their own tasks and shells using:
 - `mkTask` — create Nix derivations wrapping shell scripts with dependencies on
   PATH
 
+### Reusable Workflows
+
+#### Publish to Soldeer
+
+`.github/workflows/publish-soldeer.yaml` is a `workflow_call` reusable that
+pushes a Solidity package to soldeer.xyz on every `v*` tag. Consumer repos need
+a five-line wrapper:
+
+```yaml
+name: Publish to Soldeer
+on:
+  push:
+    tags: ["v*"]
+jobs:
+  publish:
+    uses: rainlanguage/rainix/.github/workflows/publish-soldeer.yaml@main
+    secrets: inherit
+```
+
+The package name defaults to the repo name with `.` replaced by `-`
+(`rain.solmem` → `rain-solmem`), since soldeer rejects `.` in package names.
+Override via the `package_name` input only if the registry name diverges.
+`SOLDEER_API_TOKEN` must be set in the consumer repo (or org) secrets, and the
+project must already exist on soldeer.xyz — the registry rejects pushes to
+nonexistent projects.
+
 ## Pinned Versions
 
 - Rust: 1.94.0


### PR DESCRIPTION
## Summary

Lift the soldeer publish workflow into rainix as a `workflow_call` reusable. Closes #135.

`rain.solmem` proved out the workflow shape (rain.solmem#34, rain.solmem v0.1.1 tag — registry-side `rain-solmem` project still needs creating before the actual push lands). With one repo's-worth of evidence that the steps work, copy-pasting the same YAML into 12+ rain.* repos as they soldeer-migrate is exactly the drift trap that hit us with sol-prelude. This PR moves it once.

## Consumer wrapper

```yaml
name: Publish to Soldeer
on:
  push:
    tags: ["v*"]
jobs:
  publish:
    uses: rainlanguage/rainix/.github/workflows/publish-soldeer.yaml@main
    secrets: inherit
```

The package name defaults to `${GITHUB_REPOSITORY##*/}` with `.` → `-`, since soldeer rejects `.` in package names. An optional `package_name` input is exposed for the rare case where the registry name diverges.

## Test plan
- [ ] After merge, replace rain.solmem's bespoke workflow with the wrapper (separate PR) and bump to v0.1.2 to confirm end-to-end.
- [ ] Roll out to other rain.* repos as part of the soldeer migration tracked under rain.solmem#194.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
