### PR TITLE
ci: reusable static-checks workflow

### DIFF
--- a/.github/workflows/rainix-sol-static.yaml
+++ b/.github/workflows/rainix-sol-static.yaml
@@ -1,0 +1,25 @@
+name: rainix-sol-static
+on:
+  workflow_call:
+jobs:
+  static:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: nixbuild/nix-quick-install-action@v30
+        with:
+          nix_conf: |
+            keep-env-derivations = true
+            keep-outputs = true
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 1G
+      - name: Install soldeer dependencies
+        if: hashFiles('soldeer.lock') != ''
+        run: nix develop -c forge soldeer install
+      - run: nix develop -c rainix-sol-static

--- a/README.md
+++ b/README.md
@@ -83,6 +83,21 @@ Override via the `package_name` input only if the registry name diverges.
 project must already exist on soldeer.xyz — the registry rejects pushes to
 nonexistent projects.
 
+#### rainix-sol-static
+
+`.github/workflows/rainix-sol-static.yaml` runs `rainix-sol-static` (slither) on
+Linux. Wrapper in the consumer repo:
+
+```yaml
+name: rainix-sol-static
+on: [push]
+jobs:
+  static:
+    uses: rainlanguage/rainix/.github/workflows/rainix-sol-static.yaml@main
+```
+
+Runs `forge soldeer install` automatically when a `soldeer.lock` is present.
+
 ## Pinned Versions
 
 - Rust: 1.94.0


### PR DESCRIPTION
Single-job reusable workflow for slither static analysis. Consumer wrapper is three lines. Conditional `forge soldeer install` runs only when a `soldeer.lock` is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a reusable GitHub Actions workflow for automated static analysis checks with Nix integration and dependency caching optimization.

* **Documentation**
  * Updated documentation with setup guide and configuration details for the new static analysis workflow.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rainlanguage/rainix/pull/137)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->