### PR TITLE
ci: composite sol reusable

### DIFF
--- a/.github/workflows/rainix-sol.yaml
+++ b/.github/workflows/rainix-sol.yaml
@@ -1,0 +1,11 @@
+name: rainix-sol
+on:
+  workflow_call:
+jobs:
+  static:
+    uses: ./.github/workflows/rainix-sol-static.yaml
+  legal:
+    uses: ./.github/workflows/rainix-sol-legal.yaml
+  test:
+    uses: ./.github/workflows/rainix-sol-test.yaml
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -131,6 +131,23 @@ env vars (`ARBITRUM_RPC_URL`, `BASE_RPC_URL`, `BASE_SEPOLIA_RPC_URL`,
 `ETHERSCAN_API_KEY` and `DEPLOYMENT_KEY` from the consumer org's secrets/vars.
 Repos that do no fork tests can ignore — empty values are harmless.
 
+#### rainix-sol (composite)
+
+`.github/workflows/rainix-sol.yaml` fans out static, legal, and test in parallel
+— each on its own runner. Single wrapper for sol-only repos that want all three:
+
+```yaml
+name: rainix
+on: [push]
+jobs:
+  rainix:
+    uses: rainlanguage/rainix/.github/workflows/rainix-sol.yaml@main
+    secrets: inherit
+```
+
+Consumers needing only one of the three should call the individual reusable
+directly rather than this composite.
+
 ## Pinned Versions
 
 - Rust: 1.94.0


### PR DESCRIPTION
Fan-out workflow that dispatches the three sol reusables (static/legal/test) as parallel jobs, each on its own runner. Sol-only consumers get a one-file wrapper instead of three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)