### PR TITLE
ci: reusable build-pointers workflow

### DIFF
--- a/.github/workflows/rainix-build-pointers.yaml
+++ b/.github/workflows/rainix-build-pointers.yaml
@@ -1,0 +1,33 @@
+name: rainix-build-pointers
+on:
+  workflow_call:
+jobs:
+  build-pointers:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: nixbuild/nix-quick-install-action@v30
+        with:
+          nix_conf: |
+            keep-env-derivations = true
+            keep-outputs = true
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 1G
+      # Use rainix's sol-shell directly (slim — no rust/node/chromium).
+      # Mixed-language consumers can ship their heavy default devShell without
+      # paying for it on this purely Solidity-side check.
+      - name: Install soldeer dependencies
+        if: hashFiles('soldeer.lock') != ''
+        run: nix develop github:rainlanguage/rainix#sol-shell -c forge soldeer install
+      - name: Regenerate pointer artifacts
+        run: nix develop github:rainlanguage/rainix#sol-shell -c forge script ./script/BuildPointers.sol
+      - name: Format (so generated artifacts match committed style)
+        run: nix develop github:rainlanguage/rainix#sol-shell -c forge fmt
+      - name: Assert pointer artifacts match committed
+        run: git diff --exit-code

--- a/.github/workflows/rainix-sol-legal.yaml
+++ b/.github/workflows/rainix-sol-legal.yaml
@@ -21,5 +21,5 @@ jobs:
           gc-max-store-size-linux: 1G
       - name: Install soldeer dependencies
         if: hashFiles('soldeer.lock') != ''
-        run: nix develop -c forge soldeer install
-      - run: nix develop -c rainix-sol-legal
+        run: nix develop github:rainlanguage/rainix#sol-shell -c forge soldeer install
+      - run: nix develop github:rainlanguage/rainix#sol-shell -c rainix-sol-legal

--- a/.github/workflows/rainix-sol-static.yaml
+++ b/.github/workflows/rainix-sol-static.yaml
@@ -21,5 +21,5 @@ jobs:
           gc-max-store-size-linux: 1G
       - name: Install soldeer dependencies
         if: hashFiles('soldeer.lock') != ''
-        run: nix develop -c forge soldeer install
-      - run: nix develop -c rainix-sol-static
+        run: nix develop github:rainlanguage/rainix#sol-shell -c forge soldeer install
+      - run: nix develop github:rainlanguage/rainix#sol-shell -c rainix-sol-static

--- a/.github/workflows/rainix-sol-test.yaml
+++ b/.github/workflows/rainix-sol-test.yaml
@@ -33,5 +33,5 @@ jobs:
           gc-max-store-size-linux: 1G
       - name: Install soldeer dependencies
         if: hashFiles('soldeer.lock') != ''
-        run: nix develop -c forge soldeer install
-      - run: nix develop -c rainix-sol-test
+        run: nix develop github:rainlanguage/rainix#sol-shell -c forge soldeer install
+      - run: nix develop github:rainlanguage/rainix#sol-shell -c rainix-sol-test

--- a/README.md
+++ b/README.md
@@ -148,6 +148,25 @@ jobs:
 Consumers needing only one of the three should call the individual reusable
 directly rather than this composite.
 
+#### rainix-build-pointers
+
+`.github/workflows/rainix-build-pointers.yaml` regenerates
+`./script/BuildPointers.sol` artifacts, runs `forge fmt`, then asserts
+`git diff --exit-code` — failing the PR if a maintainer changed
+pointer-affecting source without committing the updated
+`src/generated/*.pointers.sol` files.
+
+```yaml
+name: build-pointers
+on: [push]
+jobs:
+  build-pointers:
+    uses: rainlanguage/rainix/.github/workflows/rainix-build-pointers.yaml@main
+```
+
+Always runs through rainix's `sol-shell` (slim), regardless of the consumer's
+default devShell.
+
 ## Pinned Versions
 
 - Rust: 1.94.0


### PR DESCRIPTION
Lifts the BuildPointers regen check from consumers' git-clean.yaml. Always runs through rainix's sol-shell so mixed-language consumers don't pay for their heavy default devShell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)