### PR TITLE
feat: add rust-shell slim devShell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -662,6 +662,19 @@
             '';
           };
 
+          # Slim shell for Rust-only repos: rust toolchain + cargo + the
+          # rs-tasks, no sol/node/chromium. Mirror of sol-shell for the
+          # Rust side. Consumers like rain.cli that ship a pure rust
+          # binary can alias `default = rust-shell` and skip the heavy
+          # default closure.
+          rust-shell = pkgs.mkShell {
+            buildInputs = rust-build-inputs ++ rs-tasks ++ common-shell-inputs;
+            shellHook = ''
+              ${pre-commit.shellHook}
+              ${source-dotenv}
+            '';
+          };
+
           default = pkgs.mkShell {
             buildInputs =
               sol-build-inputs


### PR DESCRIPTION
Mirror of `sol-shell` for rust-only repos. Pure-rust consumers can alias their default to `rainix.devShells.${system}.rust-shell` and skip the heavy default's chromium/sol/node closure.

Verified the rust-shell closure contains rust-default-1.94.0 + cargo + rustc, with no nodejs/chromium/forge-std/slither/reuse/the-graph/goldsky.

Part of rainlanguage/rainix#141.

🤖 Generated with [Claude Code](https://claude.com/claude-code)