### PR TITLE
drop trivial sol/rs task wrappers

### DIFF
--- a/.github/workflows/rainix-sol-legal.yaml
+++ b/.github/workflows/rainix-sol-legal.yaml
@@ -22,4 +22,4 @@ jobs:
       - name: Install soldeer dependencies
         if: hashFiles('soldeer.lock') != ''
         run: nix develop github:rainlanguage/rainix#sol-shell -c forge soldeer install
-      - run: nix develop github:rainlanguage/rainix#sol-shell -c rainix-sol-legal
+      - run: nix develop github:rainlanguage/rainix#sol-shell -c reuse lint

--- a/.github/workflows/rainix-sol-static.yaml
+++ b/.github/workflows/rainix-sol-static.yaml
@@ -22,4 +22,5 @@ jobs:
       - name: Install soldeer dependencies
         if: hashFiles('soldeer.lock') != ''
         run: nix develop github:rainlanguage/rainix#sol-shell -c forge soldeer install
-      - run: nix develop github:rainlanguage/rainix#sol-shell -c rainix-sol-static
+      - run: nix develop github:rainlanguage/rainix#sol-shell -c slither .
+      - run: nix develop github:rainlanguage/rainix#sol-shell -c forge fmt --check

--- a/.github/workflows/rainix-sol-test.yaml
+++ b/.github/workflows/rainix-sol-test.yaml
@@ -34,4 +34,4 @@ jobs:
       - name: Install soldeer dependencies
         if: hashFiles('soldeer.lock') != ''
         run: nix develop github:rainlanguage/rainix#sol-shell -c forge soldeer install
-      - run: nix develop github:rainlanguage/rainix#sol-shell -c rainix-sol-test
+      - run: nix develop github:rainlanguage/rainix#sol-shell -c forge test -vvv

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,18 +5,20 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        task: [rainix-rs-test, rainix-rs-artifacts]
+        task: ["cargo test", "cargo build --release"]
         include:
-          # Solidity doesn't need to be tested on multiple platforms
+          # Solidity doesn't need to be tested on multiple platforms.
           - os: ubuntu-latest
-            task: rainix-sol-test
+            task: forge test -vvv
           - os: ubuntu-latest
-            task: rainix-sol-static
+            task: slither .
           - os: ubuntu-latest
-            task: rainix-sol-legal
+            task: forge fmt --check
+          - os: ubuntu-latest
+            task: reuse lint
           - os: ubuntu-latest
             task: rainix-sol-artifacts
-          # We don't need to do rust static analysis on multiple platforms
+          # We don't need to do rust static analysis on multiple platforms.
           - os: ubuntu-latest
             task: rainix-rs-static
       fail-fast: false
@@ -36,17 +38,12 @@ jobs:
       - name: Restore and save Nix store
         uses: nix-community/cache-nix-action@v6
         with:
-          # restore and save a cache using this key
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
-          # if there's no cache hit, restore a cache by this prefix
           restore-prefixes-first-match: nix-${{ runner.os }}-
-          # collect garbage until the Nix store size (in bytes) is at most this number
-          # before trying to save a new cache
-          # 1G = 1073741824
           gc-max-store-size-linux: 1G
       - run: nix develop ../.. --command forge soldeer install
       - name: Run ${{ matrix.task }}
         env:
           ETH_RPC_URL: ${{ secrets.CI_DEPLOY_SEPOLIA_RPC_URL || vars.CI_DEPLOY_SEPOLIA_RPC_URL }}
           ETHERSCAN_API_KEY: ${{ secrets.EXPLORER_VERIFICATION_KEY }}
-        run: nix run ../..#${{ matrix.task }}
+        run: nix develop ../.. --command ${{ matrix.task }}

--- a/flake.nix
+++ b/flake.nix
@@ -226,34 +226,6 @@
             postBuild = "wrapProgram $out/bin/${name} --prefix PATH : $out/bin";
           };
 
-        rainix-sol-static = mkTask {
-          name = "rainix-sol-static";
-          body = ''
-            set -euxo pipefail
-            slither .
-            forge fmt --check
-          '';
-          additionalBuildInputs = sol-build-inputs;
-        };
-
-        rainix-sol-legal = mkTask {
-          name = "rainix-sol-legal";
-          body = ''
-            set -euxo pipefail
-            reuse lint
-          '';
-          additionalBuildInputs = sol-build-inputs;
-        };
-
-        rainix-sol-test = mkTask {
-          name = "rainix-sol-test";
-          body = ''
-            set -euxo pipefail
-            forge test -vvv
-          '';
-          additionalBuildInputs = sol-build-inputs;
-        };
-
         rainix-sol-artifacts = mkTask {
           name = "rainix-sol-artifacts";
           body = ''
@@ -310,35 +282,12 @@
           additionalBuildInputs = rust-build-inputs;
         };
 
-        rainix-rs-test = mkTask {
-          name = "rainix-rs-test";
-          body = ''
-            set -euxo pipefail
-            cargo test
-          '';
-          additionalBuildInputs = rust-build-inputs;
-        };
-
-        rainix-rs-artifacts = mkTask {
-          name = "rainix-rs-artifacts";
-          body = ''
-            set -euxo pipefail
-            cargo build --release
-          '';
-          additionalBuildInputs = rust-build-inputs;
-        };
-
         sol-tasks = [
-          rainix-sol-static
-          rainix-sol-test
           rainix-sol-artifacts
-          rainix-sol-legal
         ];
 
         rs-tasks = [
           rainix-rs-static
-          rainix-rs-test
-          rainix-rs-artifacts
         ];
 
         rainix-tasks = sol-tasks ++ rs-tasks;
@@ -636,13 +585,8 @@
 
         packages = {
           inherit
-            rainix-sol-static
-            rainix-sol-test
             rainix-sol-artifacts
-            rainix-sol-legal
             rainix-rs-static
-            rainix-rs-test
-            rainix-rs-artifacts
             tauri-release-env
             prettier-bundle
             sol-shell-test

--- a/test/bats/devshell/sol-shell/sol-tasks.test.bats
+++ b/test/bats/devshell/sol-shell/sol-tasks.test.bats
@@ -1,17 +1,8 @@
-@test "rainix-sol-test should be available on PATH" {
-  run command -v rainix-sol-test
-  [ "$status" -eq 0 ]
-}
-
-@test "rainix-sol-static should be available on PATH" {
-  run command -v rainix-sol-static
-  [ "$status" -eq 0 ]
-}
-
-@test "rainix-sol-legal should be available on PATH" {
-  run command -v rainix-sol-legal
-  [ "$status" -eq 0 ]
-}
+# sol-shell tasks remaining after the trivial-wrapper cleanup. Static, test,
+# and legal are now invoked directly as `slither .` / `forge test -vvv` /
+# `reuse lint` — `cargo test`-style — from the rainix reusable workflows. This
+# bats only checks `rainix-sol-artifacts` since it wraps a non-trivial deploy
+# script with retries.
 
 @test "rainix-sol-artifacts should be available on PATH" {
   run command -v rainix-sol-artifacts


### PR DESCRIPTION
Removed mkTask wrappers whose body was a single CLI invocation: rainix-sol-test, rainix-sol-static, rainix-sol-legal, rainix-rs-test, rainix-rs-artifacts. Kept rainix-rs-static (multi-flag clippy) and subgraph-test (docker-compose orchestration). Reusable workflows now call `forge t est -vvv` / `slither .` / `forge fmt --check` / `reuse lint` / etc. directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to directly invoke standard development tools (Forge, Slither, Cargo, Reuse) for testing and validation, replacing custom task abstractions.
  * Simplified project build configuration by removing intermediate task wrappers.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rainlanguage/rainix/pull/145)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->