### PR TITLE
ci: reusable rainix-rs-static workflow

### DIFF
--- a/.github/workflows/rainix-rs-static.yaml
+++ b/.github/workflows/rainix-rs-static.yaml
@@ -1,0 +1,22 @@
+name: rainix-rs-static
+on:
+  workflow_call:
+jobs:
+  rs-static:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: nixbuild/nix-quick-install-action@v30
+        with:
+          nix_conf: |
+            keep-env-derivations = true
+            keep-outputs = true
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 1G
+      - run: nix develop github:rainlanguage/rainix#rust-shell -c rainix-rs-static

--- a/README.md
+++ b/README.md
@@ -167,6 +167,22 @@ jobs:
 Always runs through rainix's `sol-shell` (slim), regardless of the consumer's
 default devShell.
 
+#### rainix-rs-static
+
+`.github/workflows/rainix-rs-static.yaml` runs `rainix-rs-static` (cargo fmt
+check + clippy with `-D clippy::all`) on Linux. Wrapper:
+
+```yaml
+name: rainix-rs-static
+on: [push]
+jobs:
+  rs-static:
+    uses: rainlanguage/rainix/.github/workflows/rainix-rs-static.yaml@main
+```
+
+Always runs through rainix's `rust-shell` (rust toolchain only — no
+chromium/sol/node), regardless of the consumer's default devShell.
+
 ## Pinned Versions
 
 - Rust: 1.94.0


### PR DESCRIPTION
## Summary

- Reusable workflow `.github/workflows/rainix-rs-static.yaml` that runs `rainix-rs-static` (cargo fmt --check + clippy -D clippy::all) on ubuntu via rainix's `rust-shell`.
- Mirrors the rainix-sol-static / rainix-sol-legal pattern so consumer repos can drop their own nix-quick-install + cache plumbing.
- README entry added under the existing reusables section.

## Test plan

- [ ] Self-test: existing `rainix-rs-static` matrix entry in `test.yml` continues to pass.
- [ ] After merge, migrate a consumer (rain.math.float / rain.string) to call this reusable in place of inlined nix steps and confirm CI is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)