### PR TITLE
ci: deny rustc warnings in rainix-rs-static

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -277,7 +277,7 @@
           body = ''
             set -euxo pipefail
             cargo fmt --all -- --check
-            cargo clippy --all-targets --all-features -- -D clippy::all
+            cargo clippy --all-targets --all-features -- -D warnings -D clippy::all
           '';
           additionalBuildInputs = rust-build-inputs;
         };


### PR DESCRIPTION
## Summary

`-D clippy::all` only denies clippy lints. Rustc warnings (e.g. `unused_doc_comments`, `dead_code`, `unused_variables`) pass through rs-static silently. Add `-D warnings` so rs-static fails on any rustc warning, matching the existing strictness for clippy.

Surfaced when migrating rain.math.float onto the rs-static reusable: an `unused_doc_comments` warning in `crates/float/src/fuzz_ops.rs` was being printed by CI but not failing the job.

## Test plan

- [ ] Self-test matrix `cargo build --release` / `cargo test` in `test.yml` continues to pass.
- [ ] After merge, downstream rs-static jobs (rain.math.float, etc.) fail when warnings present.