### PR TITLE
ci: drop unused fetch-depth: 0 from reusable workflows

### DIFF
--- a/.github/workflows/publish-soldeer.yaml
+++ b/.github/workflows/publish-soldeer.yaml
@@ -18,8 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - uses: nixbuild/nix-quick-install-action@v30
         with:
           nix_conf: |

--- a/.github/workflows/rainix-build-pointers.yaml
+++ b/.github/workflows/rainix-build-pointers.yaml
@@ -6,8 +6,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - uses: nixbuild/nix-quick-install-action@v30
         with:
           nix_conf: |

--- a/.github/workflows/rainix-rs-static.yaml
+++ b/.github/workflows/rainix-rs-static.yaml
@@ -6,8 +6,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - uses: nixbuild/nix-quick-install-action@v30
         with:
           nix_conf: |

--- a/.github/workflows/rainix-sol-legal.yaml
+++ b/.github/workflows/rainix-sol-legal.yaml
@@ -6,8 +6,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - uses: nixbuild/nix-quick-install-action@v30
         with:
           nix_conf: |

--- a/.github/workflows/rainix-sol-static.yaml
+++ b/.github/workflows/rainix-sol-static.yaml
@@ -6,8 +6,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - uses: nixbuild/nix-quick-install-action@v30
         with:
           nix_conf: |

--- a/.github/workflows/rainix-sol-test.yaml
+++ b/.github/workflows/rainix-sol-test.yaml
@@ -18,8 +18,6 @@ jobs:
       POLYGON_RPC_URL: ${{ secrets.RPC_URL_POLYGON_FORK || vars.RPC_URL_POLYGON_FORK }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - uses: nixbuild/nix-quick-install-action@v30
         with:
           nix_conf: |


### PR DESCRIPTION
## Summary

Surfaced by CodeRabbit review on a downstream consumer (rainlanguage/rain.math.float#198): `fetch-depth: 0` clones the full git history on every job, but none of the reusable workflows in this repo read history. Drop it across the reusables — sol-static, sol-legal, sol-test, build-pointers, rs-static, publish-soldeer — so the default shallow clone applies.

What each workflow does, none of which needs history:

- sol-static: slither + forge fmt --check
- sol-legal: reuse lint
- sol-test: forge test
- build-pointers: forge script + git diff --exit-code (compares working tree to HEAD; depth 1 covers HEAD)
- rs-static: cargo fmt --check + cargo clippy
- publish-soldeer: forge soldeer push

## Test plan

- [ ] Self-test matrix in test.yml continues to pass.
- [ ] After merge, downstream rs-static / sol-* jobs still complete green on consumer PRs.