### PR TITLE
ci: cache cargo build artifacts in rainix-rs-static

### DIFF
--- a/.github/workflows/rainix-rs-static.yaml
+++ b/.github/workflows/rainix-rs-static.yaml
@@ -17,4 +17,5 @@ jobs:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
           gc-max-store-size-linux: 1G
+      - uses: Swatinem/rust-cache@v2
       - run: nix develop github:rainlanguage/rainix#rust-shell -c rainix-rs-static


### PR DESCRIPTION
## Summary

Adds `Swatinem/rust-cache@v2` between the existing nix-store cache and the cargo invocation in the rs-static reusable. Caches `~/.cargo/{registry,git,bin}` and `target/`, keyed on `Cargo.lock` + toolchain + OS.

## Why

Currently the nix-store cache holds the rust toolchain binary but not cargo's compilation artifacts. Every rs-static run downloads all crates from crates.io and recompiles from scratch. For float (alloy + revm + wasm-bindgen + ~hundreds of transitive crates) that's the bulk of the ~3m20s rs-static runtime.

With rust-cache, on unchanged-Cargo.lock PRs cargo clippy goes near-incremental — only the consumer's own crate compiles. Estimated savings: 3m20s → 30s-1m on warm cache, no change on cold.

## Test plan

- [ ] Self-test matrix in test.yml passes (rs-static is in the matrix).
- [ ] After merge, observe rs-static runtime drop on subsequent runs in downstream consumers (rain.math.float#198 is the obvious one).