### PR TITLE
ci: reusable rainix-rs-test workflow

### DIFF
--- a/.github/workflows/rainix-rs-test.yaml
+++ b/.github/workflows/rainix-rs-test.yaml
@@ -1,0 +1,26 @@
+name: rainix-rs-test
+on:
+  workflow_call:
+jobs:
+  rs-test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: nixbuild/nix-quick-install-action@v30
+        with:
+          nix_conf: |
+            keep-env-derivations = true
+            keep-outputs = true
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 1G
+          gc-max-store-size-macos: 1G
+      - uses: Swatinem/rust-cache@v2
+      - run: nix develop github:rainlanguage/rainix#rust-shell -c cargo test

--- a/README.md
+++ b/README.md
@@ -183,6 +183,23 @@ jobs:
 Always runs through rainix's `rust-shell` (rust toolchain only — no
 chromium/sol/node), regardless of the consumer's default devShell.
 
+#### rainix-rs-test
+
+`.github/workflows/rainix-rs-test.yaml` runs `cargo test` on Linux and macOS.
+Wrapper:
+
+```yaml
+name: rainix-rs-test
+on: [push]
+jobs:
+  rs-test:
+    uses: rainlanguage/rainix/.github/workflows/rainix-rs-test.yaml@main
+```
+
+Same shape as rs-static — runs through `rust-shell`. Consumers whose rust crate
+compiles standalone (no live forge artifacts at compile time) can drop their
+bespoke rs-test matrix in favour of this.
+
 ## Pinned Versions
 
 - Rust: 1.94.0


### PR DESCRIPTION
## Summary

Mirrors rs-static, but runs `cargo test` on ubuntu + macos via rust-shell. Includes `Swatinem/rust-cache@v2` from the start so cargo test gets the same incremental-rebuild benefit as rs-static will after #149 lands.

For consumers whose rust crate compiles standalone (e.g. rain.math.float after rainlanguage/rain.math.float#198 commits forge artifacts under `crates/float/abi/`), this replaces the bespoke per-repo rs-test matrix with a one-line wrapper.

## Test plan

- [ ] Self-test: existing `cargo test` matrix entry in `test.yml` continues to pass.
- [ ] After merge, migrate rain.math.float from its bespoke `rainix.yaml` cargo test matrix to a one-line wrapper calling this reusable.