### PR TITLE
ci: reusable rainix-rs-wasm workflow

### DIFF
--- a/.github/workflows/rainix-rs-wasm.yaml
+++ b/.github/workflows/rainix-rs-wasm.yaml
@@ -1,0 +1,21 @@
+name: rainix-rs-wasm
+on:
+  workflow_call:
+jobs:
+  rs-wasm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: nixbuild/nix-quick-install-action@v30
+        with:
+          nix_conf: |
+            keep-env-derivations = true
+            keep-outputs = true
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 1G
+      - uses: Swatinem/rust-cache@v2
+      - run: nix develop github:rainlanguage/rainix#rust-shell -c cargo build -r --target wasm32-unknown-unknown --lib --workspace

--- a/README.md
+++ b/README.md
@@ -200,6 +200,24 @@ Same shape as rs-static — runs through `rust-shell`. Consumers whose rust crat
 compiles standalone (no live forge artifacts at compile time) can drop their
 bespoke rs-test matrix in favour of this.
 
+#### rainix-rs-wasm
+
+`.github/workflows/rainix-rs-wasm.yaml` cross-compiles the workspace to
+`wasm32-unknown-unknown` (release, library targets only). For consumers that
+ship rust crates downstream as WASM (e.g. via wasm-bindgen for JS/TS), this
+catches WASM-incompatible dependencies before they reach the JS build. Wrapper:
+
+```yaml
+name: rainix-rs-wasm
+on: [push]
+jobs:
+  rs-wasm:
+    uses: rainlanguage/rainix/.github/workflows/rainix-rs-wasm.yaml@main
+```
+
+`rust-shell`'s toolchain already includes the `wasm32-unknown-unknown` target,
+so no extra setup is required.
+
 ## Pinned Versions
 
 - Rust: 1.94.0


### PR DESCRIPTION
## Summary

Cross-compiles the consumer workspace to `wasm32-unknown-unknown` (release, library targets only) via `rust-shell`. Catches WASM-incompatible dependencies (e.g. unconditional tokio, anything reaching `std::os::unix`) before they reach the JS-side `wasm-bindgen` build.

`rust-shell`'s toolchain already includes the `wasm32-unknown-unknown` target, so no extra setup. Includes `Swatinem/rust-cache@v2` for incremental rebuilds, matching the rs-static and rs-test reusables.

## Test plan

- [ ] After merge, migrate rain.math.float's bespoke `test-wasm-build` job (currently in `rainix.yaml`) to a one-line wrapper calling this reusable.