### PR TITLE
ci: rainix-rs composite reusable

### DIFF
--- a/.github/workflows/rainix-rs.yaml
+++ b/.github/workflows/rainix-rs.yaml
@@ -1,0 +1,10 @@
+name: rainix-rs
+on:
+  workflow_call:
+jobs:
+  static:
+    uses: ./.github/workflows/rainix-rs-static.yaml
+  test:
+    uses: ./.github/workflows/rainix-rs-test.yaml
+  wasm:
+    uses: ./.github/workflows/rainix-rs-wasm.yaml

--- a/README.md
+++ b/README.md
@@ -218,6 +218,23 @@ jobs:
 `rust-shell`'s toolchain already includes the `wasm32-unknown-unknown` target,
 so no extra setup is required.
 
+#### rainix-rs (composite)
+
+`.github/workflows/rainix-rs.yaml` fans out static, test, and wasm in parallel —
+each on its own runner. Single wrapper for rust-shipping repos that want all
+three:
+
+```yaml
+name: rainix-rs
+on: [push]
+jobs:
+  rainix-rs:
+    uses: rainlanguage/rainix/.github/workflows/rainix-rs.yaml@main
+```
+
+Consumers needing only one of the three should call the individual reusable
+directly rather than this composite.
+
 ## Pinned Versions
 
 - Rust: 1.94.0


### PR DESCRIPTION
## Summary

Mirrors `rainix-sol`. Single wrapper that fans out `rs-static`, `rs-test`, and `rs-wasm` in parallel for rust-shipping consumer repos that want the full bundle.

```yaml
name: rainix-rs
on: [push]
jobs:
  rainix-rs:
    uses: rainlanguage/rainix/.github/workflows/rainix-rs.yaml@main
```

## Test plan

- [ ] After merge, migrate rain.math.float's three separate wrappers (`rainix-rs-static.yaml`, `rainix-rs-test.yaml`, `rainix-rs-wasm.yaml`) to one wrapper calling this composite.