### PR TITLE
ci: publish-soldeer uses sol-shell directly

### DIFF
--- a/.github/workflows/publish-soldeer.yaml
+++ b/.github/workflows/publish-soldeer.yaml
@@ -41,4 +41,4 @@ jobs:
             PACKAGE="${PACKAGE//./-}"
           fi
           VERSION="${GITHUB_REF_NAME#v}"
-          nix develop -c forge soldeer push "${PACKAGE}~${VERSION}"
+          nix develop github:rainlanguage/rainix#sol-shell -c forge soldeer push "${PACKAGE}~${VERSION}"


### PR DESCRIPTION
Mirrors the other reusables — invoke `nix develop github:rainlanguage/rainix#sol-shell` rather than the consumer's default devShell. Consumers with heavy default shells avoid bootstrap cost for `forge soldeer push`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow configuration to refine the build environment setup process used during package publishing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rainlanguage/rainix/pull/154)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->