### PR TITLE
ci: reusable rainix-manual-sol-artifacts workflow

### DIFF
--- a/.github/workflows/rainix-manual-sol-artifacts.yaml
+++ b/.github/workflows/rainix-manual-sol-artifacts.yaml
@@ -1,0 +1,44 @@
+name: rainix-manual-sol-artifacts
+on:
+  workflow_call:
+    inputs:
+      suite:
+        type: string
+        required: true
+        description: |
+          Passed through as `DEPLOYMENT_SUITE`. `script/Deploy.sol` dispatches
+          on this to select what to deploy.
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: nixbuild/nix-quick-install-action@v30
+        with:
+          nix_conf: |
+            keep-env-derivations = true
+            keep-outputs = true
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 1G
+      - name: Install soldeer dependencies
+        if: hashFiles('soldeer.lock') != ''
+        run: nix develop github:rainlanguage/rainix#sol-shell -c forge soldeer install
+      - run: nix develop github:rainlanguage/rainix#sol-shell -c forge selectors up --all
+      - run: nix develop github:rainlanguage/rainix#sol-shell -c forge script script/Deploy.sol:Deploy -vvvvv --slow --broadcast --verify
+        env:
+          DEPLOYMENT_SUITE: ${{ inputs.suite }}
+          DEPLOYMENT_KEY: ${{ secrets.PRIVATE_KEY }}
+          ARBITRUM_RPC_URL: ${{ secrets.RPC_URL_ARBITRUM_FORK || vars.RPC_URL_ARBITRUM_FORK || '' }}
+          BASE_RPC_URL: ${{ secrets.RPC_URL_BASE_FORK || vars.RPC_URL_BASE_FORK || '' }}
+          BASE_SEPOLIA_RPC_URL: ${{ secrets.RPC_URL_BASE_SEPOLIA_FORK || vars.RPC_URL_BASE_SEPOLIA_FORK || '' }}
+          FLARE_RPC_URL: ${{ secrets.RPC_URL_FLARE_FORK || vars.RPC_URL_FLARE_FORK || '' }}
+          POLYGON_RPC_URL: ${{ secrets.RPC_URL_POLYGON_FORK || vars.RPC_URL_POLYGON_FORK || '' }}
+          CI_DEPLOY_ARBITRUM_ETHERSCAN_API_KEY: ${{ secrets.CI_DEPLOY_ARBITRUM_ETHERSCAN_API_KEY || vars.CI_DEPLOY_ARBITRUM_ETHERSCAN_API_KEY || '' }}
+          CI_DEPLOY_BASE_ETHERSCAN_API_KEY: ${{ secrets.CI_DEPLOY_BASE_ETHERSCAN_API_KEY || vars.CI_DEPLOY_BASE_ETHERSCAN_API_KEY || '' }}
+          CI_DEPLOY_BASE_SEPOLIA_ETHERSCAN_API_KEY: ${{ secrets.CI_DEPLOY_BASE_SEPOLIA_ETHERSCAN_API_KEY || vars.CI_DEPLOY_BASE_SEPOLIA_ETHERSCAN_API_KEY || '' }}
+          CI_DEPLOY_FLARE_ETHERSCAN_API_KEY: ${{ secrets.CI_DEPLOY_FLARE_ETHERSCAN_API_KEY || vars.CI_DEPLOY_FLARE_ETHERSCAN_API_KEY || '' }}
+          CI_DEPLOY_POLYGON_ETHERSCAN_API_KEY: ${{ secrets.CI_DEPLOY_POLYGON_ETHERSCAN_API_KEY || vars.CI_DEPLOY_POLYGON_ETHERSCAN_API_KEY || '' }}


### PR DESCRIPTION
Lifts the manual-sol-artifacts pattern (currently duplicated across rain.math.float, rain.factory, rain.tofu.erc20-decimals, rain.extrospection) into a single reusable.

## Shape

```yaml
on:
  workflow_call:
    inputs:
      suite: { type: string, required: true }
```

Passes the suite through as `DEPLOYMENT_SUITE`; the consumer's `script/Deploy.sol` dispatches on it. Workflow always runs `forge script ... --broadcast --verify` with simulation enabled.

## Where simulation preconditions live

Suites whose simulation pass depends on yet-to-be-deployed state (e.g. float's `decimal-float` reading from `log-tables` via `extcodecopy`) handle their own preconditions in `Deploy.sol` via `vm.etch` — pushing the knowledge to where the precondition is actually known, not to the workflow layer.

## Consumer wrapper shape

```yaml
on:
  workflow_dispatch:
    inputs:
      suite:
        type: choice
        options: [...]
jobs:
  deploy:
    uses: rainlanguage/rainix/.github/workflows/rainix-manual-sol-artifacts.yaml@main
    with:
      suite: ${{ inputs.suite }}
    secrets: inherit
```

Single-suite repos hardcode the suite value in the wrapper.

## Test plan

- [ ] After merge, migrate float / factory / tofu / extrospection to one-line wrappers + a `vm.etch` simulation-precondition in float's Deploy.sol for the decimal-float suite.