### PR TITLE
test: add rust-shell closure regression test

### DIFF
--- a/.github/workflows/check-shell.yml
+++ b/.github/workflows/check-shell.yml
@@ -36,3 +36,4 @@ jobs:
       - run: nix develop --command gh --version
       - run: nix develop --command default-shell-test
       - run: nix develop .#sol-shell --command nix run .#sol-shell-test
+      - run: nix develop .#rust-shell --command nix run .#rust-shell-test

--- a/flake.nix
+++ b/flake.nix
@@ -364,6 +364,14 @@
           additionalBuildInputs = [ pkgs.bats ] ++ sol-build-inputs;
         };
 
+        rust-shell-test = mkTask {
+          name = "rust-shell-test";
+          body = ''
+            bats test/bats/devshell/rust-shell/closure.test.bats
+          '';
+          additionalBuildInputs = [ pkgs.bats ];
+        };
+
         pre-commit = git-hooks-nix.lib.${system}.run {
           src = ./.;
           hooks = {
@@ -540,6 +548,7 @@
             rainix-rs-static
             prettier-bundle
             sol-shell-test
+            rust-shell-test
             ;
         };
 

--- a/test/bats/devshell/rust-shell/closure.test.bats
+++ b/test/bats/devshell/rust-shell/closure.test.bats
@@ -1,0 +1,59 @@
+# Closure-level slim assertion for rust-shell.
+#
+# Mirror of sol-shell/closure.test.bats. Runtime-PATH checks miss leaks
+# where a heavy package is interpolated into a script string — the
+# script does not appear on PATH, but its referenced store paths are
+# still in rust-shell's nix closure and are downloaded/built every
+# time CI evaluates the shell.
+#
+# This file inspects rust-shell's full closure (`nix-store -q
+# --requisites`) and fails if any sol toolchain, node/npm, or chromium
+# component shows up. rust-shell is for repos that ship a pure rust
+# binary (rain.cli, rain.metadoc, etc.) and should not pull in foundry,
+# slither, solc, nodejs, or chromium.
+#
+# Skips when `nix` is not on PATH (e.g. running the bats files under a
+# stripped sandbox); CI invokes via nix and so always exercises this.
+
+setup() {
+  if ! command -v nix >/dev/null 2>&1; then
+    skip "nix not on PATH"
+  fi
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../../../.." && pwd)"
+  SYSTEM="$(nix eval --raw --impure --expr 'builtins.currentSystem')"
+  # Realise the shell so we can query its runtime closure (the drv-level
+  # closure is full of build-time bootstrap deps that never appear in the
+  # realized environment, which produces noisy false positives).
+  RUST_SHELL_OUT="$(nix build --no-link --print-out-paths "$REPO_ROOT#devShells.$SYSTEM.rust-shell")"
+  CLOSURE="$(nix-store -q --requisites "$RUST_SHELL_OUT")"
+}
+
+@test "rust-shell closure has no foundry toolchain" {
+  local hits
+  hits="$(echo "$CLOSURE" | grep -E '/nix/store/[^/]*-(foundry-|solc-static-|slither-analyzer-)' || true)"
+  if [ -n "$hits" ]; then
+    echo "FAIL: rust-shell closure references sol toolchain components:" >&2
+    echo "$hits" >&2
+    return 1
+  fi
+}
+
+@test "rust-shell closure has no node/npm" {
+  local hits
+  hits="$(echo "$CLOSURE" | grep -E '/nix/store/[^/]*-(nodejs-|nodejs_|npm-)' || true)"
+  if [ -n "$hits" ]; then
+    echo "FAIL: rust-shell closure references nodejs:" >&2
+    echo "$hits" >&2
+    return 1
+  fi
+}
+
+@test "rust-shell closure has no chromium" {
+  local hits
+  hits="$(echo "$CLOSURE" | grep -E '/nix/store/[^/]*-chromium-' || true)"
+  if [ -n "$hits" ]; then
+    echo "FAIL: rust-shell closure references chromium:" >&2
+    echo "$hits" >&2
+    return 1
+  fi
+}


### PR DESCRIPTION
## Summary
Add a closure regression test for \`rust-shell\` mirroring the one for \`sol-shell\`. Asserts the rust-shell nix closure has no foundry/solc/slither, no node/npm, and no chromium — deliberately absent so consumers like rain.cli that ship a pure rust binary skip the heavy default closure.

Adds:
- \`test/bats/devshell/rust-shell/closure.test.bats\` (mirrors \`sol-shell/closure.test.bats\`)
- \`rust-shell-test\` task in flake.nix
- new check-shell CI step that exercises it

Tracks #141 (rust-shell side). js-shell is the remaining half.

## Mutation test
Each assertion was verified locally by injecting an offending package and confirming the matching assertion fires:
- \`pkgs.foundry\` in rust-shell buildInputs → assertion 1 fires ✓
- \`pkgs.nodejs_22\` in rust-shell buildInputs → assertion 2 fires ✓
- \`writeShellScriptBin "chromium-mut-stub"\` → assertion 3 fires ✓
- Revert → all 3 pass ✓

## Test plan
- check-shell job (linux + macos) on this PR
- ad-hoc \`nix develop -c bats test/bats/devshell/rust-shell/closure.test.bats\` after mutating rust-shell

Generated with Claude Code.