### PR TITLE
docs: drop stale rainix-rs-artifacts reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,6 @@ All tasks are Nix packages run via `nix run`. From a consuming repo use `..#`
 - `nix run ..#rainix-rs-test` — `cargo test`
 - `nix run ..#rainix-rs-static` —
   `cargo fmt --all -- --check && cargo clippy --all-targets --all-features -- -D clippy::all`
-- `nix run ..#rainix-rs-artifacts` — `cargo build --release`
 
 ### Subgraph (dev shell only, not `nix run` targets)
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ All tasks are Nix packages run via `nix run`. From a consuming repo:
 
 - `nix run ..#rainix-rs-test` — cargo test
 - `nix run ..#rainix-rs-static` — cargo fmt + clippy
-- `nix run ..#rainix-rs-artifacts` — cargo build --release
 
 ### Reusable Outputs
 


### PR DESCRIPTION
## Summary
README.md and CLAUDE.md both document \`rainix-rs-artifacts\` as a \`cargo build --release\` task, but the task isn't defined in flake.nix or exported from packages. Drop the stale lines.

Conclusion from discussion on #161: \`cargo test\` (dev profile) compiles the same code as \`cargo build --release\` for library crates without \`cfg(debug_assertions)\` branches, and binary-shipping consumers add their own \`--release\` step rather than going through a rainix task. No new task needed.

## Test plan
- Diff is purely docs; nothing to run.

Generated with Claude Code.