### PR TITLE
feat(ci): upstream rainix-rs-wasm-test reusable

### DIFF
--- a/.github/workflows/rainix-rs-wasm-test.yaml
+++ b/.github/workflows/rainix-rs-wasm-test.yaml
@@ -1,0 +1,21 @@
+name: rainix-rs-wasm-test
+on:
+  workflow_call:
+jobs:
+  rs-wasm-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: nixbuild/nix-quick-install-action@v30
+        with:
+          nix_conf: |
+            keep-env-derivations = true
+            keep-outputs = true
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 1G
+      - uses: Swatinem/rust-cache@v2
+      - run: nix develop github:rainlanguage/rainix#rust-shell -c bash -c "CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=wasm-bindgen-test-runner cargo test --target wasm32-unknown-unknown --workspace"

--- a/.github/workflows/rainix-rs.yaml
+++ b/.github/workflows/rainix-rs.yaml
@@ -8,3 +8,5 @@ jobs:
     uses: ./.github/workflows/rainix-rs-test.yaml
   wasm:
     uses: ./.github/workflows/rainix-rs-wasm.yaml
+  wasm-test:
+    uses: ./.github/workflows/rainix-rs-wasm-test.yaml


### PR DESCRIPTION
## Summary
Mirror of \`rainix-rs-wasm.yaml\` but runs \`cargo test\` against the wasm32 target via \`wasm-bindgen-test-runner\`. Wired into the \`rainix-rs\` composite so downstream consumers (rain.wasm and similar repos with native + wasm-build + wasm-test jobs) can collapse to a single \`rainix-rs\` wrapper.

Resolves the gap identified in rainlanguage/rain.wasm#39: the composite \`rainix-rs.yaml\` now covers static + test + wasm-build + wasm-test, so a consumer with all four jobs can become a single 4-line wrapper.

## Test plan
After merge, rain.wasm#39 can land a follow-up that replaces its local \`rainix.yml\` matrix with \`uses: rainlanguage/rainix/.github/workflows/rainix-rs.yaml@main\`.

Generated with Claude Code.