### PR TITLE
chore: drop wasm-bindgen-cli pin to 0.2.100

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ All tasks are Nix packages run via `nix run`. From a consuming repo use `..#`
 - Foundry: via foundry.nix
 - Graph CLI: 0.69.2
 - Goldsky CLI: 8.6.6
-- wasm-bindgen-cli: 0.2.100
+- wasm-bindgen-cli: nixpkgs default (0.2.117 as of 2026-05)
 
 ## Architecture
 

--- a/flake.nix
+++ b/flake.nix
@@ -23,14 +23,10 @@
     flake-utils.lib.eachDefaultSystem (
       system:
       let
-        wasm-bindgen-overlay = _final: prev: {
-          wasm-bindgen-cli = prev.wasm-bindgen-cli_0_2_100;
-        };
         overlays = [
           (import rust-overlay)
           foundry.overlay
           solc.overlay
-          wasm-bindgen-overlay
         ];
         pkgs = import nixpkgs { inherit system overlays; };
 


### PR DESCRIPTION
The overlay pinned `wasm-bindgen-cli` to 0.2.100. Any consumer using a newer `wasm-bindgen` in their Rust deps gets a schema-version mismatch when `wasm-bindgen-test-runner` marshals their wasm. Drop the pin so consumers track the nixpkgs default (currently 0.2.117) and only need to match it in their own `Cargo.lock`.

Unblocks rainlanguage/rain.wasm#40 (which needs >=0.2.114 for the new `TryFromJsValue` API).

## Test plan
- nix flake check passes locally.
- After merge, rain.wasm#40's wasm-test job should pass once its Cargo.lock pins wasm-bindgen 0.2.117 too.