### PR TITLE
fix(ci): drop pkgs.chromium from default devShell

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Requires Nix with flakes enabled.
 
 ```sh
 nix develop                # default shell (Solidity + Rust + Node + subgraph tools)
-nix develop .#sol-shell    # slim Solidity-only shell — no rust, node, chromium, subgraph
-nix develop .#rust-shell   # slim Rust-only shell — no sol, node, chromium
+nix develop .#sol-shell    # slim Solidity-only shell — no rust, node, subgraph
+nix develop .#rust-shell   # slim Rust-only shell — no sol, node
 ```
 
 The default shell auto-sources `.env` if present and runs
@@ -179,8 +179,8 @@ jobs:
     uses: rainlanguage/rainix/.github/workflows/rainix-rs-static.yaml@main
 ```
 
-Always runs through rainix's `rust-shell` (rust toolchain only — no
-chromium/sol/node), regardless of the consumer's default devShell.
+Always runs through rainix's `rust-shell` (rust toolchain only — no sol/node),
+regardless of the consumer's default devShell.
 
 #### rainix-rs-test
 

--- a/flake.nix
+++ b/flake.nix
@@ -127,28 +127,6 @@
           '';
         };
 
-        # Cross-platform `chromium` binary for headless rendering inside the dev
-        # shell (e.g. dumping rendered DOM of a deployed SPA preview to debug
-        # JS-side errors). On Linux, defer to the nixpkgs chromium build. On
-        # Darwin, nixpkgs has no chromium, so wrap the system Chrome.app — fails
-        # at invocation time with a clear message when Chrome is not installed.
-        chromium = pkgs.writeShellScriptBin "chromium" (
-          if pkgs.stdenv.isDarwin then
-            ''
-              chrome="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
-              if [ ! -x "$chrome" ]; then
-                echo "rainix chromium wrapper: Google Chrome.app not found at $chrome" >&2
-                echo "Install Chrome (https://www.google.com/chrome/) or use a Linux dev shell." >&2
-                exit 127
-              fi
-              exec "$chrome" "$@"
-            ''
-          else
-            ''
-              exec ${pkgs.chromium}/bin/chromium "$@"
-            ''
-        );
-
         # rainix-curated prettier bundle: a single nix-built node_modules
         # tree containing prettier + the standardized plugins, plus a
         # .prettierrc.json picked up via PRETTIER_BUNDLE_DIR. Consumers
@@ -337,7 +315,6 @@
             bats test/bats/devshell/default/solc.test.bats
             bats test/bats/devshell/default/gh.test.bats
             bats test/bats/devshell/default/age.test.bats
-            bats test/bats/devshell/default/chromium.test.bats
             bats test/bats/devshell/default/prettier-bundle.test.bats
             bats test/bats/task/skip-simulation.test.bats
             bats test/bats/task/subgraph-build.test.bats
@@ -551,7 +528,7 @@
         };
 
         devShells = {
-          # Slim shell for Solidity-only repos: no chromium, rust, node,
+          # Slim shell for Solidity-only repos: no rust, node,
           # subgraph, sqlite, age. Lets sol-only consumers (rain.solmem,
           # rain.deploy, rain.datacontract, etc.) avoid the heavy default
           # closure when their CI is just rainix-sol-{test,static,legal}.
@@ -564,7 +541,7 @@
           };
 
           # Slim shell for Rust-only repos: rust toolchain + cargo + the
-          # rs-tasks, no sol/node/chromium. Mirror of sol-shell for the
+          # rs-tasks, no sol/node. Mirror of sol-shell for the
           # Rust side. Consumers like rain.cli that ship a pure rust
           # binary can alias `default = rust-shell` and skip the heavy
           # default closure.
@@ -587,7 +564,6 @@
               ++ [
                 the-graph
                 goldsky
-                chromium
                 pkgs.sqlite
                 pkgs.yq-go
                 pkgs.age

--- a/test/bats/devshell/default/chromium.test.bats
+++ b/test/bats/devshell/default/chromium.test.bats
@@ -1,4 +1,0 @@
-@test "chromium should be available on PATH" {
-  run chromium --version
-  [ "$status" -eq 0 ]
-}


### PR DESCRIPTION
## Summary
- Remove `pkgs.chromium` from the default Linux devShell. `cache.nixos.org` does not have a prebuilt chromium for the pinned nixpkgs revision, so Linux runners spend hours compiling from source and hit the 6h job timeout.
- Drop the `chromium.test.bats` smoke test that asserted chromium was on PATH; nothing in rainix actually invokes it.
- README + slim-shell comments updated to drop the now-stale \"no chromium\" enumeration.
- The sol-shell / rust-shell closure tests continue to assert chromium is absent from those slim closures.

Closes #170.

## Test plan
- [ ] CI green on Linux without timing out
- [ ] sol-shell closure test (asserts no chromium) still passes
- [ ] rust-shell closure test (asserts no chromium) still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)