### PR TITLE
feat(rust-shell): include foundry-bin for anvil-based tests

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,7 @@
           rust-toolchain
           pkgs.cargo-release
           pkgs.cargo-expand
+          pkgs.foundry-bin
           pkgs.gmp
           pkgs.openssl
           pkgs.libusb1
@@ -366,6 +367,7 @@
           body = ''
             bats test/bats/devshell/rust-shell/closure.test.bats
             bats test/bats/devshell/rust-shell/cargo-expand.test.bats
+            bats test/bats/devshell/rust-shell/anvil.test.bats
           '';
           additionalBuildInputs = [ pkgs.bats ] ++ rust-build-inputs;
         };

--- a/test/bats/devshell/rust-shell/anvil.test.bats
+++ b/test/bats/devshell/rust-shell/anvil.test.bats
@@ -1,0 +1,4 @@
+@test "anvil should be available on PATH" {
+  run anvil --version
+  [ "$status" -eq 0 ]
+}

--- a/test/bats/devshell/rust-shell/closure.test.bats
+++ b/test/bats/devshell/rust-shell/closure.test.bats
@@ -7,10 +7,10 @@
 # time CI evaluates the shell.
 #
 # This file inspects rust-shell's full closure (`nix-store -q
-# --requisites`) and fails if any sol toolchain, node/npm, or chromium
-# component shows up. rust-shell is for repos that ship a pure rust
-# binary (rain.cli, rain.metadoc, etc.) and should not pull in foundry,
-# slither, solc, nodejs, or chromium.
+# --requisites`) and fails if slither, solc, node/npm, or chromium
+# show up. rust-shell ships foundry-bin so that alloy's Anvil::new()
+# spawn works in cargo tests, but does not pull in the rest of the
+# Solidity static-analysis toolchain.
 #
 # Skips when `nix` is not on PATH (e.g. running the bats files under a
 # stripped sandbox); CI invokes via nix and so always exercises this.
@@ -28,11 +28,11 @@ setup() {
   CLOSURE="$(nix-store -q --requisites "$RUST_SHELL_OUT")"
 }
 
-@test "rust-shell closure has no foundry toolchain" {
+@test "rust-shell closure has no slither or solc" {
   local hits
-  hits="$(echo "$CLOSURE" | grep -E '/nix/store/[^/]*-(foundry-|solc-static-|slither-analyzer-)' || true)"
+  hits="$(echo "$CLOSURE" | grep -E '/nix/store/[^/]*-(solc-static-|slither-analyzer-)' || true)"
   if [ -n "$hits" ]; then
-    echo "FAIL: rust-shell closure references sol toolchain components:" >&2
+    echo "FAIL: rust-shell closure references sol static-analysis components:" >&2
     echo "$hits" >&2
     return 1
   fi


### PR DESCRIPTION
## Summary
- Add `pkgs.foundry-bin` to `rust-build-inputs`. This makes `anvil` available on PATH inside `rust-shell` and the default shell.
- Consumers using alloy's `Anvil::new().try_spawn()` for local-EVM integration tests in `cargo test` need anvil. Without it the spawn errors `Os { code: 2, kind: NotFound }`. The slim `rust-shell` was excluding the whole `sol-build-inputs` set, which dragged anvil out with it.
- Closure assertion in `test/bats/devshell/rust-shell/closure.test.bats` updated to allow foundry-bin while still rejecting slither/solc.
- New `anvil.test.bats` asserting anvil is on PATH.

## Why option 2

Two ways to fix this were considered:

1. Introduce a new `node-binding-inputs` set carrying anvil and include it in rust-shell. Architectural — anvil is conceptually a node-binding test tool, distinct from sol-build (forge/slither/solc/reuse for actual Solidity work).
2. Add `pkgs.foundry-bin` directly to `rust-build-inputs`. One-line change; brings forge/cast/chisel along but those are part of the same foundry-bin output so the closure cost is the same as just anvil.

Going with 2 — same net cost, lower diff.

## Test plan
- [ ] `rust-shell-test` (closure + cargo-expand + anvil) green
- [ ] No regression on `sol-shell-test`
- [ ] No regression on `default-shell-test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Foundry CLI tools are now available in the Rust development environment.

* **Tests**
  * Added verification that Foundry tools are accessible in the environment.
  * Improved closure assertions for development dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rainlanguage/rainix/pull/172)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->