### PR TITLE
ci: declare workflow_call secrets on sol reusable workflows

### DIFF
--- a/.github/workflows/rainix-sol-test.yaml
+++ b/.github/workflows/rainix-sol-test.yaml
@@ -1,6 +1,23 @@
 name: rainix-sol-test
 on:
   workflow_call:
+    secrets:
+      PRIVATE_KEY:
+        required: false
+      EXPLORER_VERIFICATION_KEY:
+        required: false
+      CI_DEPLOY_SEPOLIA_RPC_URL:
+        required: false
+      RPC_URL_ARBITRUM_FORK:
+        required: false
+      RPC_URL_BASE_FORK:
+        required: false
+      RPC_URL_BASE_SEPOLIA_FORK:
+        required: false
+      RPC_URL_FLARE_FORK:
+        required: false
+      RPC_URL_POLYGON_FORK:
+        required: false
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/rainix-sol.yaml
+++ b/.github/workflows/rainix-sol.yaml
@@ -1,6 +1,23 @@
 name: rainix-sol
 on:
   workflow_call:
+    secrets:
+      PRIVATE_KEY:
+        required: false
+      EXPLORER_VERIFICATION_KEY:
+        required: false
+      CI_DEPLOY_SEPOLIA_RPC_URL:
+        required: false
+      RPC_URL_ARBITRUM_FORK:
+        required: false
+      RPC_URL_BASE_FORK:
+        required: false
+      RPC_URL_BASE_SEPOLIA_FORK:
+        required: false
+      RPC_URL_FLARE_FORK:
+        required: false
+      RPC_URL_POLYGON_FORK:
+        required: false
 jobs:
   static:
     uses: ./.github/workflows/rainix-sol-static.yaml
@@ -8,4 +25,12 @@ jobs:
     uses: ./.github/workflows/rainix-sol-legal.yaml
   test:
     uses: ./.github/workflows/rainix-sol-test.yaml
-    secrets: inherit
+    secrets:
+      PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+      EXPLORER_VERIFICATION_KEY: ${{ secrets.EXPLORER_VERIFICATION_KEY }}
+      CI_DEPLOY_SEPOLIA_RPC_URL: ${{ secrets.CI_DEPLOY_SEPOLIA_RPC_URL }}
+      RPC_URL_ARBITRUM_FORK: ${{ secrets.RPC_URL_ARBITRUM_FORK }}
+      RPC_URL_BASE_FORK: ${{ secrets.RPC_URL_BASE_FORK }}
+      RPC_URL_BASE_SEPOLIA_FORK: ${{ secrets.RPC_URL_BASE_SEPOLIA_FORK }}
+      RPC_URL_FLARE_FORK: ${{ secrets.RPC_URL_FLARE_FORK }}
+      RPC_URL_POLYGON_FORK: ${{ secrets.RPC_URL_POLYGON_FORK }}


### PR DESCRIPTION
## Summary
- Adds explicit \`secrets:\` blocks to the sol reusable workflows.
- Lets cross-org callers pass named secrets (\`secrets: { RPC_URL_BASE_FORK: ... }\`) instead of \`secrets: inherit\`.
- Verified empirically on \`S01-Issuer/st0x.deploy#182\`: \`secrets: inherit\` silently drops these secrets when crossing the org boundary; named passing is the only reliable path.
- All declared secrets are \`required: false\`, so existing callers using \`secrets: inherit\` keep working unchanged.

## Test plan
- [x] yaml lints clean.
- [ ] Once merged, \`S01-Issuer/st0x.deploy#182\` re-runs CI with named passing and the fork RPC env values arrive populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)