### PR TITLE
flake: skip npm ci in default shell when lockfile already installed

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -576,7 +576,7 @@
               ${pre-commit.shellHook}
               ${source-dotenv}
 
-              if [ -f ./package.json ]; then
+              if [ -f ./package.json ] && ! cmp -s ./package-lock.json ./node_modules/.package-lock.json 2>/dev/null; then
                 npm ci --ignore-scripts;
               fi
             '';


### PR DESCRIPTION
## Summary

- The `default` devShell ran `npm ci --ignore-scripts` on every shell entry whenever a `package.json` was present, wiping and reinstalling `node_modules` even when it already matched the lockfile. Painful for ad-hoc `nix develop -c <cmd>` invocations.
- Compare `./package-lock.json` to the copy npm writes into `./node_modules/.package-lock.json` after a successful install, and skip `npm ci` when they match.
- First entry (or any entry after the lockfile changes) still runs `npm ci`.

Closes #175

## Test plan

- [ ] `nix develop` in a repo with a `package.json` + `package-lock.json` triggers `npm ci` on first entry, then is a no-op on subsequent entries.
- [ ] After modifying `package-lock.json`, the next `nix develop` entry re-runs `npm ci`.
- [ ] `nix develop` in a repo without `package.json` remains a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized development environment setup to run dependency installation only when necessary, improving development workflow efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rainlanguage/rainix/pull/176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->