### PR TITLE
feat: add rust-node-shell devShell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -555,6 +555,20 @@
             '';
           };
 
+          # Slim shell for repos that ship a Rust crate plus a node/WASM
+          # binding (e.g. rain.math.float's @rainlanguage/float npm
+          # package built from the rust-shell-compiled WASM). Adds node
+          # to rust-shell without dragging in the heavy sol/subgraph
+          # closure. Keeps everything under nix so PATH ordering and
+          # version drift between actions/setup-node and nix go away.
+          rust-node-shell = pkgs.mkShell {
+            buildInputs = rust-build-inputs ++ node-build-inputs ++ rs-tasks ++ common-shell-inputs;
+            shellHook = ''
+              ${pre-commit.shellHook}
+              ${source-dotenv}
+            '';
+          };
+
           default = pkgs.mkShell {
             buildInputs =
               sol-build-inputs


### PR DESCRIPTION
Slim shell for repos that ship a Rust crate plus a Node/WASM binding (rain.math.float pattern). rust-build-inputs + node-build-inputs + rs-tasks, without the heavy sol/subgraph closure.

Unblocks rain.math.float#221: with rust-node-shell, the package-release workflow can stay fully inside nix and stop mixing actions/setup-node with nix shells.