### PR TITLE
chore: remove .vscode/

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,0 @@
-{
-  "recommendations": ["jnoortheen.nix-ide"]
-}


### PR DESCRIPTION
The single tracked file (extensions.json) only recommended jnoortheen.nix-ide. Nix-ness is discoverable from the flake itself and the recommendation is editor-specific.

Closes #131.