### PR TITLE
feat: soften autopublish secrets requirements

### DIFF
--- a/.github/workflows/rainix-autopublish.yaml
+++ b/.github/workflows/rainix-autopublish.yaml
@@ -45,7 +45,6 @@ jobs:
           # falls back to GITHUB_TOKEN over HTTPS — pushes still succeed,
           # they just won't trigger tag-listening workflows.
           ssh-key: ${{ secrets.PUBLISH_PRIVATE_KEY }}
-          fetch-depth: 0
       - uses: nixbuild/nix-quick-install-action@v30
         with:
           nix_conf: |

--- a/.github/workflows/rainix-autopublish.yaml
+++ b/.github/workflows/rainix-autopublish.yaml
@@ -18,11 +18,11 @@ on:
         default: ''
     secrets:
       PUBLISH_PRIVATE_KEY:
-        required: true
+        required: false
       CI_GIT_EMAIL:
-        required: true
+        required: false
       CI_GIT_USER:
-        required: true
+        required: false
       CARGO_REGISTRY_TOKEN:
         required: true
       NPM_PUBLISH_PRIVATE_TOKEN:
@@ -39,6 +39,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          # PUBLISH_PRIVATE_KEY is a deploy key whose push events trigger
+          # downstream workflows (unlike GITHUB_TOKEN pushes which don't).
+          # If the consumer hasn't set it, ssh-key is empty and checkout
+          # falls back to GITHUB_TOKEN over HTTPS — pushes still succeed,
+          # they just won't trigger tag-listening workflows.
           ssh-key: ${{ secrets.PUBLISH_PRIVATE_KEY }}
           fetch-depth: 0
       - uses: nixbuild/nix-quick-install-action@v30
@@ -56,8 +61,8 @@ jobs:
         run: nix develop github:rainlanguage/rainix#rust-shell -c cargo test -p ${{ inputs.crate }}
       - name: Git config
         run: |
-          git config --global user.email "${{ secrets.CI_GIT_EMAIL }}"
-          git config --global user.name "${{ secrets.CI_GIT_USER }}"
+          git config --global user.email "${{ secrets.CI_GIT_EMAIL || 'github-actions[bot]@users.noreply.github.com' }}"
+          git config --global user.name "${{ secrets.CI_GIT_USER || 'github-actions[bot]' }}"
       # Detect cargo changes.
       - name: Cargo hashes
         id: cargo


### PR DESCRIPTION
Makes PUBLISH_PRIVATE_KEY, CI_GIT_EMAIL, CI_GIT_USER optional in rainix-autopublish so consumers without those secrets can still adopt the reusable.

- ssh-key in actions/checkout: empty string falls back to GITHUB_TOKEN over HTTPS. Pushes still work; only downside is tag-push events don't trigger downstream workflows (only matters if the consumer has tag-listening workflows like float's publish-soldeer.yaml).
- git config user.email/user.name fall back to the github-actions[bot] identity.

CARGO_REGISTRY_TOKEN stays required (no anonymous cargo publish). NPM_PUBLISH_PRIVATE_TOKEN and SOLDEER_API_TOKEN remain optional and only consulted when their feature is enabled.

Unblocks rain.erc autopublish (it has no PUBLISH_PRIVATE_KEY configured).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved robustness of the autopublish workflow by making git configuration inputs optional with sensible fallback values, ensuring the publishing process continues reliably even when custom git credentials are not specified.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rainlanguage/rainix/pull/181?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->