### PR TITLE
feat: add jq to sol-shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -64,6 +64,10 @@
           pkgs.slither-analyzer
           pkgs.solc_0_8_25
           pkgs.reuse
+          # jq is the canonical tool for extracting stable subsets of
+          # forge build artifacts via `vm.ffi` in CopyArtifacts.sol-style
+          # scripts.
+          pkgs.jq
         ];
 
         node-build-inputs = [

--- a/flake.nix
+++ b/flake.nix
@@ -336,6 +336,7 @@
             bats test/bats/devshell/sol-shell/solc.test.bats
             bats test/bats/devshell/sol-shell/reuse.test.bats
             bats test/bats/devshell/sol-shell/gh.test.bats
+            bats test/bats/devshell/sol-shell/jq.test.bats
             bats test/bats/devshell/sol-shell/sol-tasks.test.bats
             bats test/bats/devshell/sol-shell/slim.test.bats
             bats test/bats/devshell/sol-shell/closure.test.bats

--- a/test/bats/devshell/sol-shell/jq.test.bats
+++ b/test/bats/devshell/sol-shell/jq.test.bats
@@ -1,0 +1,4 @@
+@test "jq should be available on PATH" {
+  run jq --version
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Adds pkgs.jq to sol-build-inputs so sol-shell has the canonical tool for extracting stable subsets of forge build artifacts via vm.ffi (the CopyArtifacts.sol pattern that float uses to commit a deterministic abi subset for downstream rust crates). Currently rain.metadata's CopyArtifacts.sol fails in sol-shell with 'No such file or directory' because jq isn't on PATH there.