### PR TITLE
fix(autopublish): rebase before push so chained release jobs don't race

### DIFF
--- a/.github/workflows/rainix-autopublish.yaml
+++ b/.github/workflows/rainix-autopublish.yaml
@@ -119,9 +119,24 @@ jobs:
           git commit -m "Package Release npm-${NEW}"
       # Tag + push everything in one shot. Tags only created for items
       # that actually changed.
+      #
+      # A repo with several crates wires multiple callers of this workflow
+      # chained via `needs:`. Each job checks out main at the workflow-trigger
+      # sha, so once an earlier job pushes its version-bump commit, a later
+      # job's push is non-fast-forward. Because the jobs are sequential, a
+      # fetch + rebase of our bump onto the latest main lands cleanly. The
+      # only file both bumps touch is the shared Cargo.lock; regenerate it
+      # deterministically if the rebase conflicts. Tags are created after the
+      # rebase so they point at the final commit shas.
       - name: Tag and push
         if: ${{ steps.cargo.outputs.changed == 'true' || steps.npm.outputs.changed == 'true' || steps.soldeer.outputs.changed == 'true' }}
         run: |
+          git fetch origin
+          if ! git rebase "origin/${{ github.ref_name }}"; then
+            nix develop github:rainlanguage/rainix#rust-shell -c cargo generate-lockfile
+            git add Cargo.lock
+            GIT_EDITOR=true git rebase --continue
+          fi
           if [ -n "${{ env.CARGO_VERSION }}" ]; then git tag crate-${{ env.CARGO_VERSION }}; fi
           if [ -n "${{ env.NPM_VERSION }}" ]; then git tag npm-${{ env.NPM_VERSION }}; fi
           if [ "${{ steps.soldeer.outputs.changed }}" = "true" ]; then git tag sol-v${{ steps.soldeer.outputs.local }}; fi


### PR DESCRIPTION
Repos with multiple crates wire several `rainix-autopublish` callers chained via `needs:` (e.g. rain.metadata's `bindings` → `metaboard`). Each job checks out `main` at the workflow-trigger sha, so once an earlier job pushes its version-bump commit, the next job's `git push` is rejected non-fast-forward.

Observed in [rain.metadata#120](https://github.com/rainlanguage/rain.metadata/issues/120): `rain-metadata-bindings` published but `rain-metaboard-subgraph` failed at the push step every time.

Since the jobs are **sequential** (`needs:`), the fix is to fetch + rebase our bump onto the latest `main` before tagging/pushing. The only file both bumps touch is the shared `Cargo.lock`; if that's the sole conflict, regenerate it deterministically and continue. Tags are created after the rebase so they point at the final commit shas.

Closes rainlanguage/rain.metadata#120 (once consumers pick up `@main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**No user-facing changes.** This release contains internal workflow infrastructure updates to improve build reliability and consistency. These changes are not visible to end-users and do not affect product functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rainlanguage/rainix/pull/184?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->