### PR TITLE
fix(autopublish): send crates.io User-Agent (workaround for change-detection churn)

### DIFF
--- a/.github/workflows/rainix-autopublish.yaml
+++ b/.github/workflows/rainix-autopublish.yaml
@@ -96,13 +96,31 @@ jobs:
           LOCAL_CRATE=$(ls -t target/package/"$CRATE"-*.crate | head -1)
           NEW=$(norm_hash "$LOCAL_CRATE")
 
-          OLD_VERSION=$(curl -fsSL "https://crates.io/api/v1/crates/$CRATE" | python3 -c "import sys, json; print(json.load(sys.stdin)['crate']['max_version'])" 2>/dev/null || echo "none")
+          # crates.io requires a descriptive User-Agent and returns 403 to
+          # default curl UAs. Without it the lookup silently fell back to
+          # "none", so OLD never matched NEW and the crate re-bumped on every
+          # run. Send a UA, and distinguish a real 404 (never published) from
+          # other failures so we fail loudly instead of churning versions.
+          UA="rainix-autopublish (+https://github.com/rainlanguage/rainix)"
+          resp=$(curl -sS -H "User-Agent: $UA" -w $'\n%{http_code}' "https://crates.io/api/v1/crates/$CRATE")
+          http=$(printf '%s' "$resp" | tail -n1)
+          body=$(printf '%s' "$resp" | sed '$d')
+          if [ "$http" = "404" ]; then
+            OLD_VERSION="none"
+          elif [ "$http" = "200" ]; then
+            OLD_VERSION=$(printf '%s' "$body" | python3 -c "import sys, json; print(json.load(sys.stdin)['crate']['max_version'])")
+          else
+            echo "crates.io API returned HTTP $http for $CRATE" >&2
+            exit 1
+          fi
+          echo "resolved OLD_VERSION=$OLD_VERSION (http $http)"
           if [ "$OLD_VERSION" = "none" ]; then
             OLD="none"
           else
-            curl -fsSL "https://crates.io/api/v1/crates/$CRATE/$OLD_VERSION/download" -o /tmp/old.crate
+            curl -fsSL -H "User-Agent: $UA" "https://crates.io/api/v1/crates/$CRATE/$OLD_VERSION/download" -o /tmp/old.crate
             OLD=$(norm_hash /tmp/old.crate)
           fi
+          echo "cargo gate: OLD=$OLD NEW=$NEW"
 
           echo "old=$OLD" >> $GITHUB_OUTPUT
           echo "new=$NEW" >> $GITHUB_OUTPUT


### PR DESCRIPTION
crates.io 403s default curl User-Agents, so the change-detection gate's version lookup silently fell back to `OLD_VERSION=none` → `OLD=none` → `changed=true` on **every** run. That's why `rain-metadata-bindings` churned `0.1.0 → 0.1.4` with byte-identical content (the metaboard job's log showed the literal `curl: (22) 403`).

Fix: send a descriptive `User-Agent`, distinguish a real `404` (never published) from other HTTP errors (fail loudly instead of assuming `none`), and echo resolved values to the log.

### Important: this is a workaround, not the full fix
It makes **unchanged** crates correctly no-op. It does **not** fix the deeper issue: when 2+ genuinely-changed interdependent crates publish via chained jobs, each `cargo release` rewrites the shared dependent manifest (`crates/cli/Cargo.toml` pins both bindings and metaboard versions), so rebasing one bump onto the other conflicts there — the `Cargo.lock`-only fallback from #184 can't resolve it. Proper fix = single combined release job per repo. Filing separately.

Pairs with #184/#186.

🤖 Generated with [Claude Code](https://claude.com/claude-code)