### PR TITLE
fix(autopublish): namespace crate tags by crate name

### DIFF
--- a/.github/workflows/rainix-autopublish.yaml
+++ b/.github/workflows/rainix-autopublish.yaml
@@ -185,7 +185,7 @@ jobs:
             git add Cargo.lock
             GIT_EDITOR=true git rebase --continue
           fi
-          if [ -n "${{ env.CARGO_VERSION }}" ]; then git tag crate-${{ env.CARGO_VERSION }}; fi
+          if [ -n "${{ env.CARGO_VERSION }}" ]; then git tag ${{ inputs.crate }}-${{ env.CARGO_VERSION }}; fi
           if [ -n "${{ env.NPM_VERSION }}" ]; then git tag npm-${{ env.NPM_VERSION }}; fi
           if [ "${{ steps.soldeer.outputs.changed }}" = "true" ]; then git tag sol-v${{ steps.soldeer.outputs.local }}; fi
           git push origin HEAD
@@ -219,8 +219,8 @@ jobs:
         if: ${{ steps.cargo.outputs.changed == 'true' }}
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: crate-${{ env.CARGO_VERSION }}
-          name: Cargo Crate Release crate-${{ env.CARGO_VERSION }}
+          tag_name: ${{ inputs.crate }}-${{ env.CARGO_VERSION }}
+          name: Cargo Crate Release ${{ inputs.crate }}-${{ env.CARGO_VERSION }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: GitHub Release (npm)


### PR DESCRIPTION
Tags were `crate-v<version>` (literal "crate"), so in a multi-crate repo two crates bumping to the same version collide. `rain-metadata-bindings` created `crate-v0.1.1..0.1.4`; then `rain-metaboard-subgraph`'s bump to 0.1.1 tried to push `crate-v0.1.1` → rejected (already exists) → the publish step never ran (the reusable tags before publishing). That's why metaboard never landed despite #184/#186/#187.

Tag as `<crate>-v<version>` (e.g. `rain-metaboard-subgraph-v0.1.1`) so each crate has its own tag namespace. Also updates the GitHub release tag/name.

4th multi-crate symptom — the structural fix is still #188 (single combined job), but this unblocks metaboard now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)