### PR TITLE
feat: pin wasm-bindgen-cli to 0.2.122

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,9 @@ All tasks are Nix packages run via `nix run`. From a consuming repo use `..#`
 - Foundry: via foundry.nix
 - Graph CLI: 0.69.2
 - Goldsky CLI: 8.6.6
-- wasm-bindgen-cli: nixpkgs default (0.2.117 as of 2026-05)
+- wasm-bindgen-cli: 0.2.122 (pinned via `buildWasmBindgenCli` in flake.nix; must
+  match the `wasm-bindgen` crate version downstream lockfiles resolve to, or
+  `wasm-bindgen` over the wasm file fails)
 
 ## Architecture
 

--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,23 @@
           ];
         });
 
+        # wasm-bindgen CLI and crate versions must match exactly or
+        # `wasm-bindgen` over the wasm file fails. nixpkgs' default lags behind
+        # what current lockfiles resolve to, so pin the CLI to that version via
+        # the nixpkgs builder (no nixpkgs bump, no other tool churn).
+        wasm-bindgen-cli = pkgs.buildWasmBindgenCli rec {
+          src = pkgs.fetchCrate {
+            pname = "wasm-bindgen-cli";
+            version = "0.2.122";
+            hash = "sha256-vO4RSxi/sMWxmsEs3GuljdMfIRSu75A+Q+c5wgYToRU=";
+          };
+          cargoDeps = pkgs.rustPlatform.fetchCargoVendor {
+            inherit src;
+            inherit (src) pname version;
+            hash = "sha256-Inup6vvJSG5ghNyeDPyZbfZo4d0LsMG2OJfStoaeDBs=";
+          };
+        };
+
         rust-build-inputs = [
           rust-toolchain
           pkgs.cargo-release
@@ -48,7 +65,7 @@
           pkgs.openssl
           pkgs.libusb1
           pkgs.pkg-config
-          pkgs.wasm-bindgen-cli
+          wasm-bindgen-cli
           pkgs.gettext
           pkgs.libiconv
           pkgs.cargo-flamegraph


### PR DESCRIPTION
nixpkgs' default `wasm-bindgen-cli` (0.2.117) lags the `wasm-bindgen` crate version current lockfiles resolve to (0.2.122). The CLI and crate must match **exactly** or `Error: executing wasm-bindgen over the Wasm file` — this broke rain.wasm's `rs-wasm-test` and blocked its `0.1.0` publish.

Pin the CLI to 0.2.122 via nixpkgs' `buildWasmBindgenCli` (fetchCrate + fetchCargoVendor with discovered hashes) — no nixpkgs bump, no other tool-version churn. Verified: `nix develop -c wasm-bindgen --version` → `0.2.122`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)