### PR TITLE
rainix-rs-static: run the pre-commit hook bundle in CI

### DIFF
--- a/.github/workflows/rainix-rs-static.yaml
+++ b/.github/workflows/rainix-rs-static.yaml
@@ -19,3 +19,13 @@ jobs:
           gc-max-store-size-linux: 1G
       - uses: Swatinem/rust-cache@v2
       - run: nix develop github:rainlanguage/rainix#rust-shell -c rainix-rs-static
+      # Run the rainix pre-commit hook bundle (taplo, the nix hooks, yamlfmt,
+      # shellcheck, rustfmt) over all files — the same hooks a local commit
+      # runs. rainix-rs-static only covers rustfmt + clippy, so a file that is
+      # hook-dirty but rustfmt-clean (e.g. a non-canonical Cargo.toml) used to
+      # pass PR CI and only blow up later in the autopublish bump commit. Folded
+      # in as a step (not a separate job) to reuse this job's warm Nix store
+      # rather than re-paying runner setup. Reuses rust-shell, so prettier-rainix
+      # (which needs the default shell's RAINIX_PRETTIER_BUNDLE_DIR) no-ops here;
+      # frontend repos format svelte/ts via their own pipeline.
+      - run: nix develop github:rainlanguage/rainix#rust-shell -c pre-commit run --all-files --show-diff-on-failure --color always


### PR DESCRIPTION
## Why
`rainix-rs-static` only ran `cargo fmt --check` + clippy. taplo (TOML formatting) — and the other hooks (nix, yamlfmt, shellcheck) — ran **only** as a local pre-commit hook, never in CI. So a file that is hook-dirty but rustfmt-clean passed PR CI.

That gap bit the rain.wasm publish: `Cargo.toml`'s `tsify` dependency line exceeded taplo's line width and was never reformatted. PR CI was green. Then cargo-release's version-bump commit in the autopublish job ran the locally-installed hooks, taplo reformatted the file, and the bump step aborted with `files were modified by this hook` — surfacing a formatting defect as a *release* failure.

## What
Run `pre-commit run --all-files` so hook-dirtiness fails the PR instead of the release.

Added as a **step in the existing `rs-static` job**, not a separate job — a separate job re-pays runner spin-up + nix install + the (up to 1 GB) cache restore/save just to run hooks. Folding it in reuses this job's already-warm Nix store and `rust-shell`, so the marginal cost is just the hook run.

It reuses `rust-shell`, so `prettier-rainix` (which needs the default shell's `RAINIX_PRETTIER_BUNDLE_DIR`) no-ops here; frontend repos format svelte/ts via their own pipeline. All other hooks — taplo, nix (nil/nixfmt/deadnix/statix), yamlfmt, shellcheck, rustfmt — run for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration checks to catch formatting and linting issues earlier in the pull request validation process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rainlanguage/rainix/pull/195?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->