### PR TITLE
CI: shared Cachix binary cache (resilience #196)

### DIFF
--- a/.github/workflows/check-shell.yml
+++ b/.github/workflows/check-shell.yml
@@ -16,6 +16,15 @@ jobs:
           nix_conf: |
             keep-env-derivations = true
             keep-outputs = true
+      # Substitute prebuilt rainix derivations from the shared Cachix binary
+      # cache instead of rebuilding toolchain crates from source (rainix#196).
+      # Pushes new paths when CACHIX_AUTH_TOKEN is set; continue-on-error so a
+      # missing cache/token or a Cachix outage degrades to a normal build.
+      - uses: cachix/cachix-action@v15
+        continue-on-error: true
+        with:
+          name: rainlanguage
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Restore and save Nix store
         uses: nix-community/cache-nix-action@v7
         with:

--- a/.github/workflows/publish-soldeer.yaml
+++ b/.github/workflows/publish-soldeer.yaml
@@ -23,6 +23,15 @@ jobs:
           nix_conf: |
             keep-env-derivations = true
             keep-outputs = true
+      # Substitute prebuilt rainix derivations from the shared Cachix binary
+      # cache instead of rebuilding toolchain crates from source (rainix#196).
+      # Pushes new paths when CACHIX_AUTH_TOKEN is set; continue-on-error so a
+      # missing cache/token or a Cachix outage degrades to a normal build.
+      - uses: cachix/cachix-action@v15
+        continue-on-error: true
+        with:
+          name: rainlanguage
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Restore and save Nix store
         uses: nix-community/cache-nix-action@v7
         with:

--- a/.github/workflows/rainix-autopublish.yaml
+++ b/.github/workflows/rainix-autopublish.yaml
@@ -62,6 +62,15 @@ jobs:
           nix_conf: |
             keep-env-derivations = true
             keep-outputs = true
+      # Substitute prebuilt rainix derivations from the shared Cachix binary
+      # cache instead of rebuilding toolchain crates from source (rainix#196).
+      # Pushes new paths when CACHIX_AUTH_TOKEN is set; continue-on-error so a
+      # missing cache/token or a Cachix outage degrades to a normal build.
+      - uses: cachix/cachix-action@v15
+        continue-on-error: true
+        with:
+          name: rainlanguage
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Restore and save Nix store
         uses: nix-community/cache-nix-action@v6
         with:

--- a/.github/workflows/rainix-build-pointers.yaml
+++ b/.github/workflows/rainix-build-pointers.yaml
@@ -11,6 +11,15 @@ jobs:
           nix_conf: |
             keep-env-derivations = true
             keep-outputs = true
+      # Substitute prebuilt rainix derivations from the shared Cachix binary
+      # cache instead of rebuilding toolchain crates from source (rainix#196).
+      # Pushes new paths when CACHIX_AUTH_TOKEN is set; continue-on-error so a
+      # missing cache/token or a Cachix outage degrades to a normal build.
+      - uses: cachix/cachix-action@v15
+        continue-on-error: true
+        with:
+          name: rainlanguage
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Restore and save Nix store
         uses: nix-community/cache-nix-action@v7
         with:

--- a/.github/workflows/rainix-manual-sol-artifacts.yaml
+++ b/.github/workflows/rainix-manual-sol-artifacts.yaml
@@ -18,6 +18,15 @@ jobs:
           nix_conf: |
             keep-env-derivations = true
             keep-outputs = true
+      # Substitute prebuilt rainix derivations from the shared Cachix binary
+      # cache instead of rebuilding toolchain crates from source (rainix#196).
+      # Pushes new paths when CACHIX_AUTH_TOKEN is set; continue-on-error so a
+      # missing cache/token or a Cachix outage degrades to a normal build.
+      - uses: cachix/cachix-action@v15
+        continue-on-error: true
+        with:
+          name: rainlanguage
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Restore and save Nix store
         uses: nix-community/cache-nix-action@v7
         with:

--- a/.github/workflows/rainix-rs-static.yaml
+++ b/.github/workflows/rainix-rs-static.yaml
@@ -11,6 +11,15 @@ jobs:
           nix_conf: |
             keep-env-derivations = true
             keep-outputs = true
+      # Substitute prebuilt rainix derivations from the shared Cachix binary
+      # cache instead of rebuilding toolchain crates from source (rainix#196).
+      # Pushes new paths when CACHIX_AUTH_TOKEN is set; continue-on-error so a
+      # missing cache/token or a Cachix outage degrades to a normal build.
+      - uses: cachix/cachix-action@v15
+        continue-on-error: true
+        with:
+          name: rainlanguage
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Restore and save Nix store
         uses: nix-community/cache-nix-action@v7
         with:

--- a/.github/workflows/rainix-rs-test.yaml
+++ b/.github/workflows/rainix-rs-test.yaml
@@ -15,6 +15,15 @@ jobs:
           nix_conf: |
             keep-env-derivations = true
             keep-outputs = true
+      # Substitute prebuilt rainix derivations from the shared Cachix binary
+      # cache instead of rebuilding toolchain crates from source (rainix#196).
+      # Pushes new paths when CACHIX_AUTH_TOKEN is set; continue-on-error so a
+      # missing cache/token or a Cachix outage degrades to a normal build.
+      - uses: cachix/cachix-action@v15
+        continue-on-error: true
+        with:
+          name: rainlanguage
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Restore and save Nix store
         uses: nix-community/cache-nix-action@v7
         with:

--- a/.github/workflows/rainix-rs-wasm-test.yaml
+++ b/.github/workflows/rainix-rs-wasm-test.yaml
@@ -11,6 +11,15 @@ jobs:
           nix_conf: |
             keep-env-derivations = true
             keep-outputs = true
+      # Substitute prebuilt rainix derivations from the shared Cachix binary
+      # cache instead of rebuilding toolchain crates from source (rainix#196).
+      # Pushes new paths when CACHIX_AUTH_TOKEN is set; continue-on-error so a
+      # missing cache/token or a Cachix outage degrades to a normal build.
+      - uses: cachix/cachix-action@v15
+        continue-on-error: true
+        with:
+          name: rainlanguage
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Restore and save Nix store
         uses: nix-community/cache-nix-action@v7
         with:

--- a/.github/workflows/rainix-rs-wasm.yaml
+++ b/.github/workflows/rainix-rs-wasm.yaml
@@ -11,6 +11,15 @@ jobs:
           nix_conf: |
             keep-env-derivations = true
             keep-outputs = true
+      # Substitute prebuilt rainix derivations from the shared Cachix binary
+      # cache instead of rebuilding toolchain crates from source (rainix#196).
+      # Pushes new paths when CACHIX_AUTH_TOKEN is set; continue-on-error so a
+      # missing cache/token or a Cachix outage degrades to a normal build.
+      - uses: cachix/cachix-action@v15
+        continue-on-error: true
+        with:
+          name: rainlanguage
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Restore and save Nix store
         uses: nix-community/cache-nix-action@v7
         with:

--- a/.github/workflows/rainix-sol-legal.yaml
+++ b/.github/workflows/rainix-sol-legal.yaml
@@ -11,6 +11,15 @@ jobs:
           nix_conf: |
             keep-env-derivations = true
             keep-outputs = true
+      # Substitute prebuilt rainix derivations from the shared Cachix binary
+      # cache instead of rebuilding toolchain crates from source (rainix#196).
+      # Pushes new paths when CACHIX_AUTH_TOKEN is set; continue-on-error so a
+      # missing cache/token or a Cachix outage degrades to a normal build.
+      - uses: cachix/cachix-action@v15
+        continue-on-error: true
+        with:
+          name: rainlanguage
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Restore and save Nix store
         uses: nix-community/cache-nix-action@v7
         with:

--- a/.github/workflows/rainix-sol-static.yaml
+++ b/.github/workflows/rainix-sol-static.yaml
@@ -11,6 +11,15 @@ jobs:
           nix_conf: |
             keep-env-derivations = true
             keep-outputs = true
+      # Substitute prebuilt rainix derivations from the shared Cachix binary
+      # cache instead of rebuilding toolchain crates from source (rainix#196).
+      # Pushes new paths when CACHIX_AUTH_TOKEN is set; continue-on-error so a
+      # missing cache/token or a Cachix outage degrades to a normal build.
+      - uses: cachix/cachix-action@v15
+        continue-on-error: true
+        with:
+          name: rainlanguage
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Restore and save Nix store
         uses: nix-community/cache-nix-action@v7
         with:

--- a/.github/workflows/rainix-sol-test.yaml
+++ b/.github/workflows/rainix-sol-test.yaml
@@ -40,6 +40,15 @@ jobs:
           nix_conf: |
             keep-env-derivations = true
             keep-outputs = true
+      # Substitute prebuilt rainix derivations from the shared Cachix binary
+      # cache instead of rebuilding toolchain crates from source (rainix#196).
+      # Pushes new paths when CACHIX_AUTH_TOKEN is set; continue-on-error so a
+      # missing cache/token or a Cachix outage degrades to a normal build.
+      - uses: cachix/cachix-action@v15
+        continue-on-error: true
+        with:
+          name: rainlanguage
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Restore and save Nix store
         uses: nix-community/cache-nix-action@v7
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,15 @@ jobs:
           nix_conf: |
             keep-env-derivations = true
             keep-outputs = true
+      # Substitute prebuilt rainix derivations from the shared Cachix binary
+      # cache instead of rebuilding toolchain crates from source (rainix#196).
+      # Pushes new paths when CACHIX_AUTH_TOKEN is set; continue-on-error so a
+      # missing cache/token or a Cachix outage degrades to a normal build.
+      - uses: cachix/cachix-action@v15
+        continue-on-error: true
+        with:
+          name: rainlanguage
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Restore and save Nix store
         uses: nix-community/cache-nix-action@v7
         with:


### PR DESCRIPTION
Implements #196 (resilience option #2 from the crates.io 403 incident).

## What
Adds `cachix/cachix-action@v15` to every nix-building workflow (13 files: `test.yml`, `check-shell`, `publish-soldeer`, and the `rainix-rs-*` / `rainix-sol-*` / `rainix-build-pointers` / `rainix-autopublish` reusables). Builds **substitute** prebuilt rainix derivations (rust/sol toolchain, `wasm-bindgen-cli`, …) from a shared Cachix cache instead of rebuilding toolchain crates from source — decoupling nix builds from crates.io download availability (the failure that broke CI org-wide today).

cachix-action also **pushes** newly-built paths when `CACHIX_AUTH_TOKEN` is set, so rainix's own CI populates the cache and downstream consumers (which call these reusable workflows with `secrets: inherit`) read from it.

## Graceful degradation
`continue-on-error: true` on the step: until the cache + token exist (or during a Cachix outage) it no-ops and the build proceeds normally from source. So this is safe to merge before the cache is set up.

## Manual setup (tracked in #196 — not blocking this PR)
- Create the `rainlanguage` Cachix cache (public)
- Add the `CACHIX_AUTH_TOKEN` org secret (write token)

Once those exist, pushes/substitution activate automatically — no further code change. (cachix-action auto-configures the substituter + public key for the named cache, so no key is hardcoded.)

## Related
- #197 — CI store-cache retention (complementary)
- #198 — static.crates.io fetch fix (the immediate unblock for today's 403)

🤖 Generated with [Claude Code](https://claude.com/claude-code)