### PR TITLE
Add reusable rainix-copy-artifacts workflow (no prelude)

### DIFF
--- a/.github/workflows/rainix-copy-artifacts.yaml
+++ b/.github/workflows/rainix-copy-artifacts.yaml
@@ -1,0 +1,62 @@
+name: rainix-copy-artifacts
+on:
+  workflow_call:
+jobs:
+  copy-artifacts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: nixbuild/nix-quick-install-action@v30
+        with:
+          nix_conf: |
+            keep-env-derivations = true
+            keep-outputs = true
+      # Substitute prebuilt derivations from the shared Cachix cache so the
+      # toolchain + any prelude build don't refetch crates from crates.io (whose
+      # download endpoint 403s nix's User-Agent). Pushes new paths when
+      # CACHIX_AUTH_TOKEN is set; continue-on-error degrades gracefully.
+      - uses: cachix/cachix-action@v15
+        continue-on-error: true
+        with:
+          name: rainlanguage
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 8G
+      - name: Install soldeer dependencies
+        if: hashFiles('soldeer.lock') != ''
+        run: nix develop github:rainlanguage/rainix#sol-shell -c forge soldeer install
+      # Regenerate generated inputs (e.g. CBOR meta) before building, by
+      # convention: a consumer whose artifacts depend on a pre-build step
+      # exposes a `prelude` flake app/package. Run it only if defined, so repos
+      # without one skip cleanly and a real prelude failure still surfaces.
+      - name: Prelude
+        run: |
+          set -euo pipefail
+          sys=$(nix eval --impure --raw --expr 'builtins.currentSystem')
+          if nix eval --impure --expr \
+            "let f = builtins.getFlake (toString ./.); in ((f.apps.\"$sys\" or {}) ? prelude) || ((f.packages.\"$sys\" or {}) ? prelude)" \
+            2>/dev/null | grep -qx true; then
+            nix run .#prelude
+          else
+            echo "no .#prelude in this flake; skipping"
+          fi
+      - name: Regenerate pointer artifacts
+        if: hashFiles('script/BuildPointers.sol') != ''
+        run: nix develop github:rainlanguage/rainix#sol-shell -c forge script ./script/BuildPointers.sol
+      - name: Build Solidity
+        run: nix develop github:rainlanguage/rainix#sol-shell -c forge build
+      - name: Copy forge artifacts into committed location
+        if: hashFiles('script/CopyArtifacts.sol') != ''
+        run: nix develop github:rainlanguage/rainix#sol-shell -c forge script ./script/CopyArtifacts.sol --ffi
+      - name: Format (so generated artifacts match committed style)
+        run: nix develop github:rainlanguage/rainix#sol-shell -c forge fmt
+      - name: Assert committed artifacts match freshly built
+        run: |
+          if ! git diff --exit-code; then
+            echo "::error::Committed meta/pointer/abi artifacts are stale. Regenerate (.#prelude, BuildPointers.sol, CopyArtifacts.sol, forge fmt) and commit."
+            exit 1
+          fi

--- a/.github/workflows/rainix-copy-artifacts.yaml
+++ b/.github/workflows/rainix-copy-artifacts.yaml
@@ -29,21 +29,10 @@ jobs:
       - name: Install soldeer dependencies
         if: hashFiles('soldeer.lock') != ''
         run: nix develop github:rainlanguage/rainix#sol-shell -c forge soldeer install
-      # Regenerate generated inputs (e.g. CBOR meta) before building, by
-      # convention: a consumer whose artifacts depend on a pre-build step
-      # exposes a `prelude` flake app/package. Run it only if defined, so repos
-      # without one skip cleanly and a real prelude failure still surfaces.
-      - name: Prelude
-        run: |
-          set -euo pipefail
-          sys=$(nix eval --impure --raw --expr 'builtins.currentSystem')
-          if nix eval --impure --expr \
-            "let f = builtins.getFlake (toString ./.); in ((f.apps.\"$sys\" or {}) ? prelude) || ((f.packages.\"$sys\" or {}) ? prelude)" \
-            2>/dev/null | grep -qx true; then
-            nix run .#prelude
-          else
-            echo "no .#prelude in this flake; skipping"
-          fi
+      # No prelude/codegen step on purpose: committing the generated artifacts
+      # (meta, pointers, abi) is exactly what lets consumers build without a
+      # prelude. This job rebuilds from the committed sources and asserts the
+      # committed artifacts still match — it does not regenerate meta inputs.
       - name: Regenerate pointer artifacts
         if: hashFiles('script/BuildPointers.sol') != ''
         run: nix develop github:rainlanguage/rainix#sol-shell -c forge script ./script/BuildPointers.sol

--- a/.github/workflows/rainix-copy-artifacts.yaml
+++ b/.github/workflows/rainix-copy-artifacts.yaml
@@ -20,6 +20,9 @@ jobs:
         with:
           name: rainlanguage
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          # No store-watching daemon: it checkpoints the nix DB concurrently
+          # with cache-nix-action and corrupts it. Push happens in the post step.
+          useDaemon: false
       - name: Restore and save Nix store
         uses: nix-community/cache-nix-action@v7
         with:


### PR DESCRIPTION
A shared reusable for the *regenerate-from-committed-sources and assert-clean* artifact check that rainlang, rain.math.float, and rain.metadata each duplicate. Centralizes the boilerplate + the resilience fixes (Cachix substitution, 8G GC cap) + the clean-build determinism gate.

**No prelude/codegen step — by design.** Committing the generated artifacts (meta, pointers, abi) is the whole point of copy-artifacts: it removes the need to run a prelude in CI. This job rebuilds from the committed sources and asserts the committed artifacts still match; it does not regenerate meta inputs.

**No inputs** — repo-specific steps are guarded by `hashFiles`:
- `forge soldeer install` if `soldeer.lock` exists
- `forge script ./script/BuildPointers.sol` if it exists
- `forge script ./script/CopyArtifacts.sol --ffi` if it exists
- always: `forge build`, `forge fmt`, then `git diff --exit-code`

Consumers replace their entire `copy-artifacts.yaml` with:
```yaml
jobs:
  copy-artifacts:
    uses: rainlanguage/rainix/.github/workflows/rainix-copy-artifacts.yaml@main
    secrets: inherit
```
(reusable runs in the caller's checkout, so `./script/*.sol` resolve to the consumer's; `secrets: inherit` carries `CACHIX_AUTH_TOKEN`).

Rollout: rainlang first (folded into its copy-artifacts fix), then rain.math.float / rain.metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)