### PR TITLE
Fix CI: cachix-action useDaemon:false (nix DB corruption)

### DIFF
--- a/.github/workflows/check-shell.yml
+++ b/.github/workflows/check-shell.yml
@@ -25,6 +25,10 @@ jobs:
         with:
           name: rainlanguage
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          # No store-watching daemon: it checkpoints the nix DB
+          # concurrently with cache-nix-action and corrupts it ("database
+          # disk image is malformed"). Push happens once in the post step.
+          useDaemon: false
       - name: Restore and save Nix store
         uses: nix-community/cache-nix-action@v7
         with:

--- a/.github/workflows/publish-soldeer.yaml
+++ b/.github/workflows/publish-soldeer.yaml
@@ -32,6 +32,10 @@ jobs:
         with:
           name: rainlanguage
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          # No store-watching daemon: it checkpoints the nix DB
+          # concurrently with cache-nix-action and corrupts it ("database
+          # disk image is malformed"). Push happens once in the post step.
+          useDaemon: false
       - name: Restore and save Nix store
         uses: nix-community/cache-nix-action@v7
         with:

--- a/.github/workflows/rainix-autopublish.yaml
+++ b/.github/workflows/rainix-autopublish.yaml
@@ -71,6 +71,10 @@ jobs:
         with:
           name: rainlanguage
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          # No store-watching daemon: it checkpoints the nix DB
+          # concurrently with cache-nix-action and corrupts it ("database
+          # disk image is malformed"). Push happens once in the post step.
+          useDaemon: false
       - name: Restore and save Nix store
         uses: nix-community/cache-nix-action@v6
         with:

--- a/.github/workflows/rainix-build-pointers.yaml
+++ b/.github/workflows/rainix-build-pointers.yaml
@@ -20,6 +20,10 @@ jobs:
         with:
           name: rainlanguage
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          # No store-watching daemon: it checkpoints the nix DB
+          # concurrently with cache-nix-action and corrupts it ("database
+          # disk image is malformed"). Push happens once in the post step.
+          useDaemon: false
       - name: Restore and save Nix store
         uses: nix-community/cache-nix-action@v7
         with:

--- a/.github/workflows/rainix-manual-sol-artifacts.yaml
+++ b/.github/workflows/rainix-manual-sol-artifacts.yaml
@@ -27,6 +27,10 @@ jobs:
         with:
           name: rainlanguage
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          # No store-watching daemon: it checkpoints the nix DB
+          # concurrently with cache-nix-action and corrupts it ("database
+          # disk image is malformed"). Push happens once in the post step.
+          useDaemon: false
       - name: Restore and save Nix store
         uses: nix-community/cache-nix-action@v7
         with:

--- a/.github/workflows/rainix-rs-static.yaml
+++ b/.github/workflows/rainix-rs-static.yaml
@@ -20,6 +20,10 @@ jobs:
         with:
           name: rainlanguage
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          # No store-watching daemon: it checkpoints the nix DB
+          # concurrently with cache-nix-action and corrupts it ("database
+          # disk image is malformed"). Push happens once in the post step.
+          useDaemon: false
       - name: Restore and save Nix store
         uses: nix-community/cache-nix-action@v7
         with:

--- a/.github/workflows/rainix-rs-test.yaml
+++ b/.github/workflows/rainix-rs-test.yaml
@@ -24,6 +24,10 @@ jobs:
         with:
           name: rainlanguage
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          # No store-watching daemon: it checkpoints the nix DB
+          # concurrently with cache-nix-action and corrupts it ("database
+          # disk image is malformed"). Push happens once in the post step.
+          useDaemon: false
       - name: Restore and save Nix store
         uses: nix-community/cache-nix-action@v7
         with:

--- a/.github/workflows/rainix-rs-wasm-test.yaml
+++ b/.github/workflows/rainix-rs-wasm-test.yaml
@@ -20,6 +20,10 @@ jobs:
         with:
           name: rainlanguage
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          # No store-watching daemon: it checkpoints the nix DB
+          # concurrently with cache-nix-action and corrupts it ("database
+          # disk image is malformed"). Push happens once in the post step.
+          useDaemon: false
       - name: Restore and save Nix store
         uses: nix-community/cache-nix-action@v7
         with:

--- a/.github/workflows/rainix-rs-wasm.yaml
+++ b/.github/workflows/rainix-rs-wasm.yaml
@@ -20,6 +20,10 @@ jobs:
         with:
           name: rainlanguage
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          # No store-watching daemon: it checkpoints the nix DB
+          # concurrently with cache-nix-action and corrupts it ("database
+          # disk image is malformed"). Push happens once in the post step.
+          useDaemon: false
       - name: Restore and save Nix store
         uses: nix-community/cache-nix-action@v7
         with:

--- a/.github/workflows/rainix-sol-legal.yaml
+++ b/.github/workflows/rainix-sol-legal.yaml
@@ -20,6 +20,10 @@ jobs:
         with:
           name: rainlanguage
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          # No store-watching daemon: it checkpoints the nix DB
+          # concurrently with cache-nix-action and corrupts it ("database
+          # disk image is malformed"). Push happens once in the post step.
+          useDaemon: false
       - name: Restore and save Nix store
         uses: nix-community/cache-nix-action@v7
         with:

--- a/.github/workflows/rainix-sol-static.yaml
+++ b/.github/workflows/rainix-sol-static.yaml
@@ -20,6 +20,10 @@ jobs:
         with:
           name: rainlanguage
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          # No store-watching daemon: it checkpoints the nix DB
+          # concurrently with cache-nix-action and corrupts it ("database
+          # disk image is malformed"). Push happens once in the post step.
+          useDaemon: false
       - name: Restore and save Nix store
         uses: nix-community/cache-nix-action@v7
         with:

--- a/.github/workflows/rainix-sol-test.yaml
+++ b/.github/workflows/rainix-sol-test.yaml
@@ -49,6 +49,10 @@ jobs:
         with:
           name: rainlanguage
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          # No store-watching daemon: it checkpoints the nix DB
+          # concurrently with cache-nix-action and corrupts it ("database
+          # disk image is malformed"). Push happens once in the post step.
+          useDaemon: false
       - name: Restore and save Nix store
         uses: nix-community/cache-nix-action@v7
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,10 @@ jobs:
         with:
           name: rainlanguage
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          # No store-watching daemon: it checkpoints the nix DB
+          # concurrently with cache-nix-action and corrupts it ("database
+          # disk image is malformed"). Push happens once in the post step.
+          useDaemon: false
       - name: Restore and save Nix store
         uses: nix-community/cache-nix-action@v7
         with:


### PR DESCRIPTION
**Incident fix.** #199 added `cachix-action` with its default store-watching daemon, which checkpoints the nix SQLite DB concurrently with `cache-nix-action` — **every job on every OS** failed with `database disk image is malformed (11)`, red-ing rainix main and the reusable workflows (so consumer CI too).

`useDaemon: false` drops the daemon; cachix pushes new store paths once in the post step instead, with no concurrent DB access. Preserves the binary-cache substitution + push, fixes the corruption.

Applied to all 13 cachix-action steps. Validating on this branch (the cache step must pass) before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)