### PR TITLE
CI: namespace Foundry cache keys by mode (fix #203 cross-restore)

### DIFF
--- a/.github/workflows/rainix-copy-artifacts.yaml
+++ b/.github/workflows/rainix-copy-artifacts.yaml
@@ -36,9 +36,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: cache
-          key: foundry-${{ runner.os }}-${{ hashFiles('src/**/*.sol', 'test/**/*.sol', 'script/**/*.sol', 'foundry.toml', 'soldeer.lock', 'remappings.txt') }}
+          key: foundry-co-${{ runner.os }}-${{ hashFiles('src/**/*.sol', 'test/**/*.sol', 'script/**/*.sol', 'foundry.toml', 'soldeer.lock', 'remappings.txt') }}
           restore-keys: |
-            foundry-${{ runner.os }}-
+            foundry-co-${{ runner.os }}-
       - name: Install soldeer dependencies
         if: hashFiles('soldeer.lock') != ''
         run: nix develop github:rainlanguage/rainix#sol-shell -c forge soldeer install

--- a/.github/workflows/rainix-manual-sol-artifacts.yaml
+++ b/.github/workflows/rainix-manual-sol-artifacts.yaml
@@ -45,9 +45,9 @@ jobs:
           path: |
             cache
             out
-          key: foundry-${{ runner.os }}-${{ hashFiles('src/**/*.sol', 'test/**/*.sol', 'script/**/*.sol', 'foundry.toml', 'soldeer.lock', 'remappings.txt') }}
+          key: foundry-full-${{ runner.os }}-${{ hashFiles('src/**/*.sol', 'test/**/*.sol', 'script/**/*.sol', 'foundry.toml', 'soldeer.lock', 'remappings.txt') }}
           restore-keys: |
-            foundry-${{ runner.os }}-
+            foundry-full-${{ runner.os }}-
       - name: Install soldeer dependencies
         if: hashFiles('soldeer.lock') != ''
         run: nix develop github:rainlanguage/rainix#sol-shell -c forge soldeer install

--- a/.github/workflows/rainix-sol-static.yaml
+++ b/.github/workflows/rainix-sol-static.yaml
@@ -38,9 +38,9 @@ jobs:
           path: |
             cache
             out
-          key: foundry-${{ runner.os }}-${{ hashFiles('src/**/*.sol', 'test/**/*.sol', 'script/**/*.sol', 'foundry.toml', 'soldeer.lock', 'remappings.txt') }}
+          key: foundry-full-${{ runner.os }}-${{ hashFiles('src/**/*.sol', 'test/**/*.sol', 'script/**/*.sol', 'foundry.toml', 'soldeer.lock', 'remappings.txt') }}
           restore-keys: |
-            foundry-${{ runner.os }}-
+            foundry-full-${{ runner.os }}-
       - name: Install soldeer dependencies
         if: hashFiles('soldeer.lock') != ''
         run: nix develop github:rainlanguage/rainix#sol-shell -c forge soldeer install

--- a/.github/workflows/rainix-sol-test.yaml
+++ b/.github/workflows/rainix-sol-test.yaml
@@ -67,9 +67,9 @@ jobs:
           path: |
             cache
             out
-          key: foundry-${{ runner.os }}-${{ hashFiles('src/**/*.sol', 'test/**/*.sol', 'script/**/*.sol', 'foundry.toml', 'soldeer.lock', 'remappings.txt') }}
+          key: foundry-full-${{ runner.os }}-${{ hashFiles('src/**/*.sol', 'test/**/*.sol', 'script/**/*.sol', 'foundry.toml', 'soldeer.lock', 'remappings.txt') }}
           restore-keys: |
-            foundry-${{ runner.os }}-
+            foundry-full-${{ runner.os }}-
       - name: Install soldeer dependencies
         if: hashFiles('soldeer.lock') != ''
         run: nix develop github:rainlanguage/rainix#sol-shell -c forge soldeer install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,9 +62,9 @@ jobs:
           path: |
             cache
             out
-          key: foundry-${{ runner.os }}-${{ hashFiles('src/**/*.sol', 'test/**/*.sol', 'script/**/*.sol', 'foundry.toml', 'soldeer.lock', 'remappings.txt') }}
+          key: foundry-full-${{ runner.os }}-${{ hashFiles('src/**/*.sol', 'test/**/*.sol', 'script/**/*.sol', 'foundry.toml', 'soldeer.lock', 'remappings.txt') }}
           restore-keys: |
-            foundry-${{ runner.os }}-
+            foundry-full-${{ runner.os }}-
       - run: nix develop ../.. --command forge soldeer install
       - name: Run ${{ matrix.task }}
         env:


### PR DESCRIPTION
Follow-up review of #203 caught a real bug CI didn't: all sol workflows shared one cache `key` + `restore-keys` prefix (`foundry-${{ runner.os }}-`). GitHub's cache archive reflects the **saver's** `path` set, and a matching-key restorer extracts that archive regardless of its own `path` — so the **cache-only** (determinism: copy-artifacts) and **cache+out** (build/test) groups cross-restore:
- cache-only could restore a stale `out/` (undermines the fresh-build intent — though forge build reconciles, so the assert stays valid)
- cache+out could restore an entry missing `out/` (silently loses the speedup)

Split into distinct namespaces so the groups never share an entry:
- `rainix-copy-artifacts` → `foundry-co-${{ runner.os }}-…`
- `rainix-sol-test` / `-sol-static` / `-manual-sol-artifacts` / `test.yml` → `foundry-full-${{ runner.os }}-…`

`rainix-build-pointers` is intentionally left on the old prefix — #204 retires it, and it's now alone in that namespace (no collision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)