### PR TITLE
copy-artifacts: drop the Foundry build cache (no-op for a clean-build check)

### DIFF
--- a/.github/workflows/rainix-copy-artifacts.yaml
+++ b/.github/workflows/rainix-copy-artifacts.yaml
@@ -29,16 +29,11 @@ jobs:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
           gc-max-store-size-linux: 8G
-      # Cache Foundry's incremental compilation cache only (NOT out/): out/ is
-      # regenerated fresh each run so the committed-artifact assert stays a true
-      # clean-build check, while cache/ still speeds recompilation.
-      - name: Cache Foundry build
-        uses: actions/cache@v4
-        with:
-          path: cache
-          key: foundry-co-${{ runner.os }}-${{ hashFiles('src/**/*.sol', 'test/**/*.sol', 'script/**/*.sol', 'foundry.toml', 'soldeer.lock', 'remappings.txt') }}
-          restore-keys: |
-            foundry-co-${{ runner.os }}-
+      # No Foundry build cache here on purpose: this is a clean-build determinism
+      # check, so out/ must be regenerated fresh — and caching only cache/ (not
+      # out/) gives no real speedup, since forge recompiles to rebuild the
+      # missing out/ artifacts anyway. The cache+out workflows (sol-test etc.)
+      # keep the cache; copy-artifacts skips the save/restore overhead.
       - name: Install soldeer dependencies
         if: hashFiles('soldeer.lock') != ''
         run: nix develop github:rainlanguage/rainix#sol-shell -c forge soldeer install


### PR DESCRIPTION
copy-artifacts caches `cache/` only (not `out/`) to keep its determinism assert honest. But forge needs `out/` artifacts present to skip compilation — with `out/` absent it recompiles to regenerate them, so `cache/` alone yields no real speedup (measured: `Build Solidity` stayed ~105s). The `actions/cache` save/restore was therefore pure overhead.

Remove it — copy-artifacts is now a clean determinism check with no Foundry cache. The `cache+out` workflows (sol-test, sol-static, manual-sol-artifacts, rainix test.yml) keep the cache, where it genuinely skips recompilation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)