### PR TITLE
copy-artifacts: regenerate meta via consumer-provided build-meta.sh hook

### DIFF
--- a/.github/workflows/rainix-copy-artifacts.yaml
+++ b/.github/workflows/rainix-copy-artifacts.yaml
@@ -37,10 +37,14 @@ jobs:
       - name: Install soldeer dependencies
         if: hashFiles('soldeer.lock') != ''
         run: nix develop github:rainlanguage/rainix#sol-shell -c forge soldeer install
-      # No prelude/codegen step on purpose: committing the generated artifacts
-      # (meta, pointers, abi) is exactly what lets consumers build without a
-      # prelude. This job rebuilds from the committed sources and asserts the
-      # committed artifacts still match — it does not regenerate meta inputs.
+      # Currency-check every committed generated artifact by re-running each
+      # consumer-provided codegen step. The final git diff fails if any
+      # committed file has drifted from its source. The build-meta.sh hook is
+      # consumer-supplied because rain meta build's invocation (input/output
+      # filenames, meta type) varies per repo.
+      - name: Regenerate meta artifacts
+        if: hashFiles('script/build-meta.sh') != ''
+        run: nix develop github:rainlanguage/rainix#sol-shell -c ./script/build-meta.sh
       - name: Regenerate pointer artifacts
         if: hashFiles('script/BuildPointers.sol') != ''
         run: nix develop github:rainlanguage/rainix#sol-shell -c forge script ./script/BuildPointers.sol
@@ -54,6 +58,6 @@ jobs:
       - name: Assert committed artifacts match freshly built
         run: |
           if ! git diff --exit-code; then
-            echo "::error::Committed meta/pointer/abi artifacts are stale. Regenerate (.#prelude, BuildPointers.sol, CopyArtifacts.sol, forge fmt) and commit."
+            echo "::error::Committed meta/pointer/abi artifacts are stale. Regenerate (script/build-meta.sh, script/BuildPointers.sol, script/CopyArtifacts.sol, forge fmt) and commit."
             exit 1
           fi


### PR DESCRIPTION
## Summary
- Add a `script/build-meta.sh` hook step to `rainix-copy-artifacts.yaml` (`if: hashFiles(...) != ''`), running between soldeer install and `BuildPointers.sol` via `#sol-shell`, so the reusable currency-checks committed authoring-meta artifacts the same way it already checks pointers and ABIs.
- Script is consumer-provided because `rain meta build`'s invocation (input/output filenames, meta type) varies per repo — same shape as the existing `BuildPointers.sol` / `CopyArtifacts.sol` hooks.
- Updates the rationale comment and the failure-error message to match.

Resolves #207. Once this lands, raindex#2600 can resolve by dropping its bespoke `git-clean` workflow (its only unique coverage was meta currency).

## Test plan
- [ ] CI green on this PR (the test/fixture repo doesn't ship a `build-meta.sh`, so the new step is a no-op there — verifies the `if: hashFiles(...)` guard works and nothing regresses).
- [ ] Smoke-test downstream by pointing raindex's `copy-artifacts.yaml` at this branch with an added `script/build-meta.sh`; expect green on raindex CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow to regenerate meta artifacts with improved script detection and refined failure messages for artifact management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rainlanguage/rainix/pull/208?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->