### PR TITLE
subgraph-shell + rainix-subgraph-test reusable + build-subgraph.sh hook

### DIFF
--- a/.github/workflows/rainix-copy-artifacts.yaml
+++ b/.github/workflows/rainix-copy-artifacts.yaml
@@ -53,11 +53,14 @@ jobs:
       - name: Copy forge artifacts into committed location
         if: hashFiles('script/CopyArtifacts.sol') != ''
         run: nix develop github:rainlanguage/rainix#sol-shell -c forge script ./script/CopyArtifacts.sol --ffi
+      - name: Regenerate subgraph artifacts
+        if: hashFiles('script/build-subgraph.sh') != ''
+        run: nix develop github:rainlanguage/rainix#subgraph-shell -c ./script/build-subgraph.sh
       - name: Format (so generated artifacts match committed style)
         run: nix develop github:rainlanguage/rainix#sol-shell -c forge fmt
       - name: Assert committed artifacts match freshly built
         run: |
           if ! git diff --exit-code; then
-            echo "::error::Committed meta/pointer/abi artifacts are stale. Regenerate (script/build-meta.sh, script/BuildPointers.sol, script/CopyArtifacts.sol, forge fmt) and commit."
+            echo "::error::Committed meta/pointer/abi/subgraph artifacts are stale. Regenerate (script/build-meta.sh, script/BuildPointers.sol, script/CopyArtifacts.sol, script/build-subgraph.sh, forge fmt) and commit."
             exit 1
           fi

--- a/.github/workflows/rainix-subgraph-test.yaml
+++ b/.github/workflows/rainix-subgraph-test.yaml
@@ -1,0 +1,31 @@
+name: rainix-subgraph-test
+on:
+  workflow_call:
+jobs:
+  subgraph-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: nixbuild/nix-quick-install-action@v30
+        with:
+          nix_conf: |
+            keep-env-derivations = true
+            keep-outputs = true
+      # Substitute prebuilt rainix derivations from the shared Cachix binary
+      # cache. Pushes new paths when CACHIX_AUTH_TOKEN is set; continue-on-error
+      # so a missing cache/token or a Cachix outage degrades to a normal build.
+      - uses: cachix/cachix-action@v15
+        continue-on-error: true
+        with:
+          name: rainlanguage
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          # No store-watching daemon: it checkpoints the nix DB concurrently
+          # with cache-nix-action and corrupts it. Push happens in the post step.
+          useDaemon: false
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 8G
+      - run: nix develop github:rainlanguage/rainix#subgraph-shell -c subgraph-test

--- a/flake.nix
+++ b/flake.nix
@@ -604,6 +604,25 @@
             '';
           };
 
+          # Slim shell for subgraph repos: node + the-graph + goldsky +
+          # subgraph-tasks. No rust, no foundry, no sqlite/yq/age. Lets
+          # consumers avoid the heavy default closure when CI is just
+          # subgraph-test.
+          subgraph-shell = pkgs.mkShell {
+            buildInputs =
+              node-build-inputs
+              ++ subgraph-tasks
+              ++ common-shell-inputs
+              ++ [
+                the-graph
+                goldsky
+              ];
+            shellHook = ''
+              ${pre-commit.shellHook}
+              ${source-dotenv}
+            '';
+          };
+
           default = pkgs.mkShell {
             buildInputs =
               sol-build-inputs


### PR DESCRIPTION
## Summary
Resolves #209.

- Add `devShells.subgraph-shell`: node + the-graph + goldsky + `subgraph-tasks`. No rust, no foundry, no sqlite/yq/age.
- Add `rainix-subgraph-test.yaml`: thin reusable that runs `subgraph-test` in the slim shell. End-state CI for subgraph repos with committed `subgraph/abis/` + `subgraph/generated/`.
- Extend `rainix-copy-artifacts.yaml` with an optional `script/build-subgraph.sh` hook (between `CopyArtifacts.sol` and `forge fmt`, run in `#subgraph-shell`). Consumers put their `graph codegen` there and the existing `git diff --exit-code` gate catches drift.

## Test plan
- [ ] Rainix's existing CI green (the fixture doesn't ship a subgraph, so the new reusable + hook are no-op for fixture; the flake-eval change is the main thing to verify).
- [ ] Once merged, raindex#2605 wires up `subgraph/abis/` + `subgraph/generated/` + `script/build-subgraph.sh` + flips `test-subgraph.yml` to this reusable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new reusable testing workflow for comprehensive subgraph functionality validation
  * Enhanced CI/CD pipeline with automatic subgraph artifact regeneration during deployment
  * Improved error messages to guide developers when artifact drift is detected
  * Updated development environment setup with specialized tools for subgraph development

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rainlanguage/rainix/pull/210?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->