### PR TITLE
Add devShells.wasm-shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -604,6 +604,22 @@
             '';
           };
 
+          # Slim shell for repos that ship a wasm-pack browser test or an
+          # npm wrapper around the rust-compiled WASM. rust-node-shell +
+          # wasm-pack. No sol-tasks, no subgraph, no sqlite/yq/age.
+          wasm-shell = pkgs.mkShell {
+            buildInputs =
+              rust-build-inputs
+              ++ node-build-inputs
+              ++ rs-tasks
+              ++ common-shell-inputs
+              ++ [ pkgs.wasm-pack ];
+            shellHook = ''
+              ${pre-commit.shellHook}
+              ${source-dotenv}
+            '';
+          };
+
           # Slim shell for subgraph repos: node + the-graph + goldsky +
           # subgraph-tasks. No rust, no foundry, no sqlite/yq/age. Lets
           # consumers avoid the heavy default closure when CI is just


### PR DESCRIPTION
## Summary
- New `devShells.wasm-shell`: `rust-build-inputs` + `node-build-inputs` + `rs-tasks` + `pkgs.wasm-pack`. No sol/subgraph/sqlite/yq/age.

## Why
Consumers running wasm-pack browser tests or building npm wrappers around rust-compiled WASM (e.g. raindex's `rainix-wasm-browser-test`, `test-js-bindings`) currently fall back to the full default shell because `wasm-pack` only lives there. With `#wasm-shell` those jobs can drop the sol toolchain + subgraph tooling + every mkTask wrapper they don't use, cutting nix-eval mass on each CI matrix job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)