### PR TITLE
copy-artifacts: generic build.sh hook

### DIFF
--- a/.github/workflows/rainix-copy-artifacts.yaml
+++ b/.github/workflows/rainix-copy-artifacts.yaml
@@ -53,14 +53,17 @@ jobs:
       - name: Copy forge artifacts into committed location
         if: hashFiles('script/CopyArtifacts.sol') != ''
         run: nix develop github:rainlanguage/rainix#sol-shell -c forge script ./script/CopyArtifacts.sol --ffi
-      - name: Regenerate subgraph artifacts
-        if: hashFiles('script/build-subgraph.sh') != ''
-        run: nix develop github:rainlanguage/rainix#subgraph-shell -c ./script/build-subgraph.sh
+      # Catch-all post-forge regen hook: consumer-supplied. Runs outside any
+      # nix devshell so the script picks shells per command (subgraph-shell,
+      # sol-shell, etc.) for whatever derived artifacts it emits.
+      - name: Regenerate derived artifacts
+        if: hashFiles('script/build.sh') != ''
+        run: ./script/build.sh
       - name: Format (so generated artifacts match committed style)
         run: nix develop github:rainlanguage/rainix#sol-shell -c forge fmt
       - name: Assert committed artifacts match freshly built
         run: |
           if ! git diff --exit-code; then
-            echo "::error::Committed meta/pointer/abi/subgraph artifacts are stale. Regenerate (script/build-meta.sh, script/BuildPointers.sol, script/CopyArtifacts.sol, script/build-subgraph.sh, forge fmt) and commit."
+            echo "::error::Committed artifacts are stale. Regenerate (script/build-meta.sh, script/BuildPointers.sol, script/CopyArtifacts.sol, script/build.sh, forge fmt) and commit."
             exit 1
           fi


### PR DESCRIPTION
Rename the post-CopyArtifacts hook from `script/build-subgraph.sh` to a generic `script/build.sh`. The reusable shouldn't enumerate "build subgraph" / "build bindings" / etc — one catch-all hook the consumer fills.

Also drops the `nix develop ...#subgraph-shell -c ...` wrapper around the call. Consumer's script picks shells per command internally (`nix develop ...#sol-shell -c ...`, `nix develop ...#subgraph-shell -c ...`), so different repos can emit different derived artifacts (subgraph codegen, bindings ABIs, anything else) without rainix knowing.

`script/build-meta.sh` stays — it's a phase-specific pre-pointers hook, not in the same bucket.

Consumers: `raindex` (in flight) — `build-subgraph.sh` → `build.sh` + extends to also emit `crates/bindings/abis/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow to improve artifact regeneration process and error messaging during build and validation steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rainlanguage/rainix/pull/213?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->