### PR TITLE
rainix-autopublish: support soldeer-only (and npm-only) callers

### DIFF
--- a/.github/workflows/rainix-autopublish.yaml
+++ b/.github/workflows/rainix-autopublish.yaml
@@ -36,7 +36,7 @@ on:
       CI_GIT_USER:
         required: false
       CARGO_REGISTRY_TOKEN:
-        required: true
+        required: false
       NPM_PUBLISH_PRIVATE_TOKEN:
         required: false
       SOLDEER_API_TOKEN:
@@ -85,7 +85,12 @@ jobs:
       - name: Resolve crates
         run: |
           CRATES="${{ inputs.crates != '' && inputs.crates || inputs.crate }}"
-          if [ -z "$CRATES" ]; then echo "set inputs.crate or inputs.crates" >&2; exit 1; fi
+          # A crate is required only when nothing else is being published; npm-
+          # and soldeer-only callers legitimately have no crate.
+          if [ -z "$CRATES" ] && [ -z "${{ inputs.npm-package }}" ] && [ -z "${{ inputs.soldeer-package }}" ]; then
+            echo "set inputs.crate/crates, or inputs.npm-package, or inputs.soldeer-package" >&2
+            exit 1
+          fi
           echo "CRATES=$CRATES" >> "$GITHUB_ENV"
       - name: Git config
         run: |
@@ -107,6 +112,7 @@ jobs:
       # workspace releases as a unit: changed=true if ANY listed crate differs.
       - name: Cargo hashes
         id: cargo
+        if: ${{ inputs.crates != '' || inputs.crate != '' }}
         run: |
           set -euo pipefail
           UA="rainix-autopublish (+https://github.com/rainlanguage/rainix)"
@@ -190,7 +196,7 @@ jobs:
       # it. PR CI already tested the code before merge; this is the pre-publish
       # gate on the exact merged commit.
       - name: Cargo test
-        if: ${{ steps.cargo.outputs.changed == 'true' || steps.npm.outputs.changed == 'true' || steps.soldeer.outputs.changed == 'true' }}
+        if: ${{ (inputs.crates != '' || inputs.crate != '') && (steps.cargo.outputs.changed == 'true' || steps.npm.outputs.changed == 'true' || steps.soldeer.outputs.changed == 'true') }}
         run: nix develop github:rainlanguage/rainix#rust-shell -c cargo test --workspace
       # Bump versions. One cargo-release invocation bumps every listed crate and
       # rewrites their inter-crate version pins atomically in one commit.


### PR DESCRIPTION
## Problem

`rainix-autopublish.yaml` exposes a `soldeer-package` input (publish a Soldeer package when its `foundry.toml` version diverges from the registry), but a **pure-Soldeer** consumer (no Rust crate) can't actually use it: the `Resolve crates` step runs unconditionally and `exit 1`s when no crate is given, so the job fails before reaching the guarded soldeer steps. No consumer has wired up soldeer-only autopublish yet (rain.vats is the first).

## Fix (minimal; existing crate/hybrid callers unaffected)

- **Resolve crates** — require a crate only when *nothing else* is being published (no crate AND no `npm-package` AND no `soldeer-package`). Otherwise allow an empty crate list.
- **Cargo hashes** — gate on a crate actually being provided, so `steps.cargo.outputs.changed` stays empty for soldeer/npm-only (downstream `== 'true'` guards then correctly skip the cargo bump/publish/test/release steps).
- **Cargo test** — additionally require a crate, so it doesn't run `cargo test --workspace` in a crate-less repo when only soldeer/npm changed.
- **CARGO_REGISTRY_TOKEN** — `required: false`, so a soldeer/npm-only caller isn't forced to carry a crates token.

The soldeer / npm steps were already `if: <pkg> != ''` guarded; this just lets the job *reach* them when there's no crate.

## Soldeer-only trace (after fix)

Resolve(ok, CRATES empty) → Cargo hashes skip → Soldeer version check runs → (cargo bump/test skip) → Tag and push (soldeer tag only; HEAD push is a no-op) → Publish to Soldeer (`forge soldeer push pkg~version`) → GitHub Release (soldeer).

Enables rain.vats (and other pure-Soldeer libs) to auto-publish to Soldeer on merge to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced publishing automation to support npm and Soldeer packages independently, without requiring Cargo crate inputs.
  * Expanded testing to run for npm and Soldeer package changes, in addition to Cargo changes, ensuring broader test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->