### PR TITLE
rainix-autopublish: fix Soldeer version-check endpoint (was 404ing -> always republished)

### DIFF
--- a/.github/workflows/rainix-autopublish.yaml
+++ b/.github/workflows/rainix-autopublish.yaml
@@ -182,7 +182,7 @@ jobs:
         id: soldeer
         run: |
           LOCAL=$(awk -F\" '/^version[[:space:]]*=/ { print $2; exit }' foundry.toml)
-          REMOTE=$(curl -fsSL "https://api.soldeer.xyz/api/v1/revisions/all?package_name=${{ inputs.soldeer-package }}&offset=0&limit=1" \
+          REMOTE=$(curl -fsSL "https://api.soldeer.xyz/api/v1/revision?project_name=${{ inputs.soldeer-package }}&offset=0&limit=1" \
             | python3 -c "import sys, json; d=json.load(sys.stdin); print(d['data'][0]['version'] if d.get('data') else 'none')" 2>/dev/null \
             || echo "none")
           echo "local=$LOCAL" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Problem

The `Soldeer version check` step queries `https://api.soldeer.xyz/api/v1/revisions/all?package_name=<pkg>` — but that path **404s for every package** (verified with `forge-std` too). The real endpoint is `…/api/v1/revision?project_name=<pkg>`.

Because the URL is dead, `curl -fsSL` fails and `REMOTE` falls back to `"none"` on every run. Consequences for a `soldeer-package` consumer:

- The change gate (`LOCAL != REMOTE`) is *always* true, so it re-attempts `forge soldeer push <pkg>~<version>` on **every push to main**.
- The first publish of a new version succeeds; every subsequent push fails the `Publish to Soldeer` step (Soldeer rejects the already-published version) until the `foundry.toml` version is bumped.

(rain.vats just hit the first half of this: `rain-vats~0.1.6` published fine, but the next main push would have failed.)

## Fix

One-line URL correction: `revisions/all?package_name=` → `revision?project_name=`. The response shape (`data[0].version`, latest-first) is unchanged, so the existing parse works.

Verified against the live API:
- `rain-vats` → `0.1.6` (matches local `foundry.toml` → `changed=false`, no republish)
- unknown package → `404` → `none` (correct "never published" fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)