### PR TITLE
flake: subgraph-deploy builds from committed artifacts (slim shell)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -309,8 +309,11 @@
             set -euxo pipefail
             source ${./lib/subgraph.sh}
 
-            ${pkgs.foundry-bin}/bin/forge build
-            (cd ./subgraph && ${pkgs.nodejs_22}/bin/npm ci && ${the-graph}/bin/graph codegen)
+            # subgraph/abis and subgraph/generated are committed, so the deploy
+            # builds the subgraph directly from them with just the graph +
+            # goldsky toolchain — the same committed-artifact path as
+            # subgraph-test, slim enough for the subgraph shell.
+            (cd ./subgraph && ${pkgs.nodejs_22}/bin/npm ci)
 
             commit="$(${pkgs.git}/bin/git rev-parse --short HEAD)"
             for network in $(subgraph_networks ./subgraph/networks.json); do
@@ -328,7 +331,7 @@
               fi
             done
           '';
-          additionalBuildInputs = sol-build-inputs ++ node-build-inputs;
+          additionalBuildInputs = node-build-inputs;
         };
 
         subgraph-tasks = [


### PR DESCRIPTION
`subgraph-deploy` ran `forge build` + `graph codegen`, which forces consumers (e.g. raindex's `deploy-subgraph.yaml`) onto the full devshell plus an explicit `forge soldeer install`. But `subgraph/abis` + `subgraph/generated` are committed — the same committed artifacts `subgraph-test` already builds from — so the deploy can build straight from them with just the graph + goldsky toolchain.

- Drops `forge build` + `graph codegen` from `subgraph-deploy`.
- Drops `sol-build-inputs` (no foundry needed).
- `subgraph-deploy` now runs on the slim `#subgraph-shell` (validated: the task builds and is callable there).

**Consumer follow-up:** raindex's `deploy-subgraph.yaml` can drop `forge soldeer install` + `forge build` and switch `nix develop -c subgraph-deploy` → `nix develop github:rainlanguage/rainix#subgraph-shell -c subgraph-deploy`. (This is the last full-devshell holdout flagged in raindex #2601.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)