### PR TITLE
fix(autopublish): soldeer next-version + idempotent bump (stop no-op-failing reruns)

### DIFF
--- a/.github/workflows/rainix-autopublish.yaml
+++ b/.github/workflows/rainix-autopublish.yaml
@@ -203,8 +203,15 @@ jobs:
           if [ -z "$URL" ] || [ "$REMOTE" = "none" ]; then OLD="none"; else
             curl -fsSL "$URL" -o /tmp/soldeer_pub.zip; OLD=$(nh /tmp/soldeer_pub.zip); fi
           echo "soldeer gate: remote=$REMOTE local=$LOCAL OLD=$OLD NEW=$NEW"
-          BASE="$REMOTE"; [ "$BASE" = "none" ] && BASE="$LOCAL"
-          NEXT=$(python3 -c "p=[int(x) for x in (('$BASE'.split('.')+['0','0','0'])[:3])]; p[2]+=1; print('.'.join(map(str,p)))")
+          # Next version: a first publish (never on the registry) uses LOCAL
+          # as-is; otherwise patch-bump the GREATER of local/remote so NEXT is
+          # always > LOCAL — foundry.toml left ahead of the registry by a prior
+          # bumped-but-unpublished run must not yield a no-op bump.
+          if [ "$REMOTE" = "none" ]; then
+            NEXT="$LOCAL"
+          else
+            NEXT=$(python3 -c "t=lambda v:[int(x) for x in (v.split('.')+['0','0','0'])[:3]]; b=max(t('$LOCAL'),t('$REMOTE')); b[2]+=1; print('.'.join(map(str,b)))")
+          fi
           if [ "$OLD" != "$NEW" ]; then echo "changed=true" >> "$GITHUB_OUTPUT"; else echo "changed=false" >> "$GITHUB_OUTPUT"; fi
           echo "next=$NEXT" >> "$GITHUB_OUTPUT"
           echo "remote=$REMOTE" >> "$GITHUB_OUTPUT"
@@ -252,7 +259,15 @@ jobs:
           NEXT="${{ steps.soldeer.outputs.next }}"
           sed -i -E "0,/^version[[:space:]]*=.*/s//version = \"$NEXT\"/" foundry.toml
           git add foundry.toml
-          git commit -m "Package Release: soldeer ${{ inputs.soldeer-package }} $NEXT"
+          # A first publish (NEXT == the current foundry.toml version) stages
+          # nothing — only commit when the version actually changed, so the bump
+          # step never fails with "nothing to commit". --no-verify: an automated
+          # version bump must not be gated on the repo's pre-commit hooks.
+          if git diff --cached --quiet; then
+            echo "foundry.toml already at $NEXT; nothing to commit"
+          else
+            git commit --no-verify -m "Package Release: soldeer ${{ inputs.soldeer-package }} $NEXT"
+          fi
       # Tag + push everything in one shot. cargo tags are namespaced
       # <crate>-v<version>; rebase onto any concurrent push first (only the
       # shared Cargo.lock is expected to conflict).


### PR DESCRIPTION
Follow-up to #221. The first real raindex autopublish run surfaced two bugs:

1. **No-op re-bump.** `next` was computed from the **registry** (`remote`) only. Once `foundry.toml` got ahead of the registry — a prior run bumped + tagged `sol-v0.1.1` but its **publish failed** (separate issue, below) — every rerun set `next = remote+1 = local = 0.1.1`, so the `sed` was a no-op, `git commit` died `nothing to commit`, and publish was never re-attempted (registry stuck at 0.1.0). **Fix:** `next = patch(max(local, remote))`; a first publish (`remote=none`) uses `local` as-is.
2. **Bump commit fragility.** It failed on an empty stage and ran the repo's pre-commit hooks. **Fix:** only commit when foundry.toml changed; `--no-verify`.

**Not changed:** the publish step. The original publish failure was soldeer's interactive *sensitive-files* warning (`error during IO operation: not connected` in CI, because raindex packages `.env.example`). The fix for that is on the **consumer side** — keep sensitive files out of the package via `.soldeerignore` — **not** `--skip-warnings` (that warning exists to stop publishing secrets and should stay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)