### PR TITLE
Add one-contract-per-.sol-file static check (rainix#214)

### DIFF
--- a/.github/workflows/rainix-sol-static.yaml
+++ b/.github/workflows/rainix-sol-static.yaml
@@ -46,3 +46,5 @@ jobs:
         run: nix develop github:rainlanguage/rainix#sol-shell -c forge soldeer install
       - run: nix develop github:rainlanguage/rainix#sol-shell -c slither .
       - run: nix develop github:rainlanguage/rainix#sol-shell -c forge fmt --check
+      # Enforce Rain's one-contract-per-.sol-file convention (rainix#214).
+      - run: nix develop github:rainlanguage/rainix#sol-shell -c rainix-sol-single-contract

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,9 @@ All tasks are Nix packages run via `nix run`. From a consuming repo use `..#`
 - `nix run ..#rainix-sol-prelude` — `forge install && forge build`
 - `nix run ..#rainix-sol-test` — `forge test -vvv`
 - `nix run ..#rainix-sol-static` — `slither . && forge fmt --check`
+- `nix run ..#rainix-sol-single-contract` — fail if any tracked `.sol` declares
+  more than one top-level `contract`/`abstract contract` (one-contract-per-file
+  convention; `library`/`interface` not counted)
 - `nix run ..#rainix-sol-legal` — `reuse lint` (REUSE/DCL-1.0 license
   compliance)
 - `nix run ..#rainix-sol-artifacts` — deploy to testnet via `script/Deploy.sol`

--- a/flake.nix
+++ b/flake.nix
@@ -252,6 +252,20 @@
           additionalBuildInputs = sol-build-inputs;
         };
 
+        # Enforces Rain's one-contract-per-file convention (rainix#214). Runs
+        # over git-tracked .sol files so it works the same locally and in CI.
+        # `library`/`interface` are not counted; only `contract` and
+        # `abstract contract` declarations.
+        rainix-sol-single-contract = mkTask {
+          name = "rainix-sol-single-contract";
+          body = ''
+            set -euo pipefail
+            source ${./lib/sol-single-contract.sh}
+            sol_single_contract_check_tracked
+          '';
+          additionalBuildInputs = [ pkgs.git ];
+        };
+
         rainix-rs-static = mkTask {
           name = "rainix-rs-static";
           body = ''
@@ -264,6 +278,7 @@
 
         sol-tasks = [
           rainix-sol-artifacts
+          rainix-sol-single-contract
         ];
 
         rs-tasks = [
@@ -358,6 +373,7 @@
             bats test/bats/task/skip-simulation.test.bats
             bats test/bats/task/subgraph-build.test.bats
             bats test/bats/task/subgraph-deploy-version.test.bats
+            bats test/bats/task/sol-single-contract.test.bats
           '';
           additionalBuildInputs = [ pkgs.bats ] ++ sol-build-inputs ++ node-build-inputs;
         };
@@ -562,6 +578,7 @@
         packages = {
           inherit
             rainix-sol-artifacts
+            rainix-sol-single-contract
             rainix-rs-static
             prettier-bundle
             sol-shell-test

--- a/lib/sol-single-contract.sh
+++ b/lib/sol-single-contract.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+# Rain convention is one contract per .sol file (named after the file). This
+# library enforces it mechanically so the convention does not drift via inline
+# helper/mock contracts in .t.sol test files or accumulated source helpers.
+#
+# Scope (per rainlanguage/rainix#214):
+# - Counts top-level `contract` and `abstract contract` declarations.
+# - `library` and `interface` are NOT counted — they are allowed alongside (or
+#   instead of) a single contract.
+# - File-scope `error`/`struct`/`enum`/`constant`/`function`/`type` are not
+#   contracts and are always allowed.
+
+# Count top-level `contract` / `abstract contract` declarations in a single
+# .sol file, ignoring matches inside `//` line comments and `/* */` block
+# comments. Top-level declarations sit at column zero in `forge fmt`-formatted
+# source (which rainix enforces via `forge fmt --check`), so the count anchors
+# the keyword to the start of the line.
+# Usage: sol_count_contracts <sol_file>
+sol_count_contracts() {
+  local sol_file="$1"
+  # 1. Strip /* ... */ block comments (including multi-line ones).
+  # 2. Strip // ... line comments.
+  # 3. Count lines whose first non-space token is an optional `abstract `
+  #    qualifier followed by `contract ` and an identifier character. The
+  #    leading-whitespace anchor avoids matching `contract` mid-expression
+  #    (e.g. a `contract`-suffixed identifier) while tolerating the stray
+  #    indentation a leading inline block comment leaves behind.
+  # `grep -c` exits non-zero when it finds zero matches; that is a valid
+  # result here (a file with no contracts), so it must not propagate as a
+  # failure. `{ ...; } || true` keeps the count without the no-match status.
+  {
+    sed -E ':a;/\/\*/{/\*\//!{N;ba}};s,/\*[^*]*\*+([^/*][^*]*\*+)*/,,g' "$sol_file" \
+      | sed -E 's,//.*$,,' \
+      | grep -cE '^[[:space:]]*(abstract[[:space:]]+)?contract[[:space:]]+[A-Za-z_]'
+  } || true
+}
+
+# Check a list of .sol files. Prints each offending file with its contract
+# count and returns non-zero if any file declares more than one contract.
+# Usage: sol_single_contract_check <sol_file> [<sol_file> ...]
+sol_single_contract_check() {
+  local sol_file
+  local count
+  local failed=0
+  for sol_file in "$@"; do
+    count="$(sol_count_contracts "$sol_file")"
+    if [ "$count" -gt 1 ]; then
+      echo "ERROR: $sol_file declares $count contracts; Rain convention is one contract per file." >&2
+      failed=1
+    fi
+  done
+  return "$failed"
+}
+
+# Enumerate all git-tracked .sol files in the current repository and run the
+# single-contract check over them. Returns non-zero if any file declares more
+# than one contract.
+# Usage: sol_single_contract_check_tracked
+sol_single_contract_check_tracked() {
+  # -z / read -d handles paths with spaces or unusual characters.
+  local -a files=()
+  local sol_file
+  while IFS= read -r -d '' sol_file; do
+    files+=("$sol_file")
+  done < <(git ls-files -z '*.sol')
+
+  if [ "${#files[@]}" -eq 0 ]; then
+    return 0
+  fi
+
+  sol_single_contract_check "${files[@]}"
+}

--- a/test/bats/task/sol-single-contract.test.bats
+++ b/test/bats/task/sol-single-contract.test.bats
@@ -10,7 +10,6 @@ teardown() {
 
 @test "sol_count_contracts counts a single contract" {
   cat > "$TESTDIR/Counter.sol" <<'EOF'
-// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
 contract Counter {

--- a/test/bats/task/sol-single-contract.test.bats
+++ b/test/bats/task/sol-single-contract.test.bats
@@ -1,0 +1,186 @@
+setup() {
+  # shellcheck disable=SC1091
+  source lib/sol-single-contract.sh
+  TESTDIR="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$TESTDIR"
+}
+
+@test "sol_count_contracts counts a single contract" {
+  cat > "$TESTDIR/Counter.sol" <<'EOF'
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+contract Counter {
+    uint256 public count;
+}
+EOF
+  run sol_count_contracts "$TESTDIR/Counter.sol"
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 1 ]
+}
+
+@test "sol_count_contracts counts abstract contract" {
+  cat > "$TESTDIR/Base.sol" <<'EOF'
+pragma solidity ^0.8.25;
+
+abstract contract Base {
+    function foo() public virtual;
+}
+EOF
+  run sol_count_contracts "$TESTDIR/Base.sol"
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 1 ]
+}
+
+@test "sol_count_contracts counts two contracts" {
+  cat > "$TESTDIR/Two.sol" <<'EOF'
+pragma solidity ^0.8.25;
+
+contract A {}
+
+contract B {}
+EOF
+  run sol_count_contracts "$TESTDIR/Two.sol"
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 2 ]
+}
+
+@test "sol_count_contracts does not count library or interface" {
+  cat > "$TESTDIR/Lib.sol" <<'EOF'
+pragma solidity ^0.8.25;
+
+library Math {
+    function add(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a + b;
+    }
+}
+
+interface IThing {
+    function go() external;
+}
+EOF
+  run sol_count_contracts "$TESTDIR/Lib.sol"
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 0 ]
+}
+
+@test "sol_count_contracts ignores the keyword in line comments" {
+  cat > "$TESTDIR/Commented.sol" <<'EOF'
+pragma solidity ^0.8.25;
+
+// contract Decoy is not real
+contract Real {}
+EOF
+  run sol_count_contracts "$TESTDIR/Commented.sol"
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 1 ]
+}
+
+@test "sol_count_contracts ignores the keyword in block comments" {
+  cat > "$TESTDIR/BlockComment.sol" <<'EOF'
+pragma solidity ^0.8.25;
+
+/*
+contract Decoy {}
+contract AlsoDecoy {}
+*/
+contract Real {}
+EOF
+  run sol_count_contracts "$TESTDIR/BlockComment.sol"
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 1 ]
+}
+
+@test "sol_count_contracts allows file-scope error/struct/enum alongside one contract" {
+  cat > "$TESTDIR/WithFileScope.sol" <<'EOF'
+pragma solidity ^0.8.25;
+
+error Unauthorized();
+
+struct Point {
+    uint256 x;
+    uint256 y;
+}
+
+enum State {
+    Open,
+    Closed
+}
+
+uint256 constant MAX = 100;
+
+contract Real {}
+EOF
+  run sol_count_contracts "$TESTDIR/WithFileScope.sol"
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 1 ]
+}
+
+@test "sol_single_contract_check passes for one contract per file" {
+  cat > "$TESTDIR/A.sol" <<'EOF'
+contract A {}
+EOF
+  cat > "$TESTDIR/B.sol" <<'EOF'
+abstract contract B {}
+EOF
+  run sol_single_contract_check "$TESTDIR/A.sol" "$TESTDIR/B.sol"
+  [ "$status" -eq 0 ]
+}
+
+@test "sol_single_contract_check fails when a file declares two contracts" {
+  cat > "$TESTDIR/Ok.sol" <<'EOF'
+contract Ok {}
+EOF
+  cat > "$TESTDIR/Bad.sol" <<'EOF'
+contract Bad1 {}
+contract Bad2 {}
+EOF
+  run sol_single_contract_check "$TESTDIR/Ok.sol" "$TESTDIR/Bad.sol"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Bad.sol"* ]]
+  [[ "$output" == *"declares 2 contracts"* ]]
+}
+
+@test "sol_single_contract_check fails on a contract plus an inline mock" {
+  cat > "$TESTDIR/Mock.t.sol" <<'EOF'
+pragma solidity ^0.8.25;
+
+contract MockAsset {}
+
+contract ManagerTest {}
+EOF
+  run sol_single_contract_check "$TESTDIR/Mock.t.sol"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Mock.t.sol"* ]]
+}
+
+@test "sol_single_contract_check_tracked passes on a clean tracked repo" {
+  (
+    cd "$TESTDIR" || exit 1
+    git init -q
+    git config user.email test@example.com
+    git config user.name test
+    printf 'contract A {}\n' > A.sol
+    printf 'contract B {}\n' > B.sol
+    git add A.sol B.sol
+  )
+  run bash -c "cd '$TESTDIR' && source '$BATS_TEST_DIRNAME/../../../lib/sol-single-contract.sh' && sol_single_contract_check_tracked"
+  [ "$status" -eq 0 ]
+}
+
+@test "sol_single_contract_check_tracked fails on a tracked multi-contract file" {
+  (
+    cd "$TESTDIR" || exit 1
+    git init -q
+    git config user.email test@example.com
+    git config user.name test
+    printf 'contract A {}\ncontract B {}\n' > Multi.sol
+    git add Multi.sol
+  )
+  run bash -c "cd '$TESTDIR' && source '$BATS_TEST_DIRNAME/../../../lib/sol-single-contract.sh' && sol_single_contract_check_tracked"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Multi.sol"* ]]
+}


### PR DESCRIPTION
## What

Adds a standard "one contract per `.sol` file" check that all consuming rain repos inherit via the reusable `rainix-sol-static` workflow.

- **`lib/sol-single-contract.sh`** — counts top-level `contract` / `abstract contract` declarations per file (ignoring matches inside `//` line comments and `/* */` block comments) and fails when any tracked `.sol` declares more than one. Per the issue's recommended scope:
  - `library` and `interface` are **not** counted.
  - File-scope `error` / `struct` / `enum` / `constant` declarations alongside a single contract remain allowed (they aren't contracts).
- **`rainix-sol-single-contract` task** (`flake.nix`) — runs the check over `git ls-files '*.sol'`. Added to `sol-tasks` so it is on `PATH` in `sol-shell`, and exported as a package so consumers can `nix run ..#rainix-sol-single-contract` locally.
- **`rainix-sol-static.yaml`** — invokes the task as a CI step alongside `slither .` and `forge fmt --check`, so every consumer of the reusable workflow inherits the check.
- **bats coverage** (`test/bats/task/sol-single-contract.test.bats`, wired into `default-shell-test`) — single/abstract/two-contract counts, library/interface not counted, line- and block-comment stripping, file-scope declarations allowed, and the git-tracked enumeration pass/fail paths.

## Why

Rain's convention is one contract per file, but it was only enforced by review and drifted — inline helper/mock contracts in `.t.sol` files and accumulated source helpers. A mechanical rainix-level check prevents this class of drift everywhere without reviewer effort.

## Rollout caveat (from the issue)

As the issue notes, this will fail CI in consumers that currently have multi-contract files (e.g. some test helpers bundling a mock asset + a manager). This PR lands the check in rainix; downstream consumers should be cleaned up before/as they pick it up (tracked for rain.vats at rainlanguage/rain.vats#314). The check is on tracked `.sol` files only and is a hard failure, matching the issue's primary recommendation; staging it as a warning first was an option but was not requested as the default.

The two open design questions in the issue (should `library`/`interface` count; warning-first vs hard-fail) are resolved conservatively here per the issue's own recommendation: start with `contract` + `abstract contract` only, hard-fail. They can be tightened separately if maintainers prefer.

## Verification

- `nix build .#rainix-sol-single-contract` and `nix build .#sol-shell-test` build green.
- The built task exits `0` on rainix's own tracked `.sol` fixtures and exits `1` with a clear message (`ERROR: <file> declares N contracts; ...`) on a tracked multi-contract file.
- All 12 bats tests pass.
- `shellcheck` (lib script), `nixfmt` (flake.nix), `yamlfmt` (workflow), and `deno fmt` (CLAUDE.md) are clean on the changed files.

Fixes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)
