### PR TITLE
flake: keep sol-build-inputs chromium-free for sol-only shell (#128)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -89,6 +89,13 @@
         ])
         ++ (pkgs.lib.optionals pkgs.stdenv.isDarwin [ pkgs.darwin.DarwinTools ]);
 
+        # The Solidity toolchain shared by sol-shell and default. sol-only
+        # repos (rain.solmem, rain.deploy, rain.datacontract, etc.) consume
+        # this set via `nix develop github:rainlanguage/rainix#sol-shell` and
+        # nothing else, so it carries no browser (chromium/playwright), node,
+        # rust, or wasm dependency — keeping the sol-shell closure slim. The
+        # sol-shell closure test asserts chromium, node, and the rust
+        # toolchain stay absent.
         sol-build-inputs = [
           pkgs.git
           pkgs.foundry-bin


### PR DESCRIPTION
## What

Issue #128 asks that the dev shell for Solidity-only repos not pull chromium.

On investigation, **this is already the case on `main`**:

- The slim `sol-shell` devShell already exists (option 1 from the issue): `forge`, `slither`, `solc 0.8.25`, `reuse`, `jq`, `git` — no chromium, no node, no rust, no wasm. Every sol-only CI workflow (`rainix-sol-test`/`-static`/`-legal`, `rainix-copy-artifacts`, autopublish dry-run, etc.) consumes `nix develop github:rainlanguage/rainix#sol-shell`.
- Chromium is in **no** rainix dev shell at all: commit 37c992d (Closes #170) removed `pkgs.chromium` from the `default` shell because building it from source on a cold cache was exceeding the 6h CI timeout.

Verified against the realized closure of `sol-shell` on `x86_64-linux`:

```
$ nix-store -q --requisites $(nix build --no-link --print-out-paths .#devShells.x86_64-linux.sol-shell) | grep chromium
# (no output) -> chromium ABSENT
```

`nix run .#sol-shell-test` passes, including the regression guards `chromium should NOT come from nix` (slim.test.bats) and `sol-shell closure has no chromium` (closure.test.bats). The `sol-shell` still provides the full sol toolchain (forge / solc / slither / reuse / jq); the wasm/browser-test shell still carries `wasm-pack`.

## Change

Since the slim shell already satisfies the ask, this PR makes the invariant durable at its source: a comment on `sol-build-inputs` (the list shared by `sol-shell` and `default`) recording that it is the chromium-free shared Solidity set sol-only repos depend on. This is the exact place a future browser/chromium dependency would leak into every sol-only consumer, so the contract is documented where edits happen. Flake-only, nixfmt-clean, derivation-identical (the `sol-shell` drv path is unchanged).

Closes #128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)