### PR TITLE
fix(actions): strip live ${{ }} expressions from composite-action descriptions

### DIFF
--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -1,7 +1,7 @@
 name: checkout
 description: >-
   Single-source wrapper around `actions/checkout`. GitHub Actions can't
-  parameterize a `uses:` ref (no `uses: ${{ env.X }}`), so the only way to pin
+  parameterize a `uses:` ref with an env expression, so the only way to pin
   the checkout SHA in ONE place across every rainix workflow is to wrap it in a
   composite. The `ssh-key` input covers the one call site (autopublish) that
   needs a deploy-key checkout; every other site uses the default token checkout.

--- a/.github/actions/rust-cache/action.yml
+++ b/.github/actions/rust-cache/action.yml
@@ -9,8 +9,8 @@ description: >-
 inputs:
   prefix-key:
     description: >-
-      Optional `prefix-key` for `Swatinem/rust-cache` (e.g.
-      `rust-${{ github.workflow }}`). Empty (the default) leaves the action's
+      Optional `prefix-key` for `Swatinem/rust-cache` (e.g. one namespaced per
+      workflow via the github context). Empty (the default) leaves the action's
       own default prefix in place.
     required: false
     default: ''


### PR DESCRIPTION
## Problem

The GitHub Actions runner's manifest loader evaluates `${{ }}` expression syntax **even inside `description:` block-scalars** of composite actions. The `checkout` composite (added in `9c4b6063d` "ci: single-source every repeated third-party action via composites") has the literal `${{ env.X }}` in its description prose. `env` is not a valid named-value in that context, so loading the action fails:

```
Failed to load rainlanguage/rainix/main/.github/actions/checkout/action.yml
The template is not valid. ... (Line: 2, Col: 14): Unrecognized named-value: 'env'.
Located at position 1 within expression: env.X
```

This breaks **every consumer** that resolves `rainlanguage/rainix/.github/actions/checkout@main` — including raindex's `manual-sol-artifacts.yaml` on-chain deploys, which now fail in ~5s at action-load before any broadcast (e.g. raindex run [27573977795](https://github.com/rainlanguage/raindex/actions/runs/27573977795)). This is on the critical path of an approved pre-audit production deploy.

## Fix

Rephrase the two composite-action descriptions that embed live expressions into plain prose with no `${{ }}` delimiters:

- `checkout/action.yml` — `${{ env.X }}` → "an env expression" (the confirmed blocker)
- `rust-cache/action.yml` — `rust-${{ github.workflow }}` → "one namespaced per workflow via the github context" (defensive: same anti-pattern, removes the only other prose expression in any composite action so the next deploy can't trip a second landmine)

Behavior-neutral: description text only; no `runs:`/`with:`/`uses:` change. Both files validate as YAML. No other `action.yml` description carries an active expression after this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)