### PR TITLE
fix: yamlfmt composite action.yml files to green rainix-check-shell on main

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -1,10 +1,6 @@
 name: cache
 description: >-
-  Single-source wrapper around `actions/cache`. GitHub Actions can't
-  parameterize a `uses:` ref, so wrapping the step in a composite is the only
-  way to pin the action's SHA in ONE place across every rainix workflow that
-  caches build outputs. Each call site passes its own `path` / `key` /
-  `restore-keys` (the Foundry build cache, the npm cache, etc.).
+  Single-source wrapper around `actions/cache`. GitHub Actions can't parameterize a `uses:` ref, so wrapping the step in a composite is the only way to pin the action's SHA in ONE place across every rainix workflow that caches build outputs. Each call site passes its own `path` / `key` / `restore-keys` (the Foundry build cache, the npm cache, etc.).
 inputs:
   path:
     description: A list of files, directories, and patterns to cache and restore.
@@ -14,8 +10,7 @@ inputs:
     required: true
   restore-keys:
     description: >-
-      An ordered multiline string listing the prefix-matched keys used to
-      restore a stale cache if no cache hit occurred for `key`.
+      An ordered multiline string listing the prefix-matched keys used to restore a stale cache if no cache hit occurred for `key`.
     required: false
     default: ''
 runs:

--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -1,17 +1,10 @@
 name: checkout
 description: >-
-  Single-source wrapper around `actions/checkout`. GitHub Actions can't
-  parameterize a `uses:` ref with an env expression, so the only way to pin
-  the checkout SHA in ONE place across every rainix workflow is to wrap it in a
-  composite. The `ssh-key` input covers the one call site (autopublish) that
-  needs a deploy-key checkout; every other site uses the default token checkout.
+  Single-source wrapper around `actions/checkout`. GitHub Actions can't parameterize a `uses:` ref with an env expression, so the only way to pin the checkout SHA in ONE place across every rainix workflow is to wrap it in a composite. The `ssh-key` input covers the one call site (autopublish) that needs a deploy-key checkout; every other site uses the default token checkout.
 inputs:
   ssh-key:
     description: >-
-      Optional deploy key (e.g. `secrets.PUBLISH_PRIVATE_KEY`) for a checkout
-      whose pushes should trigger downstream workflows. A composite action
-      cannot read `secrets.*`, so the caller must plumb the secret through here.
-      Empty (the default) falls back to the standard GITHUB_TOKEN checkout.
+      Optional deploy key (e.g. `secrets.PUBLISH_PRIVATE_KEY`) for a checkout whose pushes should trigger downstream workflows. A composite action cannot read `secrets.*`, so the caller must plumb the secret through here. Empty (the default) falls back to the standard GITHUB_TOKEN checkout.
     required: false
     default: ''
 runs:

--- a/.github/actions/gh-release/action.yml
+++ b/.github/actions/gh-release/action.yml
@@ -1,10 +1,6 @@
 name: gh-release
 description: >-
-  Single-source wrapper around `softprops/action-gh-release`. GitHub Actions
-  can't parameterize a `uses:` ref, so wrapping the step in a composite is the
-  only way to pin the action's SHA in ONE place across the (npm / soldeer)
-  GitHub Release steps in the autopublish workflow. Each call site passes its
-  own `tag-name` / `name` / `files`.
+  Single-source wrapper around `softprops/action-gh-release`. GitHub Actions can't parameterize a `uses:` ref, so wrapping the step in a composite is the only way to pin the action's SHA in ONE place across the (npm / soldeer) GitHub Release steps in the autopublish workflow. Each call site passes its own `tag-name` / `name` / `files`.
 inputs:
   tag-name:
     description: The git tag to create the release against (passed to `tag_name`).
@@ -15,14 +11,12 @@ inputs:
     default: ''
   files:
     description: >-
-      Newline- or comma-separated globs of files to upload as release assets.
-      Empty (the default) creates a release with no attached assets.
+      Newline- or comma-separated globs of files to upload as release assets. Empty (the default) creates a release with no attached assets.
     required: false
     default: ''
   github-token:
     description: >-
-      GitHub token used to create the release. A composite action cannot read
-      `secrets.*`, so the caller must plumb `secrets.GITHUB_TOKEN` through here.
+      GitHub token used to create the release. A composite action cannot read `secrets.*`, so the caller must plumb `secrets.GITHUB_TOKEN` through here.
     required: true
 runs:
   using: composite

--- a/.github/actions/nix-cachix-setup/action.yml
+++ b/.github/actions/nix-cachix-setup/action.yml
@@ -1,16 +1,10 @@
 name: nix-cachix-setup
 description: >-
-  Shared 'nix + cachix CI' preamble for the rainix reusable workflows: checkout,
-  nix-quick-install, the Cachix substituter/pusher, and the cache-nix-action Nix
-  store restore/save. This composite is the single source of truth for the
-  pinned third-party action SHAs used by that preamble — each SHA lives here once
-  instead of being copy-pasted across the reusables.
+  Shared 'nix + cachix CI' preamble for the rainix reusable workflows: checkout, nix-quick-install, the Cachix substituter/pusher, and the cache-nix-action Nix store restore/save. This composite is the single source of truth for the pinned third-party action SHAs used by that preamble — each SHA lives here once instead of being copy-pasted across the reusables.
 inputs:
   cachix-auth-token:
     description: >-
-      Cachix auth token. A composite action cannot read `secrets.*`, so the
-      caller reusable must plumb `secrets.CACHIX_AUTH_TOKEN` through to here.
-      Empty (the default) degrades to a read-only/anonymous Cachix pull.
+      Cachix auth token. A composite action cannot read `secrets.*`, so the caller reusable must plumb `secrets.CACHIX_AUTH_TOKEN` through to here. Empty (the default) degrades to a read-only/anonymous Cachix pull.
     required: false
     default: ''
   cachix-name:
@@ -19,23 +13,17 @@ inputs:
     default: rainlanguage
   checkout:
     description: >-
-      Run the bundled `actions/checkout` (default). Set to 'false' if the
-      caller needs a non-default checkout (e.g. an ssh-key deploy-key checkout)
-      and runs `actions/checkout` itself before calling this composite.
+      Run the bundled `actions/checkout` (default). Set to 'false' if the caller needs a non-default checkout (e.g. an ssh-key deploy-key checkout) and runs `actions/checkout` itself before calling this composite.
     required: false
     default: 'true'
   cache-nix:
     description: >-
-      Run the bundled `cache-nix-action` Nix store restore/save (default). Set
-      to 'false' if the caller pins a different cache-nix-action version and runs
-      it itself.
+      Run the bundled `cache-nix-action` Nix store restore/save (default). Set to 'false' if the caller pins a different cache-nix-action version and runs it itself.
     required: false
     default: 'true'
   gc-max-store-size-macos:
     description: >-
-      Optional `gc-max-store-size-macos` for the bundled cache-nix-action. Left
-      empty (the action's own default) unless a caller needs to cap the macOS
-      store before saving.
+      Optional `gc-max-store-size-macos` for the bundled cache-nix-action. Left empty (the action's own default) unless a caller needs to cap the macOS store before saving.
     required: false
     default: ''
 runs:

--- a/.github/actions/rust-cache/action.yml
+++ b/.github/actions/rust-cache/action.yml
@@ -1,17 +1,10 @@
 name: rust-cache
 description: >-
-  Single-source wrapper around `Swatinem/rust-cache`. GitHub Actions can't
-  parameterize a `uses:` ref, so wrapping the step in a composite is the only
-  way to pin the action's SHA in ONE place across every rainix workflow that
-  caches Rust build artifacts. The `prefix-key` input covers the one call site
-  (vercel) that namespaces its cache per-workflow; every other site uses the
-  action's default key.
+  Single-source wrapper around `Swatinem/rust-cache`. GitHub Actions can't parameterize a `uses:` ref, so wrapping the step in a composite is the only way to pin the action's SHA in ONE place across every rainix workflow that caches Rust build artifacts. The `prefix-key` input covers the one call site (vercel) that namespaces its cache per-workflow; every other site uses the action's default key.
 inputs:
   prefix-key:
     description: >-
-      Optional `prefix-key` for `Swatinem/rust-cache` (e.g. one namespaced per
-      workflow via the github context). Empty (the default) leaves the action's
-      own default prefix in place.
+      Optional `prefix-key` for `Swatinem/rust-cache` (e.g. one namespaced per workflow via the github context). Empty (the default) leaves the action's own default prefix in place.
     required: false
     default: ''
 runs:


### PR DESCRIPTION
`main`'s `rainix-check-shell` check is red (ubuntu + macos) because the composite `action.yml` files under `.github/actions/` are not yamlfmt-formatted.

`nix flake check --impure` builds a `pre-commit-run` derivation that runs the repo's `yamlfmt` pre-commit hook (yamlfmt 0.21.0). yamlfmt collapses these files' hand-wrapped `>-` folded-scalar `description` bodies onto single lines, so the hook reports the files as modified and the check fails.

This PR applies the exact formatter the pre-commit hook enforces. The change is pure yamlfmt reflow of the folded-scalar `description` bodies — no semantic, logic, or comment-content changes — in:

- `.github/actions/cache/action.yml`
- `.github/actions/checkout/action.yml`
- `.github/actions/gh-release/action.yml`
- `.github/actions/nix-cachix-setup/action.yml`
- `.github/actions/rust-cache/action.yml`

`nix flake check --impure` passes locally (exit 0).