### PR TITLE
fix(vercel-reusable): production deploy false-red — URL parse only matched "Preview:" and aborted under set -e on --prod

### DIFF
--- a/.github/workflows/rainix-vercel.yaml
+++ b/.github/workflows/rainix-vercel.yaml
@@ -125,14 +125,18 @@ jobs:
           deploy_log="$(mktemp)"
           "$VERCEL_BIN" deploy --prebuilt ${{ inputs.production && '--prod' || '' }} --token="$VERCEL_TOKEN" "${{ inputs.deploy-path }}" 2>&1 | tee "$deploy_log"
 
-          # Preview URL: prefer the "Preview: <url>" line; fall back to the last
-          # bare https://*.vercel.app URL the CLI emitted (the deployment URL).
-          preview_url="$(grep -oE 'Preview: https://[^[:space:]]+' "$deploy_log" | tail -n1 | sed 's/^Preview: //')"
+          # Deployment URL: prefer the "Preview:"/"Production:" line (the CLI
+          # prints "Production:" for --prod and "Preview:" otherwise); fall back
+          # to the last bare https://*.vercel.app URL. Guard every grep with
+          # `|| true` so a no-match never aborts the step under `set -euo
+          # pipefail` — this was the bug: on a --prod deploy the "Preview:"-only
+          # grep matched nothing and set -e killed an otherwise-successful deploy.
+          preview_url="$(grep -oE '(Preview|Production): https://[^[:space:]]+' "$deploy_log" | tail -n1 | sed -E 's/^(Preview|Production): //' || true)"
           if [ -z "$preview_url" ]; then
-            preview_url="$(grep -oE 'https://[a-zA-Z0-9.-]+\.vercel\.app[^[:space:]]*' "$deploy_log" | tail -n1)"
+            preview_url="$(grep -oE 'https://[a-zA-Z0-9.-]+\.vercel\.app[^[:space:]]*' "$deploy_log" | tail -n1 || true)"
           fi
           # Inspect (dashboard) URL, if present.
-          inspect_url="$(grep -oE 'Inspect: https://[^[:space:]]+' "$deploy_log" | tail -n1 | sed 's/^Inspect: //')"
+          inspect_url="$(grep -oE 'Inspect: https://[^[:space:]]+' "$deploy_log" | tail -n1 | sed 's/^Inspect: //' || true)"
 
           echo "url=$preview_url" >> "$GITHUB_OUTPUT"
           echo "inspect=$inspect_url" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
The `Deploy to Vercel` step in this reusable extracted the deployment URL with `grep -oE 'Preview: https://...'` under `bash --noprofile --norc -euo pipefail`. A **production** (`--prod`) deploy prints `Production: <url>`, **not** `Preview:`, so that grep matched nothing, exited 1, and pipefail + `set -e` aborted the step **before the fallback ran** — even though the deploy itself **succeeded** (it aliases to the production domain, e.g. `v6.raindex.finance`).

That is exactly why **preview** deploys are green but **production** deploys go red.

### Fix
- Match both `Preview:` and `Production:` in the primary grep.
- Guard every URL-extraction grep with `|| true` so a no-match can never abort the step under `set -euo pipefail`.

### Validation (local, against the real failed production output)
- Old extraction → exit **1** (reproduces the false-red).
- New extraction → exit **0**, extracts `url=https://rain-orderbook-v6-…vercel.app` **and** the Inspect URL.

### Impact
Unblocks raindex `main` `production / deploy`, red since rainlanguage/raindex#2739 migrated raindex onto this reusable. **Production was never actually broken** — the site has been deploying the whole time; only the post-deploy URL-parse step false-failed. Shared by every webapp deploy that uses this reusable, so this fixes the production path for all of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment workflow reliability with enhanced URL extraction logic for both preview and production deployments, ensuring more robust error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->