### PR TITLE
ci(manual-sol-artifacts): declare workflow_call secrets for cross-org callers

### DIFF
--- a/.github/workflows/rainix-manual-sol-artifacts.yaml
+++ b/.github/workflows/rainix-manual-sol-artifacts.yaml
@@ -8,6 +8,39 @@ on:
         description: |
           Passed through as `DEPLOYMENT_SUITE`. `script/Deploy.sol` dispatches
           on this to select what to deploy.
+    # Secrets consumed by the deploy step. Declared here so callers in a
+    # different organization can pass them explicitly — `secrets: inherit`
+    # only forwards a caller's secrets within the same org, so a cross-org
+    # caller cannot reach them otherwise. All optional: an unset secret falls
+    # back to the `|| vars.* || ''` chain in the job `env`. Mirrors the
+    # declaration in `rainix-sol.yaml`.
+    secrets:
+      PRIVATE_KEY:
+        required: false
+      CACHIX_AUTH_TOKEN:
+        required: false
+      EXPLORER_VERIFICATION_KEY:
+        required: false
+      RPC_URL_ARBITRUM_FORK:
+        required: false
+      RPC_URL_BASE_FORK:
+        required: false
+      RPC_URL_BASE_SEPOLIA_FORK:
+        required: false
+      RPC_URL_FLARE_FORK:
+        required: false
+      RPC_URL_POLYGON_FORK:
+        required: false
+      CI_DEPLOY_ARBITRUM_ETHERSCAN_API_KEY:
+        required: false
+      CI_DEPLOY_BASE_ETHERSCAN_API_KEY:
+        required: false
+      CI_DEPLOY_BASE_SEPOLIA_ETHERSCAN_API_KEY:
+        required: false
+      CI_DEPLOY_POLYGON_ETHERSCAN_API_KEY:
+        required: false
+      CI_DEPLOY_FLARE_ETHERSCAN_API_KEY:
+        required: false
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

`rainix-manual-sol-artifacts.yaml` reads `${{ secrets.PRIVATE_KEY }}` (→ `DEPLOYMENT_KEY`) and the RPC / explorer / cachix secrets directly in its deploy step, but its `on.workflow_call` block declared **only `inputs.suite`** — no `secrets:`. That works for **same-org** callers using `secrets: inherit`, but **`secrets: inherit` does not forward a caller's org secrets across organizations**. A cross-org caller (e.g. `S01-Issuer/st0x.deploy`) therefore got an **empty** `PRIVATE_KEY` → empty `DEPLOYMENT_KEY` → `forge script` reverted at `vm.envUint("DEPLOYMENT_KEY")` before broadcasting any transaction.

## Fix

Declare the consumed secrets under `on.workflow_call.secrets` (all `required: false`), mirroring the existing declaration in `rainix-sol.yaml`, so cross-org callers can pass them explicitly.

**Backward-compatible:** same-org callers using `secrets: inherit` (e.g. rain.vats) are unaffected — `inherit` still forwards everything, and all entries are optional with the existing `|| vars.* || ''` fallbacks intact.

## Consumer follow-up

`S01-Issuer/st0x.deploy`'s `manual-sol-artifacts.yaml` switches from `secrets: inherit` to explicit passing once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the manual artifact workflow to accept a broader set of optional secrets when called externally.
  * Improved compatibility for cross-organization and automated callers by making network and verification credentials available through the workflow interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->