### PR TITLE
fix(ci): authenticate nix github flake fetches to stop 429 rate-limiting

### DIFF
--- a/.github/actions/nix-cachix-setup/action.yml
+++ b/.github/actions/nix-cachix-setup/action.yml
@@ -49,6 +49,10 @@ runs:
         nix_conf: |
           keep-env-derivations = true
           keep-outputs = true
+          # Authenticate nix GitHub API calls (flake resolution) so they
+          # use the run token rate limit (~1000/hr) instead of the
+          # unauthenticated 60/hr/IP cap, which 429s under CI bursts.
+          access-tokens = github.com=${{ github.token }}
     # Substitute prebuilt rainix derivations from the shared Cachix binary
     # cache instead of rebuilding toolchain crates from source (rainix#196).
     # Pushes new paths when the auth token is set; continue-on-error so a


### PR DESCRIPTION
## Problem
Every rainix reusable workflow runs `nix develop github:rainlanguage/rainix#<shell>`, which resolves the flake HEAD via an **unauthenticated** GitHub API call (`api.github.com/repos/rainlanguage/rainix/commits/HEAD`), capped at **60 req/hour/IP**. Under CI bursts — concurrent runs, the st0x V4 deploy rollout, the issue→PR cron — the cap blows and the run dies early with:

```
error: unable to download 'https://api.github.com/repos/rainlanguage/rainix/commits/HEAD': HTTP error 429
```

This is the recurring transient red papered over with empty "429 retrigger" commits across the org.

## Fix
Add `access-tokens = github.com=\${{ github.token }}` to the `nix_conf` of the shared `nix-cachix-setup` composite, so nix authenticates its GitHub API calls with the run token — raising the limit from 60/hr to ~1000/hr and eliminating the 429.

`github.token` is the **automatic per-run GITHUB_TOKEN**, not a secret, so it is present in every run (including cross-org reusable calls from consumers like S01-Issuer) with no `secrets:` plumbing, and only needs public-repo read to fetch the public rainix flake. Single-sourced in the preamble, so it fixes the 429 for **every** reusable in one place. Low risk: worst case it is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)