### PR TITLE
fix(ci): plumb github-token cross-org so the flake-fetch 429 fix works

### DIFF
--- a/.github/actions/nix-cachix-setup/action.yml
+++ b/.github/actions/nix-cachix-setup/action.yml
@@ -26,6 +26,16 @@ inputs:
       Optional `gc-max-store-size-macos` for the bundled cache-nix-action. Left empty (the action's own default) unless a caller needs to cap the macOS store before saving.
     required: false
     default: ''
+  github-token:
+    description: >-
+      GitHub token used to authenticate nix's GitHub API calls (flake
+      resolution), so they use the run-token rate limit (~1000/hr) instead of
+      the unauthenticated 60/hr/IP cap that 429s under CI bursts. `github.token`
+      does NOT populate inside a composite invoked across the org boundary, so a
+      cross-org reusable caller MUST pass its own `${{ github.token }}` here;
+      same-org callers may omit it and fall back to the composite's own token.
+    required: false
+    default: ''
 runs:
   using: composite
   steps:
@@ -52,7 +62,7 @@ runs:
           # Authenticate nix GitHub API calls (flake resolution) so they
           # use the run token rate limit (~1000/hr) instead of the
           # unauthenticated 60/hr/IP cap, which 429s under CI bursts.
-          access-tokens = github.com=${{ github.token }}
+          access-tokens = github.com=${{ inputs.github-token || github.token }}
     # Substitute prebuilt rainix derivations from the shared Cachix binary
     # cache instead of rebuilding toolchain crates from source (rainix#196).
     # Pushes new paths when the auth token is set; continue-on-error so a

--- a/.github/workflows/rainix-autopublish.yaml
+++ b/.github/workflows/rainix-autopublish.yaml
@@ -65,6 +65,7 @@ jobs:
       - uses: rainlanguage/rainix/.github/actions/nix-cachix-setup@main
         with:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          github-token: ${{ github.token }}
           checkout: 'false'
       # Resolve the crate list once (crates, else the back-compat singular crate).
       - name: Resolve crates

--- a/.github/workflows/rainix-copy-artifacts.yaml
+++ b/.github/workflows/rainix-copy-artifacts.yaml
@@ -11,6 +11,7 @@ jobs:
       - uses: rainlanguage/rainix/.github/actions/nix-cachix-setup@main
         with:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          github-token: ${{ github.token }}
       # No Foundry build cache here on purpose: this is a clean-build determinism
       # check, so out/ must be regenerated fresh — and caching only cache/ (not
       # out/) gives no real speedup, since forge recompiles to rebuild the

--- a/.github/workflows/rainix-manual-sol-artifacts.yaml
+++ b/.github/workflows/rainix-manual-sol-artifacts.yaml
@@ -51,6 +51,7 @@ jobs:
       - uses: rainlanguage/rainix/.github/actions/nix-cachix-setup@main
         with:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          github-token: ${{ github.token }}
       # Cache Foundry's incremental compilation cache + artifacts so unchanged
       # contracts aren't recompiled (forge build is the dominant CI cost).
       - name: Cache Foundry build

--- a/.github/workflows/rainix-rs-static.yaml
+++ b/.github/workflows/rainix-rs-static.yaml
@@ -13,6 +13,7 @@ jobs:
       - uses: rainlanguage/rainix/.github/actions/nix-cachix-setup@main
         with:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          github-token: ${{ github.token }}
       - uses: rainlanguage/rainix/.github/actions/rust-cache@main
       - run: nix develop github:rainlanguage/rainix#rust-shell -c rainix-rs-static
       # Run the rainix pre-commit hook bundle (taplo, the nix hooks, yamlfmt,

--- a/.github/workflows/rainix-rs-test.yaml
+++ b/.github/workflows/rainix-rs-test.yaml
@@ -16,6 +16,7 @@ jobs:
       - uses: rainlanguage/rainix/.github/actions/nix-cachix-setup@main
         with:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          github-token: ${{ github.token }}
           gc-max-store-size-macos: 1G
       - uses: rainlanguage/rainix/.github/actions/rust-cache@main
       - run: nix develop github:rainlanguage/rainix#rust-shell -c cargo test

--- a/.github/workflows/rainix-rs-wasm-test.yaml
+++ b/.github/workflows/rainix-rs-wasm-test.yaml
@@ -11,5 +11,6 @@ jobs:
       - uses: rainlanguage/rainix/.github/actions/nix-cachix-setup@main
         with:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          github-token: ${{ github.token }}
       - uses: rainlanguage/rainix/.github/actions/rust-cache@main
       - run: nix develop github:rainlanguage/rainix#rust-shell -c bash -c "CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=wasm-bindgen-test-runner cargo test --target wasm32-unknown-unknown --workspace"

--- a/.github/workflows/rainix-rs-wasm.yaml
+++ b/.github/workflows/rainix-rs-wasm.yaml
@@ -11,5 +11,6 @@ jobs:
       - uses: rainlanguage/rainix/.github/actions/nix-cachix-setup@main
         with:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          github-token: ${{ github.token }}
       - uses: rainlanguage/rainix/.github/actions/rust-cache@main
       - run: nix develop github:rainlanguage/rainix#rust-shell -c cargo build -r --target wasm32-unknown-unknown --lib --workspace

--- a/.github/workflows/rainix-sol-legal.yaml
+++ b/.github/workflows/rainix-sol-legal.yaml
@@ -11,6 +11,7 @@ jobs:
       - uses: rainlanguage/rainix/.github/actions/nix-cachix-setup@main
         with:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          github-token: ${{ github.token }}
       - name: Install soldeer dependencies
         if: hashFiles('soldeer.lock') != ''
         run: nix develop github:rainlanguage/rainix#sol-shell -c forge soldeer install

--- a/.github/workflows/rainix-sol-static.yaml
+++ b/.github/workflows/rainix-sol-static.yaml
@@ -11,6 +11,7 @@ jobs:
       - uses: rainlanguage/rainix/.github/actions/nix-cachix-setup@main
         with:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          github-token: ${{ github.token }}
       # Cache Foundry's incremental compilation cache + artifacts so unchanged
       # contracts aren't recompiled (forge build is the dominant CI cost).
       - name: Cache Foundry build

--- a/.github/workflows/rainix-sol-test.yaml
+++ b/.github/workflows/rainix-sol-test.yaml
@@ -40,6 +40,7 @@ jobs:
       - uses: rainlanguage/rainix/.github/actions/nix-cachix-setup@main
         with:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          github-token: ${{ github.token }}
       # Cache Foundry's incremental compilation cache + artifacts so unchanged
       # contracts aren't recompiled (forge build is the dominant CI cost).
       - name: Cache Foundry build

--- a/.github/workflows/rainix-subgraph-test.yaml
+++ b/.github/workflows/rainix-subgraph-test.yaml
@@ -11,4 +11,5 @@ jobs:
       - uses: rainlanguage/rainix/.github/actions/nix-cachix-setup@main
         with:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          github-token: ${{ github.token }}
       - run: nix develop github:rainlanguage/rainix#subgraph-shell -c subgraph-test

--- a/.github/workflows/rainix-vercel.yaml
+++ b/.github/workflows/rainix-vercel.yaml
@@ -82,6 +82,7 @@ jobs:
       - uses: rainlanguage/rainix/.github/actions/nix-cachix-setup@main
         with:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          github-token: ${{ github.token }}
           checkout: 'false'
       - uses: rainlanguage/rainix/.github/actions/rust-cache@main
         with:


### PR DESCRIPTION
## Problem

#239 added `access-tokens = github.com=${{ github.token }}` to the shared `nix-cachix-setup` preamble, but the 429 **persisted for cross-org consumers** — S01-Issuer's st0x deploy 429'd again ~40 min after #239 merged. Root cause: `${{ github.token }}` evaluates to **empty inside a composite invoked across the org boundary**, so the access-token line was effectively `github.com=` (no token) and the rainix flake fetch stayed unauthenticated.

## Fix

Add a `github-token` input to the composite and use `access-tokens = github.com=${{ inputs.github-token || github.token }}` — the explicit input wins, bare `${{ github.token }}` is the same-org fallback. The **12 cross-org reusables** pass `github-token: ${{ github.token }}` (which **is** populated in the reusable workflow's own context, unlike the composite's); `check-shell.yml` + `test.yml` (rainix's own same-org CI) omit it and ride the fallback. Consumers need no change — they already get a run token automatically.

Builds on #239.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for passing a GitHub token into the shared CI setup.
  * Updated multiple workflows to provide the built-in token during setup, improving reliability for GitHub API access in automated runs.

* **Bug Fixes**
  * Reduced the chance of rate-limit issues during dependency resolution in CI, especially across repository boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->