### PR TITLE
fix(ci): restore nix-cachix-setup load (template-validation regression from #240)

### DIFF
--- a/.github/actions/nix-cachix-setup/action.yml
+++ b/.github/actions/nix-cachix-setup/action.yml
@@ -32,7 +32,7 @@ inputs:
       resolution), so they use the run-token rate limit (~1000/hr) instead of
       the unauthenticated 60/hr/IP cap that 429s under CI bursts. `github.token`
       does NOT populate inside a composite invoked across the org boundary, so a
-      cross-org reusable caller MUST pass its own `${{ github.token }}` here;
+      cross-org reusable caller MUST pass its own `github.token` here;
       same-org callers may omit it and fall back to the composite's own token.
     required: false
     default: ''
@@ -62,7 +62,7 @@ runs:
           # Authenticate nix GitHub API calls (flake resolution) so they
           # use the run token rate limit (~1000/hr) instead of the
           # unauthenticated 60/hr/IP cap, which 429s under CI bursts.
-          access-tokens = github.com=${{ inputs.github-token || github.token }}
+          access-tokens = github.com=${{ inputs["github-token"] || github.token }}
     # Substitute prebuilt rainix derivations from the shared Cachix binary
     # cache instead of rebuilding toolchain crates from source (rainix#196).
     # Pushes new paths when the auth token is set; continue-on-error so a


### PR DESCRIPTION
## Problem (regression from #240)

#240's `github-token` input description contained a literal `${{ github.token }}`. GitHub's action-metadata template parser **evaluates expressions even inside `description:` text**, and the `github` context doesn't exist there — so `nix-cachix-setup/action.yml` failed to load with:

```
TemplateValidationException … (Line: 30, Col: 18): Unrecognized named-value: 'github' … expression: github.token
```

That broke **every** workflow using the shared preamble, org-wide (observed on the st0x deploy and any consumer CI).

## Fix

1. Strip the `${{ }}` wrapper from the description text (plain `github.token`).
2. Use bracket notation `inputs["github-token"]` on the access-tokens line, avoiding any dot-hyphen ambiguity.

The access-tokens step expression (`github.token` in a step `with:`) is valid and unchanged in spirit — only the description and the input-reference syntax are corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
