### PR TITLE
fix(ci): restore nix-cachix-setup load — dot notation for github-token input

### DIFF
--- a/.github/actions/nix-cachix-setup/action.yml
+++ b/.github/actions/nix-cachix-setup/action.yml
@@ -62,7 +62,7 @@ runs:
           # Authenticate nix GitHub API calls (flake resolution) so they
           # use the run token rate limit (~1000/hr) instead of the
           # unauthenticated 60/hr/IP cap, which 429s under CI bursts.
-          access-tokens = github.com=${{ inputs["github-token"] || github.token }}
+          access-tokens = github.com=${{ inputs.github-token || github.token }}
     # Substitute prebuilt rainix derivations from the shared Cachix binary
     # cache instead of rebuilding toolchain crates from source (rainix#196).
     # Pushes new paths when the auth token is set; continue-on-error so a


### PR DESCRIPTION
## Problem (regression from #241)

#241 fixed the description but changed the access-tokens input reference to bracket notation with **double quotes** — `inputs["github-token"]` — which GHA expressions reject:

```
TemplateValidationException … (Line: 59): Unexpected symbol: '"github-token"' … expression: inputs["github-token"] || github.token
```

So `nix-cachix-setup` still failed to load org-wide.

## Fix

Use **dot notation** `inputs.github-token` — identical to the existing, production-proven `inputs.cachix-auth-token` and `inputs.gc-max-store-size-macos` references in the same file (GHA resolves hyphenated input names this way here). All `${{ }}` expressions in the action were re-verified.

Restores `nix-cachix-setup` load; the cross-org token plumbing from #240 is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
