### PR TITLE
chore(ci): temporary token-wiring debug (log lengths only)

### DIFF
--- a/.github/actions/nix-cachix-setup/action.yml
+++ b/.github/actions/nix-cachix-setup/action.yml
@@ -63,6 +63,14 @@ runs:
           # use the run token rate limit (~1000/hr) instead of the
           # unauthenticated 60/hr/IP cap, which 429s under CI bursts.
           access-tokens = github.com=${{ inputs.github-token || github.token }}
+    # TEMPORARY: log token lengths (never values) to diagnose the cross-org
+    # flake-fetch 429. Remove once the wiring is confirmed.
+    - name: Debug token wiring
+      shell: bash
+      env:
+        INPUT_TOK: ${{ inputs.github-token }}
+        BARE_TOK: ${{ github.token }}
+      run: echo "WIRING inputs.github-token len=${#INPUT_TOK} bare-github.token len=${#BARE_TOK}"
     # Substitute prebuilt rainix derivations from the shared Cachix binary
     # cache instead of rebuilding toolchain crates from source (rainix#196).
     # Pushes new paths when the auth token is set; continue-on-error so a


### PR DESCRIPTION
Temporary debug to diagnose the persistent cross-org flake-fetch 429 despite the github-token plumbing from #240/#242. Adds one step to nix-cachix-setup that logs the LENGTHS (never values) of inputs.github-token (what the plumbing delivers) and bare github.token (cross-org-empty hypothesis). Will be reverted once the wiring is confirmed.