### PR TITLE
fix(ci): pin rainix flake rev in deploy reusable to avoid api.github.com 429

### DIFF
--- a/.github/workflows/rainix-manual-sol-artifacts.yaml
+++ b/.github/workflows/rainix-manual-sol-artifacts.yaml
@@ -65,9 +65,9 @@ jobs:
             foundry-full-${{ runner.os }}-
       - name: Install soldeer dependencies
         if: hashFiles('soldeer.lock') != ''
-        run: nix develop github:rainlanguage/rainix#sol-shell -c forge soldeer install
-      - run: nix develop github:rainlanguage/rainix#sol-shell -c forge selectors up --all
-      - run: nix develop github:rainlanguage/rainix#sol-shell -c forge script script/Deploy.sol:Deploy -vvvvv --slow --broadcast --verify
+        run: nix develop github:rainlanguage/rainix/307bf27fcc5a410994f5a6a6a96527a64625c3da#sol-shell -c forge soldeer install
+      - run: nix develop github:rainlanguage/rainix/307bf27fcc5a410994f5a6a6a96527a64625c3da#sol-shell -c forge selectors up --all
+      - run: nix develop github:rainlanguage/rainix/307bf27fcc5a410994f5a6a6a96527a64625c3da#sol-shell -c forge script script/Deploy.sol:Deploy -vvvvv --slow --broadcast --verify
         env:
           DEPLOYMENT_SUITE: ${{ inputs.suite }}
           DEPLOYMENT_KEY: ${{ secrets.PRIVATE_KEY }}


### PR DESCRIPTION
## Problem

`nix develop github:rainlanguage/rainix#sol-shell` resolves the flake's HEAD via `https://api.github.com/repos/rainlanguage/rainix/commits/HEAD`. Under CI bursts GitHub **burst/secondary rate-limits** that call (429) — and once authenticated it returns a **gzip-compressed** rate-limit body that nix-2.24.12 fails to decompress, surfacing as `json.exception.parse_error.101 … invalid literal … '<U+001F>'`. This has been the recurring org-wide nix CI flake.

**Auth does not fix it.** Verified directly: setting `access-tokens` via `NIX_CONFIG` *does* apply the token (`nix config show` lists it), but the `commits/HEAD` fetch still fails — it's a burst limit, not a missing credential.

## Fix

Pin the flake refs to a full commit sha. With an explicit rev, nix **skips the `commits/HEAD` api.github.com resolution entirely** and pulls the tarball directly (codeload, far higher limits). Pins all three `nix develop` calls in the deploy reusable to `307bf27fcc5a410994f5a6a6a96527a64625c3da` (current `main`).

## Confirmed

A deploy run on this branch got past **every** flake-fetch step (`forge soldeer install`, `forge selectors up`, into `forge script Deploy`) with zero 429/gzip errors — it now reaches the actual deploy logic. (It stops at an unrelated base-RPC dependency check.)

## Notes

- This pins the deploy toolchain to `307bf27f`; bump the sha when the rainix toolchain changes. For a deploy reusable a stable, pinned toolchain is desirable (reproducible deploys).
- The same pin should roll to the other reusables (`rainix-sol-test`, `rainix-rs-test`, etc.) for the full org-wide 429 fix — follow-up, weighed against wanting CI to track the current toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow steps to use a fixed Rainix source reference for more consistent artifact builds and verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->