### PR TITLE
chore(ci): remove the no-op nix access-tokens experiment (#239-#243)

### DIFF
--- a/.github/actions/nix-cachix-setup/action.yml
+++ b/.github/actions/nix-cachix-setup/action.yml
@@ -26,16 +26,6 @@ inputs:
       Optional `gc-max-store-size-macos` for the bundled cache-nix-action. Left empty (the action's own default) unless a caller needs to cap the macOS store before saving.
     required: false
     default: ''
-  github-token:
-    description: >-
-      GitHub token used to authenticate nix's GitHub API calls (flake
-      resolution), so they use the run-token rate limit (~1000/hr) instead of
-      the unauthenticated 60/hr/IP cap that 429s under CI bursts. `github.token`
-      does NOT populate inside a composite invoked across the org boundary, so a
-      cross-org reusable caller MUST pass its own `github.token` here;
-      same-org callers may omit it and fall back to the composite's own token.
-    required: false
-    default: ''
 runs:
   using: composite
   steps:
@@ -59,18 +49,6 @@ runs:
         nix_conf: |
           keep-env-derivations = true
           keep-outputs = true
-          # Authenticate nix GitHub API calls (flake resolution) so they
-          # use the run token rate limit (~1000/hr) instead of the
-          # unauthenticated 60/hr/IP cap, which 429s under CI bursts.
-          access-tokens = github.com=${{ inputs.github-token || github.token }}
-    # TEMPORARY: log token lengths (never values) to diagnose the cross-org
-    # flake-fetch 429. Remove once the wiring is confirmed.
-    - name: Debug token wiring
-      shell: bash
-      env:
-        INPUT_TOK: ${{ inputs.github-token }}
-        BARE_TOK: ${{ github.token }}
-      run: echo "WIRING inputs.github-token len=${#INPUT_TOK} bare-github.token len=${#BARE_TOK}"
     # Substitute prebuilt rainix derivations from the shared Cachix binary
     # cache instead of rebuilding toolchain crates from source (rainix#196).
     # Pushes new paths when the auth token is set; continue-on-error so a

--- a/.github/workflows/rainix-autopublish.yaml
+++ b/.github/workflows/rainix-autopublish.yaml
@@ -65,7 +65,6 @@ jobs:
       - uses: rainlanguage/rainix/.github/actions/nix-cachix-setup@main
         with:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          github-token: ${{ github.token }}
           checkout: 'false'
       # Resolve the crate list once (crates, else the back-compat singular crate).
       - name: Resolve crates

--- a/.github/workflows/rainix-copy-artifacts.yaml
+++ b/.github/workflows/rainix-copy-artifacts.yaml
@@ -11,7 +11,6 @@ jobs:
       - uses: rainlanguage/rainix/.github/actions/nix-cachix-setup@main
         with:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          github-token: ${{ github.token }}
       # No Foundry build cache here on purpose: this is a clean-build determinism
       # check, so out/ must be regenerated fresh — and caching only cache/ (not
       # out/) gives no real speedup, since forge recompiles to rebuild the

--- a/.github/workflows/rainix-manual-sol-artifacts.yaml
+++ b/.github/workflows/rainix-manual-sol-artifacts.yaml
@@ -51,7 +51,6 @@ jobs:
       - uses: rainlanguage/rainix/.github/actions/nix-cachix-setup@main
         with:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          github-token: ${{ github.token }}
       # Cache Foundry's incremental compilation cache + artifacts so unchanged
       # contracts aren't recompiled (forge build is the dominant CI cost).
       - name: Cache Foundry build

--- a/.github/workflows/rainix-rs-static.yaml
+++ b/.github/workflows/rainix-rs-static.yaml
@@ -13,7 +13,6 @@ jobs:
       - uses: rainlanguage/rainix/.github/actions/nix-cachix-setup@main
         with:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          github-token: ${{ github.token }}
       - uses: rainlanguage/rainix/.github/actions/rust-cache@main
       - run: nix develop github:rainlanguage/rainix#rust-shell -c rainix-rs-static
       # Run the rainix pre-commit hook bundle (taplo, the nix hooks, yamlfmt,

--- a/.github/workflows/rainix-rs-test.yaml
+++ b/.github/workflows/rainix-rs-test.yaml
@@ -16,7 +16,6 @@ jobs:
       - uses: rainlanguage/rainix/.github/actions/nix-cachix-setup@main
         with:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          github-token: ${{ github.token }}
           gc-max-store-size-macos: 1G
       - uses: rainlanguage/rainix/.github/actions/rust-cache@main
       - run: nix develop github:rainlanguage/rainix#rust-shell -c cargo test

--- a/.github/workflows/rainix-rs-wasm-test.yaml
+++ b/.github/workflows/rainix-rs-wasm-test.yaml
@@ -11,6 +11,5 @@ jobs:
       - uses: rainlanguage/rainix/.github/actions/nix-cachix-setup@main
         with:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          github-token: ${{ github.token }}
       - uses: rainlanguage/rainix/.github/actions/rust-cache@main
       - run: nix develop github:rainlanguage/rainix#rust-shell -c bash -c "CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=wasm-bindgen-test-runner cargo test --target wasm32-unknown-unknown --workspace"

--- a/.github/workflows/rainix-rs-wasm.yaml
+++ b/.github/workflows/rainix-rs-wasm.yaml
@@ -11,6 +11,5 @@ jobs:
       - uses: rainlanguage/rainix/.github/actions/nix-cachix-setup@main
         with:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          github-token: ${{ github.token }}
       - uses: rainlanguage/rainix/.github/actions/rust-cache@main
       - run: nix develop github:rainlanguage/rainix#rust-shell -c cargo build -r --target wasm32-unknown-unknown --lib --workspace

--- a/.github/workflows/rainix-sol-legal.yaml
+++ b/.github/workflows/rainix-sol-legal.yaml
@@ -11,7 +11,6 @@ jobs:
       - uses: rainlanguage/rainix/.github/actions/nix-cachix-setup@main
         with:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          github-token: ${{ github.token }}
       - name: Install soldeer dependencies
         if: hashFiles('soldeer.lock') != ''
         run: nix develop github:rainlanguage/rainix#sol-shell -c forge soldeer install

--- a/.github/workflows/rainix-sol-static.yaml
+++ b/.github/workflows/rainix-sol-static.yaml
@@ -11,7 +11,6 @@ jobs:
       - uses: rainlanguage/rainix/.github/actions/nix-cachix-setup@main
         with:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          github-token: ${{ github.token }}
       # Cache Foundry's incremental compilation cache + artifacts so unchanged
       # contracts aren't recompiled (forge build is the dominant CI cost).
       - name: Cache Foundry build

--- a/.github/workflows/rainix-sol-test.yaml
+++ b/.github/workflows/rainix-sol-test.yaml
@@ -40,7 +40,6 @@ jobs:
       - uses: rainlanguage/rainix/.github/actions/nix-cachix-setup@main
         with:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          github-token: ${{ github.token }}
       # Cache Foundry's incremental compilation cache + artifacts so unchanged
       # contracts aren't recompiled (forge build is the dominant CI cost).
       - name: Cache Foundry build

--- a/.github/workflows/rainix-subgraph-test.yaml
+++ b/.github/workflows/rainix-subgraph-test.yaml
@@ -11,5 +11,4 @@ jobs:
       - uses: rainlanguage/rainix/.github/actions/nix-cachix-setup@main
         with:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          github-token: ${{ github.token }}
       - run: nix develop github:rainlanguage/rainix#subgraph-shell -c subgraph-test

--- a/.github/workflows/rainix-vercel.yaml
+++ b/.github/workflows/rainix-vercel.yaml
@@ -82,7 +82,6 @@ jobs:
       - uses: rainlanguage/rainix/.github/actions/nix-cachix-setup@main
         with:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-          github-token: ${{ github.token }}
           checkout: 'false'
       - uses: rainlanguage/rainix/.github/actions/rust-cache@main
         with:


### PR DESCRIPTION
## What

Pure deletion (34 lines, 13 files) removing the **no-op nix access-tokens experiment** from #239–#243, now that pinning the flake rev (#245, merged) is the real fix for the org-wide nix CI 429.

Removes from `.github/actions/nix-cachix-setup/action.yml`:
- the `github-token` composite **input**,
- the `access-tokens = github.com=…` line in nix-quick-install's `nix_conf`,
- the temporary **"Debug token wiring"** step;

and the `github-token: ${{ github.token }}` plumbing line from the **12 reusables** that passed it (autopublish, copy-artifacts, manual-sol-artifacts, rs-static, rs-test, rs-wasm-test, rs-wasm, sol-legal, sol-static, sol-test, subgraph-test, vercel).

## Why it's safe (no behavior change)

The access-tokens approach was proven a **no-op**: the `access-tokens` line never landed in the effective `/etc/nix/nix.conf`, and even forced in via `NIX_CONFIG` the fetch still 429'd — it's GitHub's **secondary/burst** rate-limit on the flake `commits/HEAD` resolution, which authentication can't bypass. So removing it changes nothing at runtime.

- `github-token` was purely **internal** reusable→composite plumbing — never a `workflow_call` input — so no downstream consumer repo passed it, and none can break.
- The two callers not touched here (`check-shell.yml`, `test.yml`) never passed it.
- The legitimate `github-token` usages — `gh-release`'s own input and autopublish passing `secrets.GITHUB_TOKEN` to the release step — are untouched.

Verified by independent adversarial review across completeness, consumer-safety, and structural-correctness — all clean; `git diff` is zero insertions.

## Not included (separate decision)

The other 10 reusables still carry unpinned `github:rainlanguage/rainix#sol-shell` refs and remain subject to the intermittent 429 (exactly as before this experiment). Pinning them like #245 did for the deploy reusable is the durable org-wide fix — left out here because it trades off against test CI tracking the current toolchain. Happy to open that as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
