### PR TITLE
chore(ci): pin rainix flake rev org-wide (kill the api.github.com 429 across all reusables)

### DIFF
--- a/.github/workflows/rainix-autopublish.yaml
+++ b/.github/workflows/rainix-autopublish.yaml
@@ -123,7 +123,7 @@ jobs:
             # until that sibling is published — chicken-and-egg. If packaging
             # fails, treat the crate as changed and let the dependency-ordered
             # publish step sort it out (the sibling publishes first).
-            if ! nix develop github:rainlanguage/rainix#rust-shell -c cargo package -p "$CRATE" --allow-dirty --no-verify --quiet; then
+            if ! nix develop github:rainlanguage/rainix/307bf27fcc5a410994f5a6a6a96527a64625c3da#rust-shell -c cargo package -p "$CRATE" --allow-dirty --no-verify --quiet; then
               echo "gate $CRATE: cannot package yet (likely an unpublished intra-workspace dep) -> changed"
               changed=true
               continue
@@ -152,7 +152,7 @@ jobs:
         if: ${{ inputs.npm-package != '' }}
         id: npm
         run: |
-          nix develop github:rainlanguage/rainix#rust-node-shell -c bash -c '
+          nix develop github:rainlanguage/rainix/307bf27fcc5a410994f5a6a6a96527a64625c3da#rust-node-shell -c bash -c '
             OLD=$(npm view ${{ inputs.npm-package }}@latest dist.shasum 2>/dev/null || echo "none")
             NEW=$(npm pack --silent | xargs shasum | cut -c1-40)
             rm -f *.tgz
@@ -191,7 +191,7 @@ jobs:
           LOCAL=$(awk -F\" '/^version[[:space:]]*=/ { print $2; exit }' foundry.toml)
           # Local package content: dry-run writes <cwd-basename>.zip into the cwd.
           rm -f ./*.zip
-          nix develop github:rainlanguage/rainix#sol-shell -c forge soldeer push "$PKG~$LOCAL" --dry-run
+          nix develop github:rainlanguage/rainix/307bf27fcc5a410994f5a6a6a96527a64625c3da#sol-shell -c forge soldeer push "$PKG~$LOCAL" --dry-run
           NEW=$(nh "$(ls -t ./*.zip | head -1)"); rm -f ./*.zip
           if [ -z "$URL" ] || [ "$REMOTE" = "none" ]; then OLD="none"; else
             curl -fsSL "$URL" -o /tmp/soldeer_pub.zip; OLD=$(nh /tmp/soldeer_pub.zip); fi
@@ -217,7 +217,7 @@ jobs:
       # gate on the exact merged commit.
       - name: Cargo test
         if: ${{ (inputs.crates != '' || inputs.crate != '') && (steps.cargo.outputs.changed == 'true' || steps.npm.outputs.changed == 'true' || steps.soldeer.outputs.changed == 'true') }}
-        run: nix develop github:rainlanguage/rainix#rust-shell -c cargo test --workspace
+        run: nix develop github:rainlanguage/rainix/307bf27fcc5a410994f5a6a6a96527a64625c3da#rust-shell -c cargo test --workspace
       # Bump versions. One cargo-release invocation bumps every listed crate and
       # rewrites their inter-crate version pins atomically in one commit.
       #
@@ -233,12 +233,12 @@ jobs:
           set -euo pipefail
           PKGS=""
           for CRATE in $CRATES; do PKGS="$PKGS -p $CRATE"; done
-          nix develop github:rainlanguage/rainix#rust-shell -c cargo release --no-confirm --execute --no-tag --no-push --no-publish $PKGS ${{ inputs.level }}
+          nix develop github:rainlanguage/rainix/307bf27fcc5a410994f5a6a6a96527a64625c3da#rust-shell -c cargo release --no-confirm --execute --no-tag --no-push --no-publish $PKGS ${{ inputs.level }}
           git commit --amend -m "Package Release: cargo version bump ($CRATES)"
       - name: Bump NPM version
         if: ${{ inputs.npm-package != '' && steps.npm.outputs.changed == 'true' }}
         run: |
-          NEW=$(nix develop github:rainlanguage/rainix#rust-node-shell -c npm version patch --no-git-tag-version)
+          NEW=$(nix develop github:rainlanguage/rainix/307bf27fcc5a410994f5a6a6a96527a64625c3da#rust-node-shell -c npm version patch --no-git-tag-version)
           echo "NPM_VERSION=$NEW" >> $GITHUB_ENV
           git add package.json package-lock.json
           git commit -m "Package Release npm-${NEW}"
@@ -270,13 +270,13 @@ jobs:
           set -euo pipefail
           git fetch origin
           if ! git rebase "origin/${{ github.ref_name }}"; then
-            nix develop github:rainlanguage/rainix#rust-shell -c cargo generate-lockfile
+            nix develop github:rainlanguage/rainix/307bf27fcc5a410994f5a6a6a96527a64625c3da#rust-shell -c cargo generate-lockfile
             git add Cargo.lock
             GIT_EDITOR=true git rebase --continue
           fi
           if [ "${{ steps.cargo.outputs.changed }}" = "true" ]; then
             for CRATE in $CRATES; do
-              VER=$(nix develop github:rainlanguage/rainix#rust-shell -c cargo pkgid -p "$CRATE" | cut -d@ -f2)
+              VER=$(nix develop github:rainlanguage/rainix/307bf27fcc5a410994f5a6a6a96527a64625c3da#rust-shell -c cargo pkgid -p "$CRATE" | cut -d@ -f2)
               git tag "$CRATE-v$VER"
             done
           fi
@@ -288,7 +288,7 @@ jobs:
       - name: NPM pack
         if: ${{ inputs.npm-package != '' && steps.npm.outputs.changed == 'true' }}
         run: |
-          TARBALL=$(nix develop github:rainlanguage/rainix#rust-node-shell -c npm pack --silent)
+          TARBALL=$(nix develop github:rainlanguage/rainix/307bf27fcc5a410994f5a6a6a96527a64625c3da#rust-node-shell -c npm pack --silent)
           mv "$TARBALL" npm_package_${{ env.NPM_VERSION }}.tgz
       # Publishes. Crates publish in dependency order so each crate's deps are
       # already on the registry when it publishes.
@@ -297,7 +297,7 @@ jobs:
         run: |
           set -euo pipefail
           for CRATE in $CRATES; do
-            nix develop github:rainlanguage/rainix#rust-shell -c cargo publish -p "$CRATE"
+            nix develop github:rainlanguage/rainix/307bf27fcc5a410994f5a6a6a96527a64625c3da#rust-shell -c cargo publish -p "$CRATE"
           done
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
@@ -312,14 +312,14 @@ jobs:
         if: ${{ inputs.soldeer-package != '' && steps.soldeer.outputs.changed == 'true' }}
         env:
           SOLDEER_API_TOKEN: ${{ secrets.SOLDEER_API_TOKEN }}
-        run: nix develop github:rainlanguage/rainix#sol-shell -c forge soldeer push "${{ inputs.soldeer-package }}~${{ steps.soldeer.outputs.next }}"
+        run: nix develop github:rainlanguage/rainix/307bf27fcc5a410994f5a6a6a96527a64625c3da#sol-shell -c forge soldeer push "${{ inputs.soldeer-package }}~${{ steps.soldeer.outputs.next }}"
       # GitHub Releases. One per crate (loop), plus npm/soldeer.
       - name: GitHub Release (cargo)
         if: ${{ steps.cargo.outputs.changed == 'true' }}
         run: |
           set -euo pipefail
           for CRATE in $CRATES; do
-            VER=$(nix develop github:rainlanguage/rainix#rust-shell -c cargo pkgid -p "$CRATE" | cut -d@ -f2)
+            VER=$(nix develop github:rainlanguage/rainix/307bf27fcc5a410994f5a6a6a96527a64625c3da#rust-shell -c cargo pkgid -p "$CRATE" | cut -d@ -f2)
             gh release create "$CRATE-v$VER" --title "$CRATE-v$VER" --notes "Automated release of $CRATE $VER." || true
           done
         env:

--- a/.github/workflows/rainix-copy-artifacts.yaml
+++ b/.github/workflows/rainix-copy-artifacts.yaml
@@ -18,7 +18,7 @@ jobs:
       # keep the cache; copy-artifacts skips the save/restore overhead.
       - name: Install soldeer dependencies
         if: hashFiles('soldeer.lock') != ''
-        run: nix develop github:rainlanguage/rainix#sol-shell -c forge soldeer install
+        run: nix develop github:rainlanguage/rainix/307bf27fcc5a410994f5a6a6a96527a64625c3da#sol-shell -c forge soldeer install
       # Currency-check every committed generated artifact by re-running each
       # consumer-provided codegen step. The final git diff fails if any
       # committed file has drifted from its source. The build-meta.sh hook is
@@ -26,15 +26,15 @@ jobs:
       # filenames, meta type) varies per repo.
       - name: Regenerate meta artifacts
         if: hashFiles('script/build-meta.sh') != ''
-        run: nix develop github:rainlanguage/rainix#sol-shell -c ./script/build-meta.sh
+        run: nix develop github:rainlanguage/rainix/307bf27fcc5a410994f5a6a6a96527a64625c3da#sol-shell -c ./script/build-meta.sh
       - name: Regenerate pointer artifacts
         if: hashFiles('script/BuildPointers.sol') != ''
-        run: nix develop github:rainlanguage/rainix#sol-shell -c forge script ./script/BuildPointers.sol
+        run: nix develop github:rainlanguage/rainix/307bf27fcc5a410994f5a6a6a96527a64625c3da#sol-shell -c forge script ./script/BuildPointers.sol
       - name: Build Solidity
-        run: nix develop github:rainlanguage/rainix#sol-shell -c forge build
+        run: nix develop github:rainlanguage/rainix/307bf27fcc5a410994f5a6a6a96527a64625c3da#sol-shell -c forge build
       - name: Copy forge artifacts into committed location
         if: hashFiles('script/CopyArtifacts.sol') != ''
-        run: nix develop github:rainlanguage/rainix#sol-shell -c forge script ./script/CopyArtifacts.sol --ffi
+        run: nix develop github:rainlanguage/rainix/307bf27fcc5a410994f5a6a6a96527a64625c3da#sol-shell -c forge script ./script/CopyArtifacts.sol --ffi
       # Catch-all post-forge regen hook: consumer-supplied. Runs outside any
       # nix devshell so the script picks shells per command (subgraph-shell,
       # sol-shell, etc.) for whatever derived artifacts it emits.
@@ -42,7 +42,7 @@ jobs:
         if: hashFiles('script/build.sh') != ''
         run: ./script/build.sh
       - name: Format (so generated artifacts match committed style)
-        run: nix develop github:rainlanguage/rainix#sol-shell -c forge fmt
+        run: nix develop github:rainlanguage/rainix/307bf27fcc5a410994f5a6a6a96527a64625c3da#sol-shell -c forge fmt
       - name: Assert committed artifacts match freshly built
         run: |
           if ! git diff --exit-code; then

--- a/.github/workflows/rainix-rs-static.yaml
+++ b/.github/workflows/rainix-rs-static.yaml
@@ -14,7 +14,7 @@ jobs:
         with:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - uses: rainlanguage/rainix/.github/actions/rust-cache@main
-      - run: nix develop github:rainlanguage/rainix#rust-shell -c rainix-rs-static
+      - run: nix develop github:rainlanguage/rainix/307bf27fcc5a410994f5a6a6a96527a64625c3da#rust-shell -c rainix-rs-static
       # Run the rainix pre-commit hook bundle (taplo, the nix hooks, yamlfmt,
       # shellcheck, rustfmt) over all files — the same hooks a local commit
       # runs. rainix-rs-static only covers rustfmt + clippy, so a file that is
@@ -24,4 +24,4 @@ jobs:
       # rather than re-paying runner setup. Reuses rust-shell, so prettier-rainix
       # (which needs the default shell's RAINIX_PRETTIER_BUNDLE_DIR) no-ops here;
       # frontend repos format svelte/ts via their own pipeline.
-      - run: nix develop github:rainlanguage/rainix#rust-shell -c pre-commit run --all-files --show-diff-on-failure --color always
+      - run: nix develop github:rainlanguage/rainix/307bf27fcc5a410994f5a6a6a96527a64625c3da#rust-shell -c pre-commit run --all-files --show-diff-on-failure --color always

--- a/.github/workflows/rainix-rs-test.yaml
+++ b/.github/workflows/rainix-rs-test.yaml
@@ -18,4 +18,4 @@ jobs:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
           gc-max-store-size-macos: 1G
       - uses: rainlanguage/rainix/.github/actions/rust-cache@main
-      - run: nix develop github:rainlanguage/rainix#rust-shell -c cargo test
+      - run: nix develop github:rainlanguage/rainix/307bf27fcc5a410994f5a6a6a96527a64625c3da#rust-shell -c cargo test

--- a/.github/workflows/rainix-rs-wasm-test.yaml
+++ b/.github/workflows/rainix-rs-wasm-test.yaml
@@ -12,4 +12,4 @@ jobs:
         with:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - uses: rainlanguage/rainix/.github/actions/rust-cache@main
-      - run: nix develop github:rainlanguage/rainix#rust-shell -c bash -c "CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=wasm-bindgen-test-runner cargo test --target wasm32-unknown-unknown --workspace"
+      - run: nix develop github:rainlanguage/rainix/307bf27fcc5a410994f5a6a6a96527a64625c3da#rust-shell -c bash -c "CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=wasm-bindgen-test-runner cargo test --target wasm32-unknown-unknown --workspace"

--- a/.github/workflows/rainix-rs-wasm.yaml
+++ b/.github/workflows/rainix-rs-wasm.yaml
@@ -12,4 +12,4 @@ jobs:
         with:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - uses: rainlanguage/rainix/.github/actions/rust-cache@main
-      - run: nix develop github:rainlanguage/rainix#rust-shell -c cargo build -r --target wasm32-unknown-unknown --lib --workspace
+      - run: nix develop github:rainlanguage/rainix/307bf27fcc5a410994f5a6a6a96527a64625c3da#rust-shell -c cargo build -r --target wasm32-unknown-unknown --lib --workspace

--- a/.github/workflows/rainix-sol-legal.yaml
+++ b/.github/workflows/rainix-sol-legal.yaml
@@ -13,5 +13,5 @@ jobs:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: Install soldeer dependencies
         if: hashFiles('soldeer.lock') != ''
-        run: nix develop github:rainlanguage/rainix#sol-shell -c forge soldeer install
-      - run: nix develop github:rainlanguage/rainix#sol-shell -c reuse lint
+        run: nix develop github:rainlanguage/rainix/307bf27fcc5a410994f5a6a6a96527a64625c3da#sol-shell -c forge soldeer install
+      - run: nix develop github:rainlanguage/rainix/307bf27fcc5a410994f5a6a6a96527a64625c3da#sol-shell -c reuse lint

--- a/.github/workflows/rainix-sol-static.yaml
+++ b/.github/workflows/rainix-sol-static.yaml
@@ -24,8 +24,8 @@ jobs:
             foundry-full-${{ runner.os }}-
       - name: Install soldeer dependencies
         if: hashFiles('soldeer.lock') != ''
-        run: nix develop github:rainlanguage/rainix#sol-shell -c forge soldeer install
-      - run: nix develop github:rainlanguage/rainix#sol-shell -c slither .
-      - run: nix develop github:rainlanguage/rainix#sol-shell -c forge fmt --check
+        run: nix develop github:rainlanguage/rainix/307bf27fcc5a410994f5a6a6a96527a64625c3da#sol-shell -c forge soldeer install
+      - run: nix develop github:rainlanguage/rainix/307bf27fcc5a410994f5a6a6a96527a64625c3da#sol-shell -c slither .
+      - run: nix develop github:rainlanguage/rainix/307bf27fcc5a410994f5a6a6a96527a64625c3da#sol-shell -c forge fmt --check
       # Enforce Rain's one-contract-per-.sol-file convention (rainix#214).
-      - run: nix develop github:rainlanguage/rainix#sol-shell -c rainix-sol-single-contract
+      - run: nix develop github:rainlanguage/rainix/307bf27fcc5a410994f5a6a6a96527a64625c3da#sol-shell -c rainix-sol-single-contract

--- a/.github/workflows/rainix-sol-test.yaml
+++ b/.github/workflows/rainix-sol-test.yaml
@@ -53,5 +53,5 @@ jobs:
             foundry-full-${{ runner.os }}-
       - name: Install soldeer dependencies
         if: hashFiles('soldeer.lock') != ''
-        run: nix develop github:rainlanguage/rainix#sol-shell -c forge soldeer install
-      - run: nix develop github:rainlanguage/rainix#sol-shell -c forge test -vvv
+        run: nix develop github:rainlanguage/rainix/307bf27fcc5a410994f5a6a6a96527a64625c3da#sol-shell -c forge soldeer install
+      - run: nix develop github:rainlanguage/rainix/307bf27fcc5a410994f5a6a6a96527a64625c3da#sol-shell -c forge test -vvv

--- a/.github/workflows/rainix-subgraph-test.yaml
+++ b/.github/workflows/rainix-subgraph-test.yaml
@@ -11,4 +11,4 @@ jobs:
       - uses: rainlanguage/rainix/.github/actions/nix-cachix-setup@main
         with:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - run: nix develop github:rainlanguage/rainix#subgraph-shell -c subgraph-test
+      - run: nix develop github:rainlanguage/rainix/307bf27fcc5a410994f5a6a6a96527a64625c3da#subgraph-shell -c subgraph-test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,26 @@ Defined in `.github/workflows/`:
 - **check-shell.yml** — verifies dev shell tools are available
 - **pr-assessment.yaml** — PR size assessment
 
+### Flake-ref pinning in reusable workflows
+
+The reusable workflows (`.github/workflows/rainix-*.yaml`) invoke the dev shells
+via `nix develop github:rainlanguage/rainix/<sha>#<devshell>` — pinned to an
+explicit commit **sha**, never the bare `github:rainlanguage/rainix#…` (HEAD)
+form. Unpinned, nix resolves HEAD through `api.github.com/.../commits/HEAD`,
+which GitHub **burst-rate-limits (429)** under CI load (the error body comes back
+gzipped and nix mis-parses it as JSON) — this was the dominant org-wide CI flake.
+A full sha makes nix skip that API call and fetch the tarball directly.
+Authenticating the call does NOT help (it's a secondary limit, not missing auth);
+pinning is the fix.
+
+**Every flake ref across every reusable shares ONE sha.** To bump the toolchain,
+find-replace the old sha with the new across `.github/workflows/*.yaml`, then
+sanity-check with `nix flake show github:rainlanguage/rainix/<new-sha>` that the
+referenced devshells (`sol-shell`, `rust-shell`, `rust-node-shell`,
+`subgraph-shell`) still resolve at it. Never add a bare unpinned
+`github:rainlanguage/rainix#…` ref — it reintroduces the 429. (Single-sourcing
+this repeated sha so a bump is one line is tracked in #248.)
+
 ## Code Style
 
 - Rust: `cargo fmt` and `cargo clippy` with all warnings denied

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,11 +95,11 @@ The reusable workflows (`.github/workflows/rainix-*.yaml`) invoke the dev shells
 via `nix develop github:rainlanguage/rainix/<sha>#<devshell>` — pinned to an
 explicit commit **sha**, never the bare `github:rainlanguage/rainix#…` (HEAD)
 form. Unpinned, nix resolves HEAD through `api.github.com/.../commits/HEAD`,
-which GitHub **burst-rate-limits (429)** under CI load (the error body comes back
-gzipped and nix mis-parses it as JSON) — this was the dominant org-wide CI flake.
-A full sha makes nix skip that API call and fetch the tarball directly.
-Authenticating the call does NOT help (it's a secondary limit, not missing auth);
-pinning is the fix.
+which GitHub **burst-rate-limits (429)** under CI load (the error body comes
+back gzipped and nix mis-parses it as JSON) — this was the dominant org-wide CI
+flake. A full sha makes nix skip that API call and fetch the tarball directly.
+Authenticating the call does NOT help (it's a secondary limit, not missing
+auth); pinning is the fix.
 
 **Every flake ref across every reusable shares ONE sha.** To bump the toolchain,
 find-replace the old sha with the new across `.github/workflows/*.yaml`, then


### PR DESCRIPTION
## What

Rolls the #245 flake-pin to the **remaining 10 reusables**, killing the org-wide nix CI 429 everywhere — not just the deploy path.

Pins all **32** `github:rainlanguage/rainix#<attr>` refs across the 10 reusables to the **same sha `307bf27f`** the deploy reusable (#245) already uses. Pure sha-insertion, no other change. After this, **all 35 rainix flake refs across all 11 reusables sit on one consistent sha.**

By devshell attr: `sol-shell` ×16, `rust-shell` ×12, `rust-node-shell` ×3, `subgraph-shell` ×1.

Files: autopublish, copy-artifacts, rs-static, rs-test, rs-wasm-test, rs-wasm, sol-legal, sol-static, sol-test, subgraph-test.

## Why

`nix develop github:rainlanguage/rainix#…` resolves HEAD via `api.github.com/.../commits/HEAD`, which GitHub burst-rate-limits (429, gzipped body nix mis-parses) — the chronic org-wide CI flake. An explicit sha makes nix skip that call and fetch the tarball directly. Authenticating the call does **not** help (proven in the #239–#243 experiment, since reverted in #246).

## Verified

- Pure sha-insertion: diff is −32/+32, every line differs only by the inserted `/<sha>`, **every devshell attr preserved**.
- **0** unpinned `github:rainlanguage/rainix#` refs remain; **0** refs on any other sha.
- All 10 changed files parse as valid YAML.
- `nix flake show github:rainlanguage/rainix/307bf27f…` confirms **all four devshells (`sol-shell`, `rust-shell`, `rust-node-shell`, `subgraph-shell`) resolve at the pinned sha** — so no reusable references a missing attr.

## Maintenance tradeoff

This pins the toolchain for all rainix CI to `307bf27f` (same as the deploy reusable). When the rainix toolchain changes, bump the sha — one find-replace of `307bf27f…` across the reusables updates all of them. Trades "test CI tracks the very latest toolchain" for "reproducible, 429-free CI"; the 429 has been the dominant CI flake. `check-shell.yml` / `test.yml` are out of scope — their flakiness is `nix flake check` on the *consumer's* flake input, not a reusable flake ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for keeping development environment references pinned in reusable workflows.
* **Chores**
  * Standardized workflow environments to use a fixed version of the toolchain across builds, tests, releases, and artifact generation.
* **Bug Fixes**
  * Improved CI stability by reducing the chance of flaky failures caused by changing external environment references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->