### PR TITLE
ci: enforce no ignored tests across the org

### DIFF
--- a/.github/actions/no-ignored-tests/action.yml
+++ b/.github/actions/no-ignored-tests/action.yml
@@ -1,0 +1,57 @@
+name: no-ignored-tests
+description: >-
+  Fails when tests are statically ignored: Rust #[ignore], JS/TS
+  .skip/.only/x-prefixed suites, Solidity xtest-renamed functions, and
+  unconditional vm.skip(true). Conditional skips gated on real environment
+  availability (an if within the preceding lines, or a non-literal skip
+  argument) are allowed.
+runs:
+  using: composite
+  steps:
+    - name: Check for ignored tests
+      shell: bash
+      run: |
+        set -euo pipefail
+        fail=0
+        
+        rust_hits=$(grep -rn --include='*.rs' -E '#\[ignore' . \
+          --exclude-dir=target --exclude-dir=dependencies --exclude-dir=node_modules --exclude-dir=.git || true)
+        if [ -n "$rust_hits" ]; then
+          echo "Ignored Rust tests (#[ignore]) found:"; echo "$rust_hits"; fail=1
+        fi
+        
+        js_hits=$(grep -rn --include='*.ts' --include='*.tsx' --include='*.js' --include='*.jsx' --include='*.svelte' \
+          -E '\b(it|test|describe)\.(skip|only)[[:space:]]*\(|\bx(it|describe)[[:space:]]*\(' . \
+          --exclude-dir=node_modules --exclude-dir=dist --exclude-dir=build --exclude-dir=.svelte-kit --exclude-dir=.git --exclude-dir=target || true)
+        if [ -n "$js_hits" ]; then
+          echo "Skipped or focused JS/TS tests (.skip/.only/x-prefixed) found:"; echo "$js_hits"; fail=1
+        fi
+        
+        sol_rename=$(grep -rn --include='*.sol' -E 'function xtest' . \
+          --exclude-dir=dependencies --exclude-dir=lib --exclude-dir=node_modules --exclude-dir=.git || true)
+        if [ -n "$sol_rename" ]; then
+          echo "Disabled-by-rename Solidity tests (function xtest*) found:"; echo "$sol_rename"; fail=1
+        fi
+        
+        # Unconditional vm.skip(true) is a hard ignore. A skip is conditional (allowed)
+        # when the argument is a non-literal expression, or an `if (` appears on the
+        # same line or within the 5 preceding lines.
+        while IFS= read -r f; do
+          if ! awk -v file="$f" '
+            { lines[NR] = $0 }
+            /vm\.skip\(true\)/ {
+              ok = 0
+              if ($0 ~ /if[[:space:]]*\(/) ok = 1
+              for (i = NR - 5; i < NR; i++) if (i > 0 && lines[i] ~ /if[[:space:]]*\(/) ok = 1
+              if (!ok) { printf "%s:%d: unconditional vm.skip(true)\n", file, NR; found = 1 }
+            }
+            END { exit found ? 1 : 0 }
+          ' "$f"; then fail=1; fi
+        done < <(grep -rl --include='*.sol' 'vm\.skip(true)' . \
+          --exclude-dir=dependencies --exclude-dir=lib --exclude-dir=node_modules --exclude-dir=.git || true)
+        
+        if [ "$fail" -ne 0 ]; then
+          echo "Ignored tests are not allowed: delete the test, fix it, or make the skip conditional on real environment availability."
+          exit 1
+        fi
+        echo "No ignored tests found."

--- a/.github/actions/no-ignored-tests/action.yml
+++ b/.github/actions/no-ignored-tests/action.yml
@@ -1,10 +1,9 @@
 name: no-ignored-tests
 description: >-
-  Fails when tests are statically ignored: Rust #[ignore], JS/TS
-  .skip/.only/x-prefixed suites, Solidity xtest-renamed functions, and
-  unconditional vm.skip(true). Conditional skips gated on real environment
-  availability (an if within the preceding lines, or a non-literal skip
-  argument) are allowed.
+  Fails when tests are ignored, with no exceptions: Rust #[ignore], JS/TS
+  .skip/.only/x-prefixed suites, Solidity xtest-renamed functions, and any
+  vm.skip whatsoever. A test either runs and passes or is deleted; skips
+  hide undone work.
 runs:
   using: composite
   steps:
@@ -15,7 +14,8 @@ runs:
         fail=0
         
         rust_hits=$(grep -rn --include='*.rs' -E '#\[ignore' . \
-          --exclude-dir=target --exclude-dir=dependencies --exclude-dir=node_modules --exclude-dir=.git || true)
+          --exclude-dir=target --exclude-dir=node_modules --exclude-dir=.git \
+          | grep -vE '^\./(dependencies|lib)/' || true)
         if [ -n "$rust_hits" ]; then
           echo "Ignored Rust tests (#[ignore]) found:"; echo "$rust_hits"; fail=1
         fi
@@ -28,30 +28,21 @@ runs:
         fi
         
         sol_rename=$(grep -rn --include='*.sol' -E 'function xtest' . \
-          --exclude-dir=dependencies --exclude-dir=lib --exclude-dir=node_modules --exclude-dir=.git || true)
+          --exclude-dir=node_modules --exclude-dir=.git \
+          | grep -vE '^\./(dependencies|lib)/' || true)
         if [ -n "$sol_rename" ]; then
           echo "Disabled-by-rename Solidity tests (function xtest*) found:"; echo "$sol_rename"; fail=1
         fi
         
-        # Unconditional vm.skip(true) is a hard ignore. A skip is conditional (allowed)
-        # when the argument is a non-literal expression, or an `if (` appears on the
-        # same line or within the 5 preceding lines.
-        while IFS= read -r f; do
-          if ! awk -v file="$f" '
-            { lines[NR] = $0 }
-            /vm\.skip\(true\)/ {
-              ok = 0
-              if ($0 ~ /if[[:space:]]*\(/) ok = 1
-              for (i = NR - 5; i < NR; i++) if (i > 0 && lines[i] ~ /if[[:space:]]*\(/) ok = 1
-              if (!ok) { printf "%s:%d: unconditional vm.skip(true)\n", file, NR; found = 1 }
-            }
-            END { exit found ? 1 : 0 }
-          ' "$f"; then fail=1; fi
-        done < <(grep -rl --include='*.sol' 'vm\.skip(true)' . \
-          --exclude-dir=dependencies --exclude-dir=lib --exclude-dir=node_modules --exclude-dir=.git || true)
-        
+        sol_skips=$(grep -rn --include='*.sol' -E 'vm\.skip[[:space:]]*\(' . \
+          --exclude-dir=node_modules --exclude-dir=.git \
+          | grep -vE '^\./(dependencies|lib)/' || true)
+        if [ -n "$sol_skips" ]; then
+          echo "vm.skip found (no skips allowed, conditional or otherwise):"; echo "$sol_skips"; fail=1
+        fi
+
         if [ "$fail" -ne 0 ]; then
-          echo "Ignored tests are not allowed: delete the test, fix it, or make the skip conditional on real environment availability."
+          echo "Ignored tests are not allowed, no exceptions: a test either runs and passes, or it is deleted."
           exit 1
         fi
         echo "No ignored tests found."

--- a/.github/workflows/rainix-rs-static.yaml
+++ b/.github/workflows/rainix-rs-static.yaml
@@ -15,6 +15,10 @@ jobs:
       - uses: rainlanguage/rainix/.github/actions/nix-cachix-setup@main
         with:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      # Ignored tests (Rust #[ignore], JS .skip/.only, Solidity xtest renames
+      # or unconditional vm.skip(true)) are banned org-wide; conditional skips
+      # gated on environment availability are allowed.
+      - uses: rainlanguage/rainix/.github/actions/no-ignored-tests@main
       - uses: rainlanguage/rainix/.github/actions/rust-cache@main
       - run: nix develop github:rainlanguage/rainix/${{ env.RAINIX_SHA }}#rust-shell -c rainix-rs-static
       # Run the rainix pre-commit hook bundle (taplo, the nix hooks, yamlfmt,

--- a/.github/workflows/rainix-rs-static.yaml
+++ b/.github/workflows/rainix-rs-static.yaml
@@ -15,9 +15,9 @@ jobs:
       - uses: rainlanguage/rainix/.github/actions/nix-cachix-setup@main
         with:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      # Ignored tests (Rust #[ignore], JS .skip/.only, Solidity xtest renames
-      # or unconditional vm.skip(true)) are banned org-wide; conditional skips
-      # gated on environment availability are allowed.
+      # Ignored tests are banned org-wide with no exceptions: Rust #[ignore],
+      # JS .skip/.only, Solidity xtest renames and any vm.skip. A test either
+      # runs and passes or is deleted.
       - uses: rainlanguage/rainix/.github/actions/no-ignored-tests@main
       - uses: rainlanguage/rainix/.github/actions/rust-cache@main
       - run: nix develop github:rainlanguage/rainix/${{ env.RAINIX_SHA }}#rust-shell -c rainix-rs-static

--- a/.github/workflows/rainix-sol-static.yaml
+++ b/.github/workflows/rainix-sol-static.yaml
@@ -13,9 +13,9 @@ jobs:
       - uses: rainlanguage/rainix/.github/actions/nix-cachix-setup@main
         with:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      # Ignored tests (Rust #[ignore], JS .skip/.only, Solidity xtest renames
-      # or unconditional vm.skip(true)) are banned org-wide; conditional skips
-      # gated on environment availability are allowed.
+      # Ignored tests are banned org-wide with no exceptions: Rust #[ignore],
+      # JS .skip/.only, Solidity xtest renames and any vm.skip. A test either
+      # runs and passes or is deleted.
       - uses: rainlanguage/rainix/.github/actions/no-ignored-tests@main
       # Cache Foundry's incremental compilation cache + artifacts so unchanged
       # contracts aren't recompiled (forge build is the dominant CI cost).

--- a/.github/workflows/rainix-sol-static.yaml
+++ b/.github/workflows/rainix-sol-static.yaml
@@ -13,6 +13,10 @@ jobs:
       - uses: rainlanguage/rainix/.github/actions/nix-cachix-setup@main
         with:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      # Ignored tests (Rust #[ignore], JS .skip/.only, Solidity xtest renames
+      # or unconditional vm.skip(true)) are banned org-wide; conditional skips
+      # gated on environment availability are allowed.
+      - uses: rainlanguage/rainix/.github/actions/no-ignored-tests@main
       # Cache Foundry's incremental compilation cache + artifacts so unchanged
       # contracts aren't recompiled (forge build is the dominant CI cost).
       - name: Cache Foundry build


### PR DESCRIPTION
## What

Adds a `no-ignored-tests` composite action and runs it from both `rainix-sol-static.yaml` and `rainix-rs-static.yaml` (referenced `@main`, so consumers inherit it on their next run).

## What it bans — no exceptions

- **Rust**: `#[ignore]` (zero current usage org-wide).
- **JS/TS/Svelte**: `it/test/describe`.`skip`/`.only` and `xit`/`xdescribe` — `.only` included since a focused test silently ignores everything else (zero current usage).
- **Solidity**: `function xtest…` disabled-by-rename (zero current usage), and **any `vm.skip(` whatsoever** — conditional or not. A test either runs and passes, or it is deleted; skips hide undone work.

Parameterized `_test*` external helpers (Foundry does not auto-run them; rainlang uses the convention in 9 files) are untouched. Vendor exclusions (`dependencies/`, `lib/`) match only at the repo root so first-party `test/lib/` trees are checked; `node_modules`/`target`/`.git` stay excluded by name.

## Known reds this deliberately creates

Landing this makes the static job red in three repos until their skips are reworked into hard behavior:

- **raindex** — 5 sites in `test/lib/deploy/`: two `vm.skip(true)` (registry-unreachable guards) and three `vm.skip(vm.envOr("CI", false))` (tests that never run in CI).
- **rain.math.float** — registry-unreachable guard in `LibDecimalFloatDeployTaggedConstants.t.sol`.
- **rain.metadata** — `vm.skip(vm.envOr("CI", false))` in `LibMetaBoardDeploy.t.sol`.

The rework in each case: remove the skip so registry/RPC unavailability is a hard failure, and CI-skipped fork tests actually run in CI (the fork RPC secrets exist).

## Verification

Run against real checkouts: raindex FAILS with all 5 sites listed per file:line, rainlang PASSES (helpers untouched), synthetic repo with all four violation classes FAILS. rain.erc4626.words/rain.flare-style repos with no skips PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)