### PR TITLE
sol-static: ban @custom: NatSpec tags (exact ERC-7201 storage-location form excepted)

### DIFF
--- a/.github/actions/no-custom-natspec/action.yml
+++ b/.github/actions/no-custom-natspec/action.yml
@@ -1,0 +1,27 @@
+name: no-custom-natspec
+description: >-
+  Fails on any @custom: NatSpec tag in first-party Solidity. Custom tags are
+  an unreviewed side-channel convention (e.g. @custom:error duplicating
+  declaration-site error docs); document behavior in standard NatSpec
+  (@notice/@dev/@param/@return) instead. The single exception is ERC-7201's
+  normative, tooling-read storage annotation, which must match its exact
+  form: `@custom:storage-location erc7201:`.
+runs:
+  using: composite
+  steps:
+    - name: Check for custom NatSpec tags
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        hits=$(grep -rn --include='*.sol' -E '@custom:' . \
+          --exclude-dir=node_modules --exclude-dir=.git \
+          | grep -vE '^\./(dependencies|lib)/' \
+          | grep -vE '@custom:storage-location erc7201:' || true)
+        if [ -n "$hits" ]; then
+          echo "Custom NatSpec tags (@custom:) found — use standard NatSpec instead"
+          echo "(only ERC-7201's exact '@custom:storage-location erc7201:' form is allowed):"
+          echo "$hits"
+          exit 1
+        fi
+        echo "no-custom-natspec: clean"

--- a/.github/actions/no-custom-natspec/action.yml
+++ b/.github/actions/no-custom-natspec/action.yml
@@ -13,15 +13,7 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-
-        hits=$(grep -rn --include='*.sol' -E '@custom:' . \
-          --exclude-dir=node_modules --exclude-dir=.git \
-          | grep -vE '^\./(dependencies|lib)/' \
-          | grep -vE '@custom:storage-location erc7201:' || true)
-        if [ -n "$hits" ]; then
-          echo "Custom NatSpec tags (@custom:) found — use standard NatSpec instead"
-          echo "(only ERC-7201's exact '@custom:storage-location erc7201:' form is allowed):"
-          echo "$hits"
-          exit 1
-        fi
-        echo "no-custom-natspec: clean"
+        # Single source of truth: the BATS-covered library in rainix's lib/.
+        # shellcheck disable=SC1091
+        source "$GITHUB_ACTION_PATH/../../../lib/no-custom-natspec.sh"
+        check_no_custom_natspec .

--- a/.github/actions/no-ignored-tests/action.yml
+++ b/.github/actions/no-ignored-tests/action.yml
@@ -12,28 +12,28 @@ runs:
       run: |
         set -euo pipefail
         fail=0
-        
+
         rust_hits=$(grep -rn --include='*.rs' -E '#\[ignore' . \
           --exclude-dir=target --exclude-dir=node_modules --exclude-dir=.git \
           | grep -vE '^\./(dependencies|lib)/' || true)
         if [ -n "$rust_hits" ]; then
           echo "Ignored Rust tests (#[ignore]) found:"; echo "$rust_hits"; fail=1
         fi
-        
+
         js_hits=$(grep -rn --include='*.ts' --include='*.tsx' --include='*.js' --include='*.jsx' --include='*.svelte' \
           -E '\b(it|test|describe)\.(skip|only)[[:space:]]*\(|\bx(it|describe)[[:space:]]*\(' . \
           --exclude-dir=node_modules --exclude-dir=dist --exclude-dir=build --exclude-dir=.svelte-kit --exclude-dir=.git --exclude-dir=target || true)
         if [ -n "$js_hits" ]; then
           echo "Skipped or focused JS/TS tests (.skip/.only/x-prefixed) found:"; echo "$js_hits"; fail=1
         fi
-        
+
         sol_rename=$(grep -rn --include='*.sol' -E 'function xtest' . \
           --exclude-dir=node_modules --exclude-dir=.git \
           | grep -vE '^\./(dependencies|lib)/' || true)
         if [ -n "$sol_rename" ]; then
           echo "Disabled-by-rename Solidity tests (function xtest*) found:"; echo "$sol_rename"; fail=1
         fi
-        
+
         sol_skips=$(grep -rn --include='*.sol' -E 'vm\.skip[[:space:]]*\(' . \
           --exclude-dir=node_modules --exclude-dir=.git \
           | grep -vE '^\./(dependencies|lib)/' || true)

--- a/.github/workflows/rainix-sol-static.yaml
+++ b/.github/workflows/rainix-sol-static.yaml
@@ -17,6 +17,10 @@ jobs:
       # JS .skip/.only, Solidity xtest renames and any vm.skip. A test either
       # runs and passes or is deleted.
       - uses: rainlanguage/rainix/.github/actions/no-ignored-tests@main
+      # Custom NatSpec tags (@custom:) are banned org-wide — document behavior
+      # in standard NatSpec. Sole exception: ERC-7201's normative
+      # `@custom:storage-location erc7201:` annotation, which tooling reads.
+      - uses: rainlanguage/rainix/.github/actions/no-custom-natspec@main
       # Cache Foundry's incremental compilation cache + artifacts so unchanged
       # contracts aren't recompiled (forge build is the dominant CI cost).
       - name: Cache Foundry build

--- a/flake.nix
+++ b/flake.nix
@@ -381,6 +381,7 @@
             bats test/bats/task/subgraph-build.test.bats
             bats test/bats/task/subgraph-deploy-version.test.bats
             bats test/bats/task/sol-single-contract.test.bats
+            bats test/bats/task/no-custom-natspec.test.bats
           '';
           additionalBuildInputs = [ pkgs.bats ] ++ sol-build-inputs ++ node-build-inputs;
         };

--- a/lib/no-custom-natspec.sh
+++ b/lib/no-custom-natspec.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Custom NatSpec tags (@custom:) are banned in first-party Solidity: they are
+# an unreviewed side-channel that fragments docs (e.g. @custom:error blocks
+# duplicating declaration-site error docs). Behavior belongs in standard
+# NatSpec (@notice/@dev/@param/@return). The single allowed form is ERC-7201's
+# normative, tooling-read storage annotation, matched exactly:
+#   @custom:storage-location erc7201:
+# Vendor dirs are excluded by ROOT-ANCHORED paths (./dependencies/, ./lib/) so
+# first-party src/lib/ or test/lib/ files are still checked.
+
+# Print every offending @custom: line in first-party .sol under $1 (default
+# current dir); return 1 if any exist, 0 when clean.
+check_no_custom_natspec() {
+  local dir="${1:-.}"
+  local hits
+  hits=$(cd "$dir" && grep -rn --include='*.sol' -E '@custom:' . \
+    --exclude-dir=node_modules --exclude-dir=.git \
+    | grep -vE '^\./(dependencies|lib)/' \
+    | grep -vE '@custom:storage-location erc7201:' || true)
+  if [ -n "$hits" ]; then
+    echo "Custom NatSpec tags (@custom:) found — use standard NatSpec instead"
+    echo "(only ERC-7201's exact '@custom:storage-location erc7201:' form is allowed):"
+    echo "$hits"
+    return 1
+  fi
+  echo "no-custom-natspec: clean"
+}

--- a/test/bats/task/no-custom-natspec.test.bats
+++ b/test/bats/task/no-custom-natspec.test.bats
@@ -1,0 +1,84 @@
+setup() {
+  # shellcheck disable=SC1091
+  source lib/no-custom-natspec.sh
+  TESTDIR="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$TESTDIR"
+}
+
+@test "clean tree passes" {
+  mkdir -p "$TESTDIR/src"
+  echo 'contract A {}' > "$TESTDIR/src/A.sol"
+  run check_no_custom_natspec "$TESTDIR"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no-custom-natspec: clean"* ]]
+}
+
+@test "custom error tag fails and names the file" {
+  mkdir -p "$TESTDIR/src"
+  printf '/// @custom:error Reverts with Foo.\ncontract A {}\n' > "$TESTDIR/src/A.sol"
+  run check_no_custom_natspec "$TESTDIR"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"src/A.sol"* ]]
+  [[ "$output" == *"@custom:error"* ]]
+}
+
+@test "exact ERC-7201 storage-location form passes" {
+  mkdir -p "$TESTDIR/src"
+  printf '/// @custom:storage-location erc7201:rain.storage.Thing\ncontract A {}\n' > "$TESTDIR/src/A.sol"
+  run check_no_custom_natspec "$TESTDIR"
+  [ "$status" -eq 0 ]
+}
+
+@test "near-miss ERC-7201 forms fail: double space, erc-7201, uppercase" {
+  mkdir -p "$TESTDIR/src"
+  printf '/// @custom:storage-location  erc7201:x\ncontract A {}\n' > "$TESTDIR/src/A.sol"
+  run check_no_custom_natspec "$TESTDIR"
+  [ "$status" -eq 1 ]
+  printf '/// @custom:storage-location erc-7201:x\ncontract B {}\n' > "$TESTDIR/src/A.sol"
+  run check_no_custom_natspec "$TESTDIR"
+  [ "$status" -eq 1 ]
+  printf '/// @custom:storage-location ERC7201:x\ncontract C {}\n' > "$TESTDIR/src/A.sol"
+  run check_no_custom_natspec "$TESTDIR"
+  [ "$status" -eq 1 ]
+}
+
+@test "root-level vendor dirs are excluded" {
+  mkdir -p "$TESTDIR/dependencies/dep" "$TESTDIR/lib/dep"
+  printf '/// @custom:error vendored\ncontract V {}\n' > "$TESTDIR/dependencies/dep/V.sol"
+  printf '/// @custom:error vendored\ncontract W {}\n' > "$TESTDIR/lib/dep/W.sol"
+  run check_no_custom_natspec "$TESTDIR"
+  [ "$status" -eq 0 ]
+}
+
+@test "nested first-party lib dirs are NOT excluded (root-anchoring)" {
+  mkdir -p "$TESTDIR/test/lib"
+  printf '/// @custom:error first-party\ncontract T {}\n' > "$TESTDIR/test/lib/T.sol"
+  run check_no_custom_natspec "$TESTDIR"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"test/lib/T.sol"* ]]
+}
+
+@test "node_modules is excluded" {
+  mkdir -p "$TESTDIR/node_modules/pkg"
+  printf '/// @custom:error dep\ncontract N {}\n' > "$TESTDIR/node_modules/pkg/N.sol"
+  run check_no_custom_natspec "$TESTDIR"
+  [ "$status" -eq 0 ]
+}
+
+@test "non-Solidity files are ignored" {
+  printf '@custom:error in markdown\n' > "$TESTDIR/NOTES.md"
+  run check_no_custom_natspec "$TESTDIR"
+  [ "$status" -eq 0 ]
+}
+
+@test "allowed and banned tags in one file: fails listing only the banned line" {
+  mkdir -p "$TESTDIR/src"
+  printf '/// @custom:storage-location erc7201:rain.storage.Thing\n/// @custom:security ping me\ncontract A {}\n' > "$TESTDIR/src/A.sol"
+  run check_no_custom_natspec "$TESTDIR"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"@custom:security"* ]]
+  [[ "$output" != *"rain.storage.Thing"* ]]
+}


### PR DESCRIPTION
Adds a `no-custom-natspec` composite (same shape as `no-ignored-tests`) and wires it into `rainix-sol-static.yaml`, so it propagates to every consumer repo calling the reusable @main.

**Rule:** any `@custom:` tag in first-party `.sol` fails static — behavior belongs in standard NatSpec (`@notice`/`@dev`/`@param`/`@return`). Vendor dirs (`./dependencies/`, `./lib/`) root-anchored-excluded.

**Sole exception, by exact-form match:** `@custom:storage-location erc7201:` — ERC-7201's normative annotation that storage tooling actually reads; rain.vats uses it in 7 files and must keep it. Anything else (including other spellings of the same tag) fails, so any future machine-read tag gets added here via a reviewed PR instead of drifting in.

**Org impact at time of writing:** rain.flare goes red on `LibOpFtsoCurrentPriceUsd.sol:39` — that is the deliberate pressure behind https://github.com/rainlanguage/rain.flare/issues/197 (the pair-op site was already removed in the #194 rework, merged). rain.vats stays green (survey verified all its tags are the exact ERC-7201 form). No other repo has `@custom:` in first-party sol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)