### PR TITLE
hotfix: no-submodules runs rainix-static from the composite's own checkout

### DIFF
--- a/.github/actions/no-submodules/action.yml
+++ b/.github/actions/no-submodules/action.yml
@@ -9,6 +9,8 @@ runs:
       run: |
         set -euo pipefail
         # Single source of truth: the Rust rainix-static binary (its unit tests
-        # run inside the nix build). RAINIX_SHA is exported by the calling
-        # reusable per the org flake-pin convention; main is the dev fallback.
-        nix run "github:rainlanguage/rainix/${RAINIX_SHA:-main}#rainix-static" -- no-submodules .
+        # run inside the nix build). Run from the composite's OWN checkout via a
+        # path: flake ref — consumers' RAINIX_SHA pins predate the package and a
+        # github: ref at that sha has no such attribute (broke org statics on
+        # 2026-07-05).
+        nix run "path:$(cd "$GITHUB_ACTION_PATH/../../.." && pwd)#rainix-static" -- no-submodules .

--- a/.github/actions/no-submodules/action.yml
+++ b/.github/actions/no-submodules/action.yml
@@ -1,6 +1,6 @@
 name: no-submodules
 description: >-
-  Fails when the repo uses git submodules: a root .gitmodules file or any committed gitlink entry (mode 160000). Dependencies come from soldeer / npm / nix flakes, never vendored submodule pointers. Migrated from the rain-org-health scan's advisory `submodules` signal into a hard gate.
+  Fails when the repo uses git submodules: a root .gitmodules file or any committed gitlink entry (mode 160000). Dependencies come from soldeer / npm / nix flakes, never vendored submodule pointers.
 runs:
   using: composite
   steps:
@@ -9,8 +9,7 @@ runs:
       run: |
         set -euo pipefail
         # Single source of truth: the Rust rainix-static binary (its unit tests
-        # run inside the nix build). Run from the composite's OWN checkout via a
-        # path: flake ref — consumers' RAINIX_SHA pins predate the package and a
-        # github: ref at that sha has no such attribute (broke org statics on
-        # 2026-07-05).
+        # run inside the nix build). The path: flake ref runs it from this
+        # composite's own checkout, so the check version always matches the
+        # action version regardless of any RAINIX_SHA the caller pins.
         nix run "path:$(cd "$GITHUB_ACTION_PATH/../../.." && pwd)#rainix-static" -- no-submodules .


### PR DESCRIPTION
URGENT: #256's composite resolves `github:rainlanguage/rainix/${RAINIX_SHA}#rainix-static`, but consumer repos pin RAINIX_SHA to shas that predate the package — attribute missing, **every consumer sol/rs-static is currently red** (observed on erc4626 #175/#235 retriggers). Fix: `path:` flake ref to the composite's own checkout ($GITHUB_ACTION_PATH repo root) — version-locked to the action, no network ref, no sha skew. Smoke-verified locally via the same path: invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated check to run from the action’s local checkout instead of referencing an external source.
  * Simplified how the `rainix-static` check is launched, keeping the execution path consistent within the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->