### PR TITLE
ci: plumb RPC_URL_ETHEREUM_FORK through the sol workflows

### DIFF
--- a/.github/workflows/rainix-manual-sol-artifacts.yaml
+++ b/.github/workflows/rainix-manual-sol-artifacts.yaml
@@ -27,6 +27,8 @@ on:
         required: false
       RPC_URL_BASE_SEPOLIA_FORK:
         required: false
+      RPC_URL_ETHEREUM_FORK:
+        required: false
       RPC_URL_FLARE_FORK:
         required: false
       RPC_URL_POLYGON_FORK:
@@ -75,6 +77,7 @@ jobs:
           ARBITRUM_RPC_URL: ${{ secrets.RPC_URL_ARBITRUM_FORK || vars.RPC_URL_ARBITRUM_FORK || '' }}
           BASE_RPC_URL: ${{ secrets.RPC_URL_BASE_FORK || vars.RPC_URL_BASE_FORK || '' }}
           BASE_SEPOLIA_RPC_URL: ${{ secrets.RPC_URL_BASE_SEPOLIA_FORK || vars.RPC_URL_BASE_SEPOLIA_FORK || '' }}
+          ETHEREUM_RPC_URL: ${{ secrets.RPC_URL_ETHEREUM_FORK || vars.RPC_URL_ETHEREUM_FORK || '' }}
           FLARE_RPC_URL: ${{ secrets.RPC_URL_FLARE_FORK || vars.RPC_URL_FLARE_FORK || '' }}
           POLYGON_RPC_URL: ${{ secrets.RPC_URL_POLYGON_FORK || vars.RPC_URL_POLYGON_FORK || '' }}
           # Etherscan V2 is a single multichain API key: source all Etherscan-family

--- a/.github/workflows/rainix-sol-test.yaml
+++ b/.github/workflows/rainix-sol-test.yaml
@@ -14,6 +14,8 @@ on:
         required: false
       RPC_URL_BASE_SEPOLIA_FORK:
         required: false
+      RPC_URL_ETHEREUM_FORK:
+        required: false
       RPC_URL_FLARE_FORK:
         required: false
       RPC_URL_POLYGON_FORK:
@@ -33,6 +35,7 @@ jobs:
       ARBITRUM_RPC_URL: ${{ secrets.RPC_URL_ARBITRUM_FORK || vars.RPC_URL_ARBITRUM_FORK }}
       BASE_RPC_URL: ${{ secrets.RPC_URL_BASE_FORK || vars.RPC_URL_BASE_FORK }}
       BASE_SEPOLIA_RPC_URL: ${{ secrets.RPC_URL_BASE_SEPOLIA_FORK || vars.RPC_URL_BASE_SEPOLIA_FORK }}
+      ETHEREUM_RPC_URL: ${{ secrets.RPC_URL_ETHEREUM_FORK || vars.RPC_URL_ETHEREUM_FORK }}
       FLARE_RPC_URL: ${{ secrets.RPC_URL_FLARE_FORK || vars.RPC_URL_FLARE_FORK }}
       POLYGON_RPC_URL: ${{ secrets.RPC_URL_POLYGON_FORK || vars.RPC_URL_POLYGON_FORK }}
     steps:

--- a/.github/workflows/rainix-sol.yaml
+++ b/.github/workflows/rainix-sol.yaml
@@ -14,6 +14,8 @@ on:
         required: false
       RPC_URL_BASE_SEPOLIA_FORK:
         required: false
+      RPC_URL_ETHEREUM_FORK:
+        required: false
       RPC_URL_FLARE_FORK:
         required: false
       RPC_URL_POLYGON_FORK:
@@ -32,5 +34,6 @@ jobs:
       RPC_URL_ARBITRUM_FORK: ${{ secrets.RPC_URL_ARBITRUM_FORK }}
       RPC_URL_BASE_FORK: ${{ secrets.RPC_URL_BASE_FORK }}
       RPC_URL_BASE_SEPOLIA_FORK: ${{ secrets.RPC_URL_BASE_SEPOLIA_FORK }}
+      RPC_URL_ETHEREUM_FORK: ${{ secrets.RPC_URL_ETHEREUM_FORK }}
       RPC_URL_FLARE_FORK: ${{ secrets.RPC_URL_FLARE_FORK }}
       RPC_URL_POLYGON_FORK: ${{ secrets.RPC_URL_POLYGON_FORK }}


### PR DESCRIPTION
Adds Ethereum mainnet to the fork-RPC set across `rainix-sol.yaml`, `rainix-sol-test.yaml` and `rainix-manual-sol-artifacts.yaml`: optional secret declaration, composite passthrough, and the `ETHEREUM_RPC_URL` env mapping with the same `vars.*` fallback as every other network.

Motivation: ST0x is adding Ethereum mainnet as a deploy + fork-test network in S01-Issuer/st0x.deploy. Its `foundry.toml` maps the `ethereum` rpc alias to `ETHEREUM_RPC_URL`, which these workflows previously never set. Consumers that don't set the new secret/var are unaffected (optional, falls back exactly like the existing networks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPs1hCTxusmaSeFKvoc4Kr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Ethereum fork RPC secret support to workflow-triggered Solidity jobs.
  * Passed the Ethereum RPC URL through to deployment and test steps when available, with a safe fallback if unset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->