### PR TITLE
ci: bump RAINIX_SHA to 53e96a7 (soldeer-gate + general rainix-static)

### DIFF
--- a/.github/workflows/rainix-autopublish.yaml
+++ b/.github/workflows/rainix-autopublish.yaml
@@ -49,7 +49,7 @@ on:
       SOLDEER_API_TOKEN:
         required: false
 env:
-  RAINIX_SHA: 307bf27fcc5a410994f5a6a6a96527a64625c3da
+  RAINIX_SHA: 53e96a7d0a97d7c7c75c3b2412521324776fdac6
 jobs:
   release:
     if: ${{ !startsWith(github.event.head_commit.message, 'Package Release') }}

--- a/.github/workflows/rainix-copy-artifacts.yaml
+++ b/.github/workflows/rainix-copy-artifacts.yaml
@@ -2,7 +2,7 @@ name: rainix-copy-artifacts
 on:
   workflow_call:
 env:
-  RAINIX_SHA: 307bf27fcc5a410994f5a6a6a96527a64625c3da
+  RAINIX_SHA: 53e96a7d0a97d7c7c75c3b2412521324776fdac6
 jobs:
   copy-artifacts:
     runs-on: ubuntu-latest

--- a/.github/workflows/rainix-manual-sol-artifacts.yaml
+++ b/.github/workflows/rainix-manual-sol-artifacts.yaml
@@ -42,7 +42,7 @@ on:
       CI_DEPLOY_FLARE_ETHERSCAN_API_KEY:
         required: false
 env:
-  RAINIX_SHA: 307bf27fcc5a410994f5a6a6a96527a64625c3da
+  RAINIX_SHA: 53e96a7d0a97d7c7c75c3b2412521324776fdac6
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/rainix-rs-static.yaml
+++ b/.github/workflows/rainix-rs-static.yaml
@@ -2,7 +2,7 @@ name: rainix-rs-static
 on:
   workflow_call:
 env:
-  RAINIX_SHA: 307bf27fcc5a410994f5a6a6a96527a64625c3da
+  RAINIX_SHA: 53e96a7d0a97d7c7c75c3b2412521324776fdac6
 jobs:
   rs-static:
     runs-on: ubuntu-latest

--- a/.github/workflows/rainix-rs-test.yaml
+++ b/.github/workflows/rainix-rs-test.yaml
@@ -2,7 +2,7 @@ name: rainix-rs-test
 on:
   workflow_call:
 env:
-  RAINIX_SHA: 307bf27fcc5a410994f5a6a6a96527a64625c3da
+  RAINIX_SHA: 53e96a7d0a97d7c7c75c3b2412521324776fdac6
 jobs:
   rs-test:
     strategy:

--- a/.github/workflows/rainix-rs-wasm-test.yaml
+++ b/.github/workflows/rainix-rs-wasm-test.yaml
@@ -2,7 +2,7 @@ name: rainix-rs-wasm-test
 on:
   workflow_call:
 env:
-  RAINIX_SHA: 307bf27fcc5a410994f5a6a6a96527a64625c3da
+  RAINIX_SHA: 53e96a7d0a97d7c7c75c3b2412521324776fdac6
 jobs:
   rs-wasm-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/rainix-rs-wasm.yaml
+++ b/.github/workflows/rainix-rs-wasm.yaml
@@ -2,7 +2,7 @@ name: rainix-rs-wasm
 on:
   workflow_call:
 env:
-  RAINIX_SHA: 307bf27fcc5a410994f5a6a6a96527a64625c3da
+  RAINIX_SHA: 53e96a7d0a97d7c7c75c3b2412521324776fdac6
 jobs:
   rs-wasm:
     runs-on: ubuntu-latest

--- a/.github/workflows/rainix-sol-legal.yaml
+++ b/.github/workflows/rainix-sol-legal.yaml
@@ -2,7 +2,7 @@ name: rainix-sol-legal
 on:
   workflow_call:
 env:
-  RAINIX_SHA: 307bf27fcc5a410994f5a6a6a96527a64625c3da
+  RAINIX_SHA: 53e96a7d0a97d7c7c75c3b2412521324776fdac6
 jobs:
   legal:
     runs-on: ubuntu-latest

--- a/.github/workflows/rainix-sol-static.yaml
+++ b/.github/workflows/rainix-sol-static.yaml
@@ -2,7 +2,7 @@ name: rainix-sol-static
 on:
   workflow_call:
 env:
-  RAINIX_SHA: 307bf27fcc5a410994f5a6a6a96527a64625c3da
+  RAINIX_SHA: 53e96a7d0a97d7c7c75c3b2412521324776fdac6
 jobs:
   static:
     runs-on: ubuntu-latest

--- a/.github/workflows/rainix-sol-test.yaml
+++ b/.github/workflows/rainix-sol-test.yaml
@@ -19,7 +19,7 @@ on:
       RPC_URL_POLYGON_FORK:
         required: false
 env:
-  RAINIX_SHA: 307bf27fcc5a410994f5a6a6a96527a64625c3da
+  RAINIX_SHA: 53e96a7d0a97d7c7c75c3b2412521324776fdac6
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/rainix-subgraph-test.yaml
+++ b/.github/workflows/rainix-subgraph-test.yaml
@@ -2,7 +2,7 @@ name: rainix-subgraph-test
 on:
   workflow_call:
 env:
-  RAINIX_SHA: 307bf27fcc5a410994f5a6a6a96527a64625c3da
+  RAINIX_SHA: 53e96a7d0a97d7c7c75c3b2412521324776fdac6
 jobs:
   subgraph-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Bumps the reusable workflows' pinned flake ref (`env.RAINIX_SHA`) from `307bf27` to `53e96a7` — the #264 merge commit — across all 11 `rainix-*.yaml`.

**Why:** #264 made `rainix-static` general rainix tooling on every shell's PATH (via `common-shell-inputs`) and added `curl` to `sol-build-inputs`, so the new `rainix-static soldeer-gate` step in the autopublish workflow needs the pinned `sol-shell` to be at a commit that contains both. Until this bump, `nix develop github:.../<RAINIX_SHA>#sol-shell -c rainix-static soldeer-gate` resolves the OLD sol-shell (no `curl`, no binary).

- Mechanical find-replace, 11 files, SHA-only change.
- Devshells resolve at the new sha: `nix flake show github:rainlanguage/rainix/53e96a7d…` → `sol-shell` / `rust-shell` / `rust-node-shell` / `subgraph-shell` / `wasm-shell` all evaluate.

Standard rainix pin lifecycle (land a flake change on main, then bump the pin to it). Follows #264.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
