### PR TITLE
feat(rainix-static): enforce append-only deploy-pin snapshots in CI

### DIFF
--- a/.github/actions/frozen-snapshots-append-only/action.yml
+++ b/.github/actions/frozen-snapshots-append-only/action.yml
@@ -1,0 +1,29 @@
+name: frozen-snapshots-append-only
+description: >-
+  Fails when a branch modifies or deletes an existing per-tag deploy-pin snapshot under src/generated/<tag>/ (tag = three underscore-separated numbers, e.g. 0_1_4). These snapshots are frozen once on the base branch — downstream consumers pin the address/codehash constants they hold, so a release ADDS a new tag (bump the version), never edits an existing snapshot. No-op for repos with no such snapshots.
+runs:
+  using: composite
+  steps:
+    - name: Enforce append-only snapshots
+      shell: bash
+      run: |
+        set -euo pipefail
+        # Nothing to enforce if the repo has no per-tag snapshots.
+        if ! ls src/generated/*/*.pointers.sol >/dev/null 2>&1; then
+          echo "snapshots-append-only: no per-tag snapshots; skip"
+          exit 0
+        fi
+        # The three-dot diff needs the merge-base with the base branch, but the
+        # shared checkout is shallow — unshallow (rain repos are small, so cheap)
+        # and fetch the base. GITHUB_BASE_REF is set on pull_request; on push it
+        # is empty, so compare against main.
+        BASE_REF="${GITHUB_BASE_REF:-main}"
+        if [ -f "$(git rev-parse --git-dir)/shallow" ]; then
+          git fetch --no-tags --unshallow origin
+        fi
+        git fetch --no-tags origin "$BASE_REF"
+        # path: ref runs the check from THIS composite's own checkout, so the
+        # check version always matches the action version (same pattern as
+        # no-submodules) regardless of any RAINIX_SHA the caller pins.
+        nix run "path:$(cd "$GITHUB_ACTION_PATH/../../.." && pwd)#rainix-static" -- \
+          snapshots-append-only --base "origin/$BASE_REF"

--- a/.github/workflows/rainix-sol-static.yaml
+++ b/.github/workflows/rainix-sol-static.yaml
@@ -19,6 +19,10 @@ jobs:
       - uses: rainlanguage/rainix/.github/actions/no-ignored-tests@main
       # Git submodules are banned org-wide — deps come from soldeer/npm/nix.
       - uses: rainlanguage/rainix/.github/actions/no-submodules@main
+      # Per-tag deploy-pin snapshots under src/generated/<tag>/ are append-only:
+      # a release ADDS a new tag, never edits/deletes a frozen snapshot whose
+      # address/codehash constants downstream consumers pin. No-op when absent.
+      - uses: rainlanguage/rainix/.github/actions/frozen-snapshots-append-only@main
       # Custom NatSpec tags (@custom:) are banned org-wide — document behavior
       # in standard NatSpec. Sole exception: ERC-7201's normative
       # `@custom:storage-location erc7201:` annotation, which tooling reads.

--- a/rainix-static/src/frozen_snapshots.rs
+++ b/rainix-static/src/frozen_snapshots.rs
@@ -1,0 +1,158 @@
+//! Append-only enforcement for per-release deploy-pin snapshots.
+//!
+//! Snapshots under `<root>/<tag>/` (tag = three `_`-separated numbers, e.g.
+//! `0_1_4`) are FROZEN once they land on the base branch: downstream consumers
+//! pin the address + codehash constants they hold, so a snapshot must never
+//! change on `main` or diverge between branches. A release ships new bytecode by
+//! ADDING a new `<tag>/` snapshot (bump `[package].version`), never by editing an
+//! existing one.
+//!
+//! This check diffs the working branch against the base and flags any modified or
+//! deleted file under an existing tag dir. Adding a new tag dir is allowed;
+//! regenerated non-tag files directly under `<root>/` (the current-pin deploy
+//! libs) are not snapshots and are ignored.
+
+use std::process::Command;
+
+/// True if `seg` is a release-tag dir name: three `_`-separated non-empty numeric
+/// parts, e.g. `0_1_4` or `12_0_255`.
+pub(crate) fn is_tag(seg: &str) -> bool {
+    let parts: Vec<&str> = seg.split('_').collect();
+    parts.len() == 3
+        && parts
+            .iter()
+            .all(|p| !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit()))
+}
+
+/// True if `path` is a frozen per-tag snapshot FILE: `<root>/<tag>/<something>`.
+/// The tag dir itself (no trailing file) and non-tag files directly under `root`
+/// are not snapshots.
+pub(crate) fn is_snapshot(path: &str, root: &str) -> bool {
+    let rest = match path.strip_prefix(root).and_then(|r| r.strip_prefix('/')) {
+        Some(r) => r,
+        None => return false,
+    };
+    match rest.split_once('/') {
+        Some((seg, _file)) => is_tag(seg),
+        None => false,
+    }
+}
+
+/// Parse `git diff --name-status` output into offender messages for any modified
+/// or deleted snapshot file. Lines look like `M\tpath` or `D\tpath`.
+pub(crate) fn parse_offenders(diff: &str, root: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    for line in diff.lines() {
+        let mut it = line.splitn(2, '\t');
+        let status = it.next().unwrap_or("");
+        let path = match it.next() {
+            Some(p) => p.trim(),
+            None => continue,
+        };
+        let verb = match status.chars().next() {
+            Some('M') => "modified",
+            Some('D') => "deleted",
+            _ => continue,
+        };
+        if is_snapshot(path, root) {
+            out.push(format!(
+                "ERROR: {verb} frozen snapshot {path} — snapshots under {root}/<tag>/ are \
+                 append-only. Ship new bytecode as a NEW <tag> (bump [package].version); never \
+                 change an existing snapshot (downstream consumers pin these constants)."
+            ));
+        }
+    }
+    out
+}
+
+/// Diff `base...HEAD` and return the offenders. `base` must already be fetched
+/// (in CI, `git fetch origin <base>` first). Returns `Err` if git fails.
+pub(crate) fn check(base: &str, root: &str) -> Result<Vec<String>, String> {
+    let range = format!("{base}...HEAD");
+    // --no-renames so a snapshot rename shows as delete(old)+add(new) and the
+    // delete is caught; --diff-filter=MD keeps only modified/deleted entries.
+    let out = Command::new("git")
+        .args([
+            "diff",
+            "--no-renames",
+            "--name-status",
+            "--diff-filter=MD",
+            &range,
+            "--",
+            root,
+        ])
+        .output()
+        .map_err(|e| format!("failed to run git diff: {e}"))?;
+    if !out.status.success() {
+        return Err(format!(
+            "git diff {range} failed: {} — is the base ref fetched? In CI run `git fetch origin <base>` first.",
+            String::from_utf8_lossy(&out.stderr).trim()
+        ));
+    }
+    Ok(parse_offenders(&String::from_utf8_lossy(&out.stdout), root))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tag_names() {
+        assert!(is_tag("0_1_4"));
+        assert!(is_tag("12_0_255"));
+        assert!(!is_tag("0_1")); // two parts
+        assert!(!is_tag("0_1_4_5")); // four parts
+        assert!(!is_tag("0_1_")); // empty trailing part
+        assert!(!is_tag("_1_4")); // empty leading part
+        assert!(!is_tag("v0_1_4")); // non-digit
+        assert!(!is_tag("LibProdDeployCurrent.sol"));
+    }
+
+    #[test]
+    fn snapshot_paths() {
+        let root = "src/generated";
+        assert!(is_snapshot(
+            "src/generated/0_1_4/CloneFactory.pointers.sol",
+            root
+        ));
+        assert!(is_snapshot(
+            "src/generated/0_1_10/StoxReceipt.pointers.sol",
+            root
+        ));
+        // the mutable current-pin libs live directly under root, not in a tag dir
+        assert!(!is_snapshot("src/generated/LibProdDeployCurrent.sol", root));
+        assert!(!is_snapshot(
+            "src/generated/CloneFactory.pointers.sol",
+            root
+        ));
+        // a bare tag dir (no file) is not a snapshot file
+        assert!(!is_snapshot("src/generated/0_1_4", root));
+        // outside root
+        assert!(!is_snapshot("src/lib/LibCloneFactoryDeploy.sol", root));
+        assert!(!is_snapshot("0_1_4/x.sol", root));
+    }
+
+    #[test]
+    fn flags_only_modified_or_deleted_snapshots() {
+        let root = "src/generated";
+        let diff = "A\tsrc/generated/0_1_5/CloneFactory.pointers.sol\n\
+                    M\tsrc/generated/0_1_4/CloneFactory.pointers.sol\n\
+                    D\tsrc/generated/0_1_3/CloneFactory.pointers.sol\n\
+                    M\tsrc/generated/LibProdDeployCurrent.sol\n\
+                    M\tsrc/lib/LibCloneFactoryDeploy.sol\n";
+        let off = parse_offenders(diff, root);
+        assert_eq!(off.len(), 2);
+        assert!(off[0]
+            .contains("modified frozen snapshot src/generated/0_1_4/CloneFactory.pointers.sol"));
+        assert!(off[1]
+            .contains("deleted frozen snapshot src/generated/0_1_3/CloneFactory.pointers.sol"));
+    }
+
+    #[test]
+    fn clean_when_only_adding_a_new_tag() {
+        let root = "src/generated";
+        let diff = "A\tsrc/generated/0_1_5/CloneFactory.pointers.sol\n\
+                    M\tsrc/generated/LibProdDeployCurrent.sol\n";
+        assert!(parse_offenders(diff, root).is_empty());
+    }
+}

--- a/rainix-static/src/main.rs
+++ b/rainix-static/src/main.rs
@@ -13,12 +13,19 @@
 // Subcommands:
 //   no-submodules [dir]
 //       fail if the repo vendors git submodules.
+//   snapshots-append-only [--base <ref>] [--root <dir>]
+//       fail if the branch modifies or deletes an existing per-tag deploy-pin
+//       snapshot under <root>/<tag>/ (default root src/generated, base
+//       origin/main). Snapshots are frozen once on the base branch; a release
+//       ADDS a new <tag>, never edits an existing one. Needs the base ref
+//       fetched with history (fetch-depth: 0 + `git fetch origin <base>`).
 //   soldeer-gate --package <name> [--github-output <file>]
 //       Soldeer next-version content gate: compare the normalized content of what
 //       `forge soldeer push --dry-run` would upload against the latest published
 //       revision, and emit changed / version / next. Runs inside sol-shell, so
 //       `forge` and `curl` are on PATH.
 
+mod frozen_snapshots;
 mod no_submodules;
 mod soldeer_gate;
 
@@ -67,8 +74,25 @@ fn main() {
                 .unwrap_or_else(|| fail("soldeer-gate: --package <name> required"));
             soldeer_gate::run(&pkg, flag(&args, "--github-output").as_deref());
         }
+        "snapshots-append-only" => {
+            let base = flag(&args, "--base").unwrap_or_else(|| "origin/main".to_string());
+            let root = flag(&args, "--root").unwrap_or_else(|| "src/generated".to_string());
+            match frozen_snapshots::check(&base, &root) {
+                Err(e) => fail(&e),
+                Ok(offenders) if offenders.is_empty() => println!("snapshots-append-only: clean"),
+                Ok(offenders) => {
+                    for line in offenders {
+                        println!("{line}");
+                    }
+                    std::process::exit(1);
+                }
+            }
+        }
         other => {
-            eprintln!("rainix-static: unknown subcommand {other:?} (available: no-submodules, soldeer-gate)");
+            eprintln!(
+                "rainix-static: unknown subcommand {other:?} \
+                 (available: no-submodules, snapshots-append-only, soldeer-gate)"
+            );
             std::process::exit(2);
         }
     }


### PR DESCRIPTION
## What

Enforce, in CI, that per-tag deploy-pin snapshots are **append-only**.

- New `rainix-static snapshots-append-only [--base <ref>] [--root <dir>]` subcommand: diffs the branch against the base and fails on any **modified or deleted** file under an existing `<root>/<tag>/` dir (tag = `<n>_<n>_<n>`, e.g. `0_1_4`). Adding a new `<tag>` is fine; non-tag files directly under `src/generated/` (the mutable current-pin deploy libs) are ignored.
- New `frozen-snapshots-append-only` composite action, wired into `rainix-sol-static`. No-op for repos without such snapshots.

## Why

A per-tag snapshot (`src/generated/<tag>/*.pointers.sol`) records a released contract's deterministic address + codehash. Downstream consumers pin those constants, so a snapshot must **never change on main or diverge between branches** — a release ships new bytecode by **adding a new tag** (bumping `[package].version`), never by rewriting an existing snapshot. This turns that immutability from a convention into a CI gate.

Companion to #267 (which stops the autopublish from pre-generating a next-version snapshot at bump). Together: snapshots are created by the PR that defines a version, and can never be silently changed afterward.

## Validation

- 18 unit tests (`is_tag`, `is_snapshot`, offender parsing — new tag vs modify/delete).
- End-to-end against a real violation: a branch that rewrites an existing `0_1_4` snapshot **fails** with a clear message; a clean `main` **passes**.

## Note

The shared checkout is shallow, so the composite unshallows before the three-dot (merge-base) diff — cheap for rain-sized repos. Base is `GITHUB_BASE_REF` on PRs, else `main`.
