### PR TITLE
fix(ci): make autopublish Tag-and-push robust for soldeer-only repos

### DIFF
--- a/.github/workflows/rainix-autopublish.yaml
+++ b/.github/workflows/rainix-autopublish.yaml
@@ -277,10 +277,21 @@ jobs:
         run: |
           set -euo pipefail
           git fetch origin
+          # Entering the devShell can rewrite generated tracked files (e.g. a
+          # nix-store pre-commit-config symlink), dirtying the tree. The release
+          # commit is already made, so restore any such leftovers before the
+          # rebase, or it aborts with "cannot rebase: You have unstaged changes".
+          git checkout -- .
           if ! git rebase "origin/${{ github.ref_name }}"; then
-            nix develop github:rainlanguage/rainix/${{ env.RAINIX_SHA }}#rust-shell -c cargo generate-lockfile
-            git add Cargo.lock
-            GIT_EDITOR=true git rebase --continue
+            if [ -n "${{ inputs.crates }}${{ inputs.crate }}" ]; then
+              # Only the shared Cargo.lock is expected to conflict.
+              nix develop github:rainlanguage/rainix/${{ env.RAINIX_SHA }}#rust-shell -c cargo generate-lockfile
+              git add Cargo.lock
+              GIT_EDITOR=true git rebase --continue
+            else
+              echo "rebase onto origin/${{ github.ref_name }} conflicted, and there is no crate lockfile to regenerate; resolve manually" >&2
+              exit 1
+            fi
           fi
           if [ "${{ steps.cargo.outputs.changed }}" = "true" ]; then
             for CRATE in $CRATES; do

--- a/.github/workflows/rainix-autopublish.yaml
+++ b/.github/workflows/rainix-autopublish.yaml
@@ -283,7 +283,7 @@ jobs:
           # rebase, or it aborts with "cannot rebase: You have unstaged changes".
           git checkout -- .
           if ! git rebase "origin/${{ github.ref_name }}"; then
-            if [ -n "${{ inputs.crates }}${{ inputs.crate }}" ]; then
+            if [ -n "${{ inputs.crates }}" ] || [ -n "${{ inputs.crate }}" ]; then
               # Only the shared Cargo.lock is expected to conflict.
               nix develop github:rainlanguage/rainix/${{ env.RAINIX_SHA }}#rust-shell -c cargo generate-lockfile
               git add Cargo.lock


### PR DESCRIPTION
Hardens `rainix-autopublish.yaml`'s `Tag and push` step so **soldeer-only** packages (no `Cargo.toml`) release reliably. Companion to rainlanguage/rain.vats#328, which hit both failures below.

## Problem

For a soldeer-only repo, two things compounded and left publishes with the post-publish version bump **unpushed** (`foundry.toml` stuck at the just-published version → next release fails the next-version invariant):

1. **Dirty tree aborts the rebase.** The devShell rewrites generated tracked files on entry (e.g. a nix-store `.pre-commit-config.yaml` symlink). `forge soldeer push` enters the devShell, so by the time `Tag and push` runs the tree is dirty and `git rebase "origin/<branch>"` aborts: `cannot rebase: You have unstaged changes`.
2. **Rust-only recovery on a non-Rust repo.** The rebase-failure recovery ran `cargo generate-lockfile` unconditionally. On a soldeer-only repo there is no `Cargo.toml`, so cargo exits 101 and the whole step dies.

## Fix

- **`git checkout -- .` before the rebase** — the release commit is already made, so any remaining dirty tracked files are devShell leftovers; restoring them lets the rebase run against a clean tree.
- **Gate the `cargo generate-lockfile` recovery on a crate input** (`inputs.crates`/`inputs.crate`). A conflict on a soldeer-only repo now exits with a clear message instead of a misleading cargo error.

The proper repo-side fix (don't track the generated file) is rain.vats#328; this makes the workflow robust regardless of consumer hygiene, and stops soldeer-only repos from ever hitting the Rust recovery path.
