### PR TITLE
fix(prettier-bundle): bump svelte to 5 so prettier can format Svelte 5 syntax

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -182,7 +182,7 @@
           pname = "rainix-prettier-bundle";
           version = "0.0.0";
           src = ./prettier-bundle;
-          npmDepsHash = "sha256-64dISGPfTPK7LUSL43CKoHM5SPZYqx6Ngg2dBgsqIyg=";
+          npmDepsHash = "sha256-nSpg3uvO28W0uRYybqEIXKhYd/LnuRy4YwR6homOQYU=";
           dontNpmBuild = true;
           installPhase = ''
             runHook preInstall

--- a/prettier-bundle/package-lock.json
+++ b/prettier-bundle/package-lock.json
@@ -11,20 +11,7 @@
 				"prettier": "3.6.2",
 				"prettier-plugin-svelte": "3.5.1",
 				"prettier-plugin-tailwindcss": "0.6.14",
-				"svelte": "4.2.7"
-			}
-		},
-		"node_modules/@ampproject/remapping": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
-			"integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@jridgewell/gen-mapping": "^0.3.5",
-				"@jridgewell/trace-mapping": "^0.3.24"
-			},
-			"engines": {
-				"node": ">=6.0.0"
+				"svelte": "5.56.5"
 			}
 		},
 		"node_modules/@jridgewell/gen-mapping": {
@@ -34,6 +21,16 @@
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.0",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			}
+		},
+		"node_modules/@jridgewell/remapping": {
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+			"integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.5",
 				"@jridgewell/trace-mapping": "^0.3.24"
 			}
 		},
@@ -62,16 +59,31 @@
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
+		"node_modules/@sveltejs/acorn-typescript": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.11.tgz",
+			"integrity": "sha512-LFuZUkjJ9iF7JZye/aG5XM0SFcQ5VyL0oVX4WJ9dc0Va3R3s0OauX1BESVCb+YN/ol8TAfqGDDAQsTG627Y5kw==",
+			"license": "MIT",
+			"peerDependencies": {
+				"acorn": "^8.9.0"
+			}
+		},
 		"node_modules/@types/estree": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+			"integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+			"license": "MIT"
+		},
+		"node_modules/@types/trusted-types": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+			"integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
 			"license": "MIT"
 		},
 		"node_modules/acorn": {
-			"version": "8.16.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+			"version": "8.17.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+			"integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
 			"license": "MIT",
 			"bin": {
 				"acorn": "bin/acorn"
@@ -81,56 +93,59 @@
 			}
 		},
 		"node_modules/aria-query": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
-			"integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
+			"integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">= 0.4"
 			}
 		},
 		"node_modules/axobject-query": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.4.tgz",
-			"integrity": "sha512-aPTElBrbifBU1krmZxGZOlBkslORe7Ll7+BDnI50Wy4LgOt69luMgevkDfTq1O/ZgprooPCtWpjCwKSZw/iZ4A==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+			"integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/code-red": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/code-red/-/code-red-1.0.4.tgz",
-			"integrity": "sha512-7qJWqItLA8/VPVlKJlFXU+NBlo/qyfs39aJcuMT/2ere32ZqvF5OSxgdM5xOfJJ7O429gg2HM47y8v9P+9wrNw==",
+		"node_modules/clsx": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+			"integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
 			"license": "MIT",
-			"dependencies": {
-				"@jridgewell/sourcemap-codec": "^1.4.15",
-				"@types/estree": "^1.0.1",
-				"acorn": "^8.10.0",
-				"estree-walker": "^3.0.3",
-				"periscopic": "^3.1.0"
-			}
-		},
-		"node_modules/css-tree": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
-			"integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
-			"license": "MIT",
-			"dependencies": {
-				"mdn-data": "2.0.30",
-				"source-map-js": "^1.0.1"
-			},
 			"engines": {
-				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+				"node": ">=6"
 			}
 		},
-		"node_modules/estree-walker": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+		"node_modules/devalue": {
+			"version": "5.8.1",
+			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+			"integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
+			"license": "MIT"
+		},
+		"node_modules/esm-env": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+			"integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+			"license": "MIT"
+		},
+		"node_modules/esrap": {
+			"version": "2.2.13",
+			"resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.13.tgz",
+			"integrity": "sha512-m8jH5hZgJE2RRUK/jjkGPcJEDAV+dYnZYFkosQaPTcE+Yw4xynXHOo6FUdwaWBtdR3b1MMa7wEDTSHeR2VWsGA==",
 			"license": "MIT",
 			"dependencies": {
-				"@types/estree": "^1.0.0"
+				"@jridgewell/sourcemap-codec": "^1.4.15"
+			},
+			"peerDependencies": {
+				"@typescript-eslint/types": "^8.2.0"
+			},
+			"peerDependenciesMeta": {
+				"@typescript-eslint/types": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/is-reference": {
@@ -155,23 +170,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.5"
-			}
-		},
-		"node_modules/mdn-data": {
-			"version": "2.0.30",
-			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
-			"integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
-			"license": "CC0-1.0"
-		},
-		"node_modules/periscopic": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.1.0.tgz",
-			"integrity": "sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/estree": "^1.0.0",
-				"estree-walker": "^3.0.0",
-				"is-reference": "^3.0.0"
 			}
 		},
 		"node_modules/prettier": {
@@ -285,38 +283,38 @@
 				}
 			}
 		},
-		"node_modules/source-map-js": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/svelte": {
-			"version": "4.2.7",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.7.tgz",
-			"integrity": "sha512-UExR1KS7raTdycsUrKLtStayu4hpdV3VZQgM0akX8XbXgLBlosdE/Sf3crOgyh9xIjqSYB3UEBuUlIQKRQX2hg==",
+			"version": "5.56.5",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.5.tgz",
+			"integrity": "sha512-P03YJmUy2JoOxYHb4Ka3oFat1hq2ko2it1MOItSjsJ4B6WgZPLc3+RyyU+57OGWhs3Ieq74EJpZtSnNXdAGgDw==",
 			"license": "MIT",
 			"dependencies": {
-				"@ampproject/remapping": "^2.2.1",
-				"@jridgewell/sourcemap-codec": "^1.4.15",
-				"@jridgewell/trace-mapping": "^0.3.18",
-				"acorn": "^8.9.0",
-				"aria-query": "^5.3.0",
-				"axobject-query": "^3.2.1",
-				"code-red": "^1.0.3",
-				"css-tree": "^2.3.1",
-				"estree-walker": "^3.0.3",
-				"is-reference": "^3.0.1",
+				"@jridgewell/remapping": "^2.3.4",
+				"@jridgewell/sourcemap-codec": "^1.5.0",
+				"@sveltejs/acorn-typescript": "^1.0.10",
+				"@types/estree": "^1.0.5",
+				"@types/trusted-types": "^2.0.7",
+				"acorn": "^8.12.1",
+				"aria-query": "5.3.1",
+				"axobject-query": "^4.1.0",
+				"clsx": "^2.1.1",
+				"devalue": "^5.8.1",
+				"esm-env": "^1.2.1",
+				"esrap": "^2.2.12",
+				"is-reference": "^3.0.3",
 				"locate-character": "^3.0.0",
-				"magic-string": "^0.30.4",
-				"periscopic": "^3.1.0"
+				"magic-string": "^0.30.11",
+				"zimmerframe": "^1.1.2"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=18"
 			}
+		},
+		"node_modules/zimmerframe": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
+			"integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
+			"license": "MIT"
 		}
 	}
 }

--- a/prettier-bundle/package.json
+++ b/prettier-bundle/package.json
@@ -7,6 +7,6 @@
 		"prettier": "3.6.2",
 		"prettier-plugin-svelte": "3.5.1",
 		"prettier-plugin-tailwindcss": "0.6.14",
-		"svelte": "4.2.7"
+		"svelte": "5.56.5"
 	}
 }

--- a/test/bats/devshell/default/prettier-bundle.test.bats
+++ b/test/bats/devshell/default/prettier-bundle.test.bats
@@ -23,6 +23,24 @@ setup() {
   echo "$actual" | grep -q 'READY = "LOCK"'
 }
 
+@test "rainix-bundled prettier formats Svelte 5 snippet syntax ({@render}/{#snippet})" {
+  tmpdir="$(mktemp -d)"
+  cp "$fixtures/svelte5-snippet/App.svelte" "$tmpdir/"
+  cd "$tmpdir"
+
+  bash -c "$prettier_entry App.svelte"
+
+  actual="$(cat App.svelte)"
+  rm -rf "$tmpdir"
+
+  # A Svelte 4 compiler can't parse {#snippet}/{@render}, so the format would
+  # error and leave the source's single quotes; a Svelte 5 compiler preserves
+  # the snippet and reformats to double quotes.
+  echo "$actual" | grep -q '{#snippet row(label)}'
+  echo "$actual" | grep -q '{@render row(item)}'
+  echo "$actual" | grep -q 'class="item"'
+}
+
 @test "rainix-bundled prettier reformats to rainix canon: 2-space indent and double quotes" {
   tmpdir="$(mktemp -d)"
   cp "$fixtures/canon-style/sample.ts" "$tmpdir/"

--- a/test/fixture/prettier-bundle/svelte5-snippet/App.svelte
+++ b/test/fixture/prettier-bundle/svelte5-snippet/App.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	let { items }: { items: string[] } = $props();
+</script>
+
+{#snippet row(label)}
+	<li class='item'>{label}</li>
+{/snippet}
+
+<ul>
+	{#each items as item}
+		{@render row(item)}
+	{/each}
+</ul>


### PR DESCRIPTION
The prettier bundle pins **`svelte@4.2.7`**. `prettier-plugin-svelte` defers
parsing to the installed `svelte` compiler, so a Svelte 4 compiler cannot parse
Svelte 5's `{@render}` / `{#snippet}` template syntax — `prettier` errors
(`Unexpected token`) on any modern SvelteKit file. The canonical example is the
standard `+layout.svelte`:

```svelte
<script>
  let { children } = $props();
</script>

{@render children()}
```

A consumer on Svelte 5 hits this on **every commit**: the `prettier-rainix`
pre-commit hook fails on that file. It's masked in this flake's own CI (the
`prettier-rainix` hook no-ops in the `rust-shell`, and `denofmt` skips
`.svelte`), so it only bites downstream.

### Change

- `prettier-bundle`: `svelte` **4.2.7 → 5.56.5**
  (`prettier-plugin-svelte@3.5.1`, already bundled, supports Svelte 5).
- Regenerated `npmDepsHash`.
- Added a Svelte 5 snippet fixture
  (`test/fixture/prettier-bundle/svelte5-snippet/App.svelte`, `{@render}` +
  `{#snippet}`) and a bats test asserting the bundle formats it — so a future
  svelte downgrade can't silently reintroduce the parse failure.

### Verified locally

- `nix build .#prettier-bundle` ✅ (builds with the new svelte + hash).
- Formatting the snippet fixture with the built bundle: `{#snippet row(label)}`
  and `{@render row(item)}` preserved, `class='item'` → `class="item"`,
  reflowed to 2-space indent ✅.
- Existing `svelte-with-enum` fixture still formats correctly under svelte 5
  (enum body intact, double quotes) — no regression ✅.

Found while scaffolding a Svelte 5 SvelteKit frontend on top of rainix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Svelte support in the Prettier bundle to version 5.56.5.
  * Improved formatting compatibility for Svelte 5 snippet and render syntax.

* **Tests**
  * Added coverage validating formatting of Svelte 5 components using snippets, rendering, TypeScript props, and list iteration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->