### PR TITLE
fix: require script/Build.sol in copy-artifacts, no silent skip

### DIFF
--- a/.github/workflows/rainix-copy-artifacts.yaml
+++ b/.github/workflows/rainix-copy-artifacts.yaml
@@ -29,32 +29,19 @@ jobs:
       - name: Regenerate meta artifacts
         if: hashFiles('script/build-meta.sh') != ''
         run: nix develop github:rainlanguage/rainix/${{ env.RAINIX_SHA }}#sol-shell -c ./script/build-meta.sh
-      # A repo that commits generated sources but exposes no regen step passes
-      # every check below without anything being regenerated, which is
-      # indistinguishable from a real pass. Fail loudly instead.
-      - name: Assert committed generated sources have a regen step
+      # Committed generated sources must be regenerable here, or the currency
+      # check below passes without checking anything. The codegen script is
+      # `script/Build.sol`, matched exactly: a repo that renames or drops it
+      # goes red rather than skipping regeneration and reporting green.
+      - name: Regenerate generated sources
         run: |
-          if [ -d src/generated ] \
-            && [ ! -f script/Build.sol ] \
-            && [ ! -f script/BuildPointers.sol ] \
-            && [ ! -f script/build.sh ]; then
-            echo "::error::src/generated/ is committed but no regen step was found (script/Build.sol, script/BuildPointers.sol or script/build.sh), so the currency check below would pass without regenerating anything."
+          if [ -d src/generated ] && [ ! -f script/Build.sol ]; then
+            echo "::error::src/generated/ is committed but script/Build.sol was not found, so the committed sources cannot be currency checked here. The codegen script must be script/Build.sol."
             exit 1
           fi
-      # The codegen script is consumer named: `script/Build.sol` is the
-      # convention, `script/BuildPointers.sol` the legacy name. Both are matched
-      # because a repo that renames its script must not silently stop being
-      # regenerated, and so must not be forced to rename in lockstep with this
-      # workflow, which consumers track at @main.
-      - name: Regenerate generated sources
-        if: hashFiles('script/Build.sol', 'script/BuildPointers.sol') != ''
-        run: |
-          for candidate in script/Build.sol script/BuildPointers.sol; do
-            if [ -f "$candidate" ]; then
-              nix develop github:rainlanguage/rainix/${{ env.RAINIX_SHA }}#sol-shell -c forge script "./$candidate"
-              break
-            fi
-          done
+          if [ -f script/Build.sol ]; then
+            nix develop github:rainlanguage/rainix/${{ env.RAINIX_SHA }}#sol-shell -c forge script ./script/Build.sol
+          fi
       - name: Build Solidity
         run: nix develop github:rainlanguage/rainix/${{ env.RAINIX_SHA }}#sol-shell -c forge build
       - name: Copy forge artifacts into committed location
@@ -71,6 +58,6 @@ jobs:
       - name: Assert committed artifacts match freshly built
         run: |
           if ! git diff --exit-code; then
-            echo "::error::Committed artifacts are stale. Regenerate (script/build-meta.sh, your codegen script, script/CopyArtifacts.sol, script/build.sh, forge fmt) and commit."
+            echo "::error::Committed artifacts are stale. Regenerate (script/build-meta.sh, script/Build.sol, script/CopyArtifacts.sol, script/build.sh, forge fmt) and commit."
             exit 1
           fi

--- a/.github/workflows/rainix-copy-artifacts.yaml
+++ b/.github/workflows/rainix-copy-artifacts.yaml
@@ -29,9 +29,32 @@ jobs:
       - name: Regenerate meta artifacts
         if: hashFiles('script/build-meta.sh') != ''
         run: nix develop github:rainlanguage/rainix/${{ env.RAINIX_SHA }}#sol-shell -c ./script/build-meta.sh
-      - name: Regenerate pointer artifacts
-        if: hashFiles('script/BuildPointers.sol') != ''
-        run: nix develop github:rainlanguage/rainix/${{ env.RAINIX_SHA }}#sol-shell -c forge script ./script/BuildPointers.sol
+      # A repo that commits generated sources but exposes no regen step passes
+      # every check below without anything being regenerated, which is
+      # indistinguishable from a real pass. Fail loudly instead.
+      - name: Assert committed generated sources have a regen step
+        run: |
+          if [ -d src/generated ] \
+            && [ ! -f script/Build.sol ] \
+            && [ ! -f script/BuildPointers.sol ] \
+            && [ ! -f script/build.sh ]; then
+            echo "::error::src/generated/ is committed but no regen step was found (script/Build.sol, script/BuildPointers.sol or script/build.sh), so the currency check below would pass without regenerating anything."
+            exit 1
+          fi
+      # The codegen script is consumer named: `script/Build.sol` is the
+      # convention, `script/BuildPointers.sol` the legacy name. Both are matched
+      # because a repo that renames its script must not silently stop being
+      # regenerated, and so must not be forced to rename in lockstep with this
+      # workflow, which consumers track at @main.
+      - name: Regenerate generated sources
+        if: hashFiles('script/Build.sol', 'script/BuildPointers.sol') != ''
+        run: |
+          for candidate in script/Build.sol script/BuildPointers.sol; do
+            if [ -f "$candidate" ]; then
+              nix develop github:rainlanguage/rainix/${{ env.RAINIX_SHA }}#sol-shell -c forge script "./$candidate"
+              break
+            fi
+          done
       - name: Build Solidity
         run: nix develop github:rainlanguage/rainix/${{ env.RAINIX_SHA }}#sol-shell -c forge build
       - name: Copy forge artifacts into committed location
@@ -48,6 +71,6 @@ jobs:
       - name: Assert committed artifacts match freshly built
         run: |
           if ! git diff --exit-code; then
-            echo "::error::Committed artifacts are stale. Regenerate (script/build-meta.sh, script/BuildPointers.sol, script/CopyArtifacts.sol, script/build.sh, forge fmt) and commit."
+            echo "::error::Committed artifacts are stale. Regenerate (script/build-meta.sh, your codegen script, script/CopyArtifacts.sol, script/build.sh, forge fmt) and commit."
             exit 1
           fi


### PR DESCRIPTION
`rainix-copy-artifacts` gates regeneration on an exact filename:

```yaml
- name: Regenerate pointer artifacts
  if: hashFiles('script/BuildPointers.sol') != ''
  run: ... forge script ./script/BuildPointers.sol
```

A repo whose codegen script is named anything else doesn't fail — the step is **skipped**, then `forge build` + `forge fmt` + `git diff` run and pass. The job goes green having regenerated nothing, so the committed artifacts are no longer currency-checked at all. A stale-detection check that silently stops detecting is worse than not having one, because the green is read as proof.

Observable now on https://github.com/rainlanguage/rain.sol.codegen/pull/31, which renames its script:

```
skipped    Regenerate pointer artifacts
success    Build Solidity
success    Format
failure    Assert committed artifacts match freshly built   <- only a fmt diff
```

## Change

The codegen script is `script/Build.sol`, matched exactly. If `src/generated/` is committed and `script/Build.sol` is absent, the job **errors**. No legacy name, no `hashFiles` skip — a repo that renames or drops its script goes red instead of quietly reporting green over an unchecked tree.

Tolerating the legacy name was the obvious migration path and is deliberately not taken: a second accepted name keeps the hazard alive (the guard still can't tell "renamed" from "absent") and lets the rename defer forever. Repos that don't want to upgrade on this workflow's schedule pin rainix to a SHA.

## This is a flag day

On merge, every repo below goes red until it renames `script/BuildPointers.sol` -> `script/Build.sol`:

| repo | `src/generated` | regen script |
|---|---|---|
| rain.erc4626.words, rain.flare, rain.math.float, rain.merkle, rain.pyth, rain.sol.codegen, raindex, rainlang | yes | `BuildPointers.sol` -> **must rename** |
| rain.metadata | no | none — unaffected |

The fix per repo is `git mv script/BuildPointers.sol script/Build.sol`. `rain.metadata` has nothing generated, so the new guard never fires for it.

## Related

- https://github.com/rainlanguage/rain.sol.codegen/pull/31 — renames codegen's own script and drops the `.pointers.sol` suffix from `LibFs`/`LibSnapshot`. Must not merge before this lands, or its artifact check passes while skipping regeneration.
