### PR TITLE
Add Ethereum mainnet to the rainix-sol fork-test RPCs

### DIFF
--- a/.github/workflows/rainix-sol-test.yaml
+++ b/.github/workflows/rainix-sol-test.yaml
@@ -14,6 +14,8 @@ on:
         required: false
       RPC_URL_BASE_SEPOLIA_FORK:
         required: false
+      RPC_URL_ETHEREUM_FORK:
+        required: false
       RPC_URL_FLARE_FORK:
         required: false
       RPC_URL_POLYGON_FORK:
@@ -33,6 +35,7 @@ jobs:
       ARBITRUM_RPC_URL: ${{ secrets.RPC_URL_ARBITRUM_FORK || vars.RPC_URL_ARBITRUM_FORK }}
       BASE_RPC_URL: ${{ secrets.RPC_URL_BASE_FORK || vars.RPC_URL_BASE_FORK }}
       BASE_SEPOLIA_RPC_URL: ${{ secrets.RPC_URL_BASE_SEPOLIA_FORK || vars.RPC_URL_BASE_SEPOLIA_FORK }}
+      ETHEREUM_RPC_URL: ${{ secrets.RPC_URL_ETHEREUM_FORK || vars.RPC_URL_ETHEREUM_FORK }}
       FLARE_RPC_URL: ${{ secrets.RPC_URL_FLARE_FORK || vars.RPC_URL_FLARE_FORK }}
       POLYGON_RPC_URL: ${{ secrets.RPC_URL_POLYGON_FORK || vars.RPC_URL_POLYGON_FORK }}
     steps:

--- a/.github/workflows/rainix-sol.yaml
+++ b/.github/workflows/rainix-sol.yaml
@@ -14,6 +14,8 @@ on:
         required: false
       RPC_URL_BASE_SEPOLIA_FORK:
         required: false
+      RPC_URL_ETHEREUM_FORK:
+        required: false
       RPC_URL_FLARE_FORK:
         required: false
       RPC_URL_POLYGON_FORK:
@@ -32,5 +34,6 @@ jobs:
       RPC_URL_ARBITRUM_FORK: ${{ secrets.RPC_URL_ARBITRUM_FORK }}
       RPC_URL_BASE_FORK: ${{ secrets.RPC_URL_BASE_FORK }}
       RPC_URL_BASE_SEPOLIA_FORK: ${{ secrets.RPC_URL_BASE_SEPOLIA_FORK }}
+      RPC_URL_ETHEREUM_FORK: ${{ secrets.RPC_URL_ETHEREUM_FORK }}
       RPC_URL_FLARE_FORK: ${{ secrets.RPC_URL_FLARE_FORK }}
       RPC_URL_POLYGON_FORK: ${{ secrets.RPC_URL_POLYGON_FORK }}


### PR DESCRIPTION
The `rainix-sol` reusables wire fork-test RPCs for arbitrum / base / base_sepolia / flare / polygon, but **not Ethereum mainnet**. So a consumer whose fork test does `vm.createSelectFork("ethereum")` has no `ETHEREUM_RPC_URL` in the CI env and fails with `environment variable ETHEREUM_RPC_URL not found`.

This adds `RPC_URL_ETHEREUM_FORK` through the chain, mapped to `ETHEREUM_RPC_URL` exactly like every other network:

- `rainix-sol.yaml` — declares the optional secret and passes it to `rainix-sol-test`.
- `rainix-sol-test.yaml` — declares it and maps `ETHEREUM_RPC_URL: ${{ secrets.RPC_URL_ETHEREUM_FORK || vars.RPC_URL_ETHEREUM_FORK }}`.

Optional (`required: false`), so consumers that don't set the secret are unaffected. Unblocks `S01-Issuer/st0x.deploy#227`, which adds Ethereum mainnet to the ST0x deploy networks and needs the fork test to resolve an Ethereum RPC.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added optional Ethereum fork RPC configuration to reusable automation workflows.
  * Enabled test jobs to use the configured Ethereum fork endpoint when provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->