### PR TITLE
Add Ethereum mainnet to the rainix manual-sol-artifacts deploy RPCs

### DIFF
--- a/.github/workflows/rainix-manual-sol-artifacts.yaml
+++ b/.github/workflows/rainix-manual-sol-artifacts.yaml
@@ -27,6 +27,8 @@ on:
         required: false
       RPC_URL_BASE_SEPOLIA_FORK:
         required: false
+      RPC_URL_ETHEREUM_FORK:
+        required: false
       RPC_URL_FLARE_FORK:
         required: false
       RPC_URL_POLYGON_FORK:
@@ -36,6 +38,8 @@ on:
       CI_DEPLOY_BASE_ETHERSCAN_API_KEY:
         required: false
       CI_DEPLOY_BASE_SEPOLIA_ETHERSCAN_API_KEY:
+        required: false
+      CI_DEPLOY_ETHEREUM_ETHERSCAN_API_KEY:
         required: false
       CI_DEPLOY_POLYGON_ETHERSCAN_API_KEY:
         required: false
@@ -75,6 +79,7 @@ jobs:
           ARBITRUM_RPC_URL: ${{ secrets.RPC_URL_ARBITRUM_FORK || vars.RPC_URL_ARBITRUM_FORK || '' }}
           BASE_RPC_URL: ${{ secrets.RPC_URL_BASE_FORK || vars.RPC_URL_BASE_FORK || '' }}
           BASE_SEPOLIA_RPC_URL: ${{ secrets.RPC_URL_BASE_SEPOLIA_FORK || vars.RPC_URL_BASE_SEPOLIA_FORK || '' }}
+          ETHEREUM_RPC_URL: ${{ secrets.RPC_URL_ETHEREUM_FORK || vars.RPC_URL_ETHEREUM_FORK || '' }}
           FLARE_RPC_URL: ${{ secrets.RPC_URL_FLARE_FORK || vars.RPC_URL_FLARE_FORK || '' }}
           POLYGON_RPC_URL: ${{ secrets.RPC_URL_POLYGON_FORK || vars.RPC_URL_POLYGON_FORK || '' }}
           # Etherscan V2 is a single multichain API key: source all Etherscan-family
@@ -84,5 +89,6 @@ jobs:
           CI_DEPLOY_ARBITRUM_ETHERSCAN_API_KEY: ${{ secrets.EXPLORER_VERIFICATION_KEY || secrets.CI_DEPLOY_ARBITRUM_ETHERSCAN_API_KEY || vars.CI_DEPLOY_ARBITRUM_ETHERSCAN_API_KEY || '' }}
           CI_DEPLOY_BASE_ETHERSCAN_API_KEY: ${{ secrets.EXPLORER_VERIFICATION_KEY || secrets.CI_DEPLOY_BASE_ETHERSCAN_API_KEY || vars.CI_DEPLOY_BASE_ETHERSCAN_API_KEY || '' }}
           CI_DEPLOY_BASE_SEPOLIA_ETHERSCAN_API_KEY: ${{ secrets.EXPLORER_VERIFICATION_KEY || secrets.CI_DEPLOY_BASE_SEPOLIA_ETHERSCAN_API_KEY || vars.CI_DEPLOY_BASE_SEPOLIA_ETHERSCAN_API_KEY || '' }}
+          CI_DEPLOY_ETHEREUM_ETHERSCAN_API_KEY: ${{ secrets.EXPLORER_VERIFICATION_KEY || secrets.CI_DEPLOY_ETHEREUM_ETHERSCAN_API_KEY || vars.CI_DEPLOY_ETHEREUM_ETHERSCAN_API_KEY || '' }}
           CI_DEPLOY_POLYGON_ETHERSCAN_API_KEY: ${{ secrets.EXPLORER_VERIFICATION_KEY || secrets.CI_DEPLOY_POLYGON_ETHERSCAN_API_KEY || vars.CI_DEPLOY_POLYGON_ETHERSCAN_API_KEY || '' }}
           CI_DEPLOY_FLARE_ETHERSCAN_API_KEY: ${{ secrets.CI_DEPLOY_FLARE_ETHERSCAN_API_KEY || vars.CI_DEPLOY_FLARE_ETHERSCAN_API_KEY || '' }}


### PR DESCRIPTION
Companion to #274 (which added Ethereum to the fork-**test** reusables). The **deploy** reusable `rainix-manual-sol-artifacts.yaml` has the same 5-network list — arbitrum / base / base_sepolia / flare / polygon — and no Ethereum. So a consumer broadcasting a deploy suite to Ethereum mainnet has no `ETHEREUM_RPC_URL` and no verification key.

This wires Ethereum the same way as every other network:
- `RPC_URL_ETHEREUM_FORK` (secret) → `ETHEREUM_RPC_URL` (env)
- `CI_DEPLOY_ETHEREUM_ETHERSCAN_API_KEY` (secret) → same-named env, with the `EXPLORER_VERIFICATION_KEY` fallback like the others

Both `required: false`. Together with #274 this completes the Ethereum wiring `S01-Issuer/st0x.deploy#227` needs — test *and* deploy.