### PR TITLE
rainix-manual-sol-artifacts: add script + verify inputs

### DIFF
--- a/.github/workflows/rainix-manual-sol-artifacts.yaml
+++ b/.github/workflows/rainix-manual-sol-artifacts.yaml
@@ -6,8 +6,25 @@ on:
         type: string
         required: true
         description: |
-          Passed through as `DEPLOYMENT_SUITE`. `script/Deploy.sol` dispatches
-          on this to select what to deploy.
+          Passed through as `DEPLOYMENT_SUITE`. The deploy script dispatches on
+          this to select what to deploy.
+      script:
+        type: string
+        required: false
+        default: script/Deploy.sol:Deploy
+        description: |
+          Fully qualified forge script target (`path:Contract`) to run. Defaults
+          to the conventional `script/Deploy.sol:Deploy`. Override to run an
+          alternate deploy script in the same repo.
+      verify:
+        type: boolean
+        required: false
+        default: true
+        description: |
+          Whether to pass `--verify` to `forge script`. Disable when deploying
+          bytecode that does not match the current source (e.g. a pinned
+          historical release deployed from stored creation code), where Etherscan
+          verification against current source would fail the run.
     # Secrets consumed by the deploy step. Declared here so callers in a
     # different organization can pass them explicitly — `secrets: inherit`
     # only forwards a caller's secrets within the same org, so a cross-org
@@ -72,7 +89,7 @@ jobs:
         if: hashFiles('soldeer.lock') != ''
         run: nix develop github:rainlanguage/rainix/${{ env.RAINIX_SHA }}#sol-shell -c forge soldeer install
       - run: nix develop github:rainlanguage/rainix/${{ env.RAINIX_SHA }}#sol-shell -c forge selectors up --all
-      - run: nix develop github:rainlanguage/rainix/${{ env.RAINIX_SHA }}#sol-shell -c forge script script/Deploy.sol:Deploy -vvvvv --slow --broadcast --verify
+      - run: nix develop github:rainlanguage/rainix/${{ env.RAINIX_SHA }}#sol-shell -c forge script ${{ inputs.script }} -vvvvv --slow --broadcast ${{ inputs.verify && '--verify' || '' }}
         env:
           DEPLOYMENT_SUITE: ${{ inputs.suite }}
           DEPLOYMENT_KEY: ${{ secrets.PRIVATE_KEY }}


### PR DESCRIPTION
Adds two optional `workflow_call` inputs to `rainix-manual-sol-artifacts.yaml`:

- **`script`** (default `script/Deploy.sol:Deploy`) — the fully qualified forge script target to run, so a consumer can run an alternate deploy script in the same repo.
- **`verify`** (default `true`) — whether to pass `--verify` to `forge script`. Disable when deploying bytecode that does not match the current source (e.g. a pinned historical release deployed from stored creation code), where Etherscan verification against current source would fail the run.

The forge invocation becomes:

```
forge script ${{ inputs.script }} -vvvvv --slow --broadcast ${{ inputs.verify && '--verify' || '' }}
```

Both inputs default to the prior behaviour, so existing callers (st0x.deploy `manual-sol-artifacts.yaml`, etc.) are unaffected.

**Motivation:** st0x.deploy is launching the audited 0.1.1 production set on Ethereum mainnet from a new `script/DeployProdV4_0_1_1.sol` that deploys the stored 0.1.1 creation bytecode. That script needs `script:` to be selected and `verify: false` because the 0.1.1 bytecode of the contracts that changed by 0.1.3 won't Etherscan-verify against the current source; those are verified manually from the 0.1.1 tag afterward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployment workflows now support selecting a custom deployment script.
  * Deployment verification can be enabled or disabled per workflow run.
  * Deployment configuration inputs include clearer descriptions and defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->