### PR TITLE
feat(sol-artifacts): network input, HyperEVM RPC slot, optional --legacy

### DIFF
--- a/.github/workflows/rainix-manual-sol-artifacts.yaml
+++ b/.github/workflows/rainix-manual-sol-artifacts.yaml
@@ -16,6 +16,22 @@ on:
           Fully qualified forge script target (`path:Contract`) to run. Defaults
           to the conventional `script/Deploy.sol:Deploy`. Override to run an
           alternate deploy script in the same repo.
+      network:
+        type: string
+        required: false
+        default: ''
+        description: |
+          Passed through as `DEPLOYMENT_NETWORK`. Deploy scripts that support
+          multiple bootstrap networks dispatch on this to select which network
+          to broadcast to; scripts that ignore it keep their own default.
+      legacy:
+        type: boolean
+        required: false
+        default: false
+        description: |
+          Whether to pass `--legacy` to `forge script`. Required on networks
+          whose RPCs reject the fee-history ranges EIP-1559 estimation uses
+          (e.g. HyperEVM); type-0 transactions work everywhere.
       verify:
         type: boolean
         required: false
@@ -47,6 +63,8 @@ on:
       RPC_URL_ETHEREUM_FORK:
         required: false
       RPC_URL_FLARE_FORK:
+        required: false
+      RPC_URL_HYPEREVM_FORK:
         required: false
       RPC_URL_POLYGON_FORK:
         required: false
@@ -89,15 +107,17 @@ jobs:
         if: hashFiles('soldeer.lock') != ''
         run: nix develop github:rainlanguage/rainix/${{ env.RAINIX_SHA }}#sol-shell -c forge soldeer install
       - run: nix develop github:rainlanguage/rainix/${{ env.RAINIX_SHA }}#sol-shell -c forge selectors up --all
-      - run: nix develop github:rainlanguage/rainix/${{ env.RAINIX_SHA }}#sol-shell -c forge script ${{ inputs.script }} -vvvvv --slow --broadcast ${{ inputs.verify && '--verify' || '' }}
+      - run: nix develop github:rainlanguage/rainix/${{ env.RAINIX_SHA }}#sol-shell -c forge script ${{ inputs.script }} -vvvvv --slow --broadcast ${{ inputs.verify && '--verify' || '' }} ${{ inputs.legacy && '--legacy' || '' }}
         env:
           DEPLOYMENT_SUITE: ${{ inputs.suite }}
+          DEPLOYMENT_NETWORK: ${{ inputs.network }}
           DEPLOYMENT_KEY: ${{ secrets.PRIVATE_KEY }}
           ARBITRUM_RPC_URL: ${{ secrets.RPC_URL_ARBITRUM_FORK || vars.RPC_URL_ARBITRUM_FORK || '' }}
           BASE_RPC_URL: ${{ secrets.RPC_URL_BASE_FORK || vars.RPC_URL_BASE_FORK || '' }}
           BASE_SEPOLIA_RPC_URL: ${{ secrets.RPC_URL_BASE_SEPOLIA_FORK || vars.RPC_URL_BASE_SEPOLIA_FORK || '' }}
           ETHEREUM_RPC_URL: ${{ secrets.RPC_URL_ETHEREUM_FORK || vars.RPC_URL_ETHEREUM_FORK || '' }}
           FLARE_RPC_URL: ${{ secrets.RPC_URL_FLARE_FORK || vars.RPC_URL_FLARE_FORK || '' }}
+          HYPEREVM_RPC_URL: ${{ secrets.RPC_URL_HYPEREVM_FORK || vars.RPC_URL_HYPEREVM_FORK || '' }}
           POLYGON_RPC_URL: ${{ secrets.RPC_URL_POLYGON_FORK || vars.RPC_URL_POLYGON_FORK || '' }}
           # Etherscan V2 is a single multichain API key: source all Etherscan-family
           # networks from the one EXPLORER_VERIFICATION_KEY secret (legacy per-chain


### PR DESCRIPTION
Three additive knobs on `rainix-manual-sol-artifacts.yaml` so multichain bootstrap deploys (ST0x HyperEVM, RAI-1511) can keep using the reusable instead of forking it into caller-local jobs:

- **`network` input** → passed through as `DEPLOYMENT_NETWORK`. Deploy scripts that support multiple bootstrap networks dispatch on it; scripts that ignore the env are unaffected (default `''`).
- **`RPC_URL_HYPEREVM_FORK` secret slot** → `HYPEREVM_RPC_URL` env, matching the existing per-network pattern (secrets → vars → '' fallback).
- **`legacy` input** appending `--legacy`: HyperEVM's RPC rejects the fee-history ranges forge's EIP-1559 estimation uses (verified against a live fork); type-0 transactions work on every network.

All defaults preserve current behaviour for existing callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPs1hCTxusmaSeFKvoc4Kr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployment workflows can now target a selected network.
  * Added optional legacy transaction mode for deployments.
  * Added HyperEVM fork RPC configuration support.
  * Deployment verification and transaction options are applied based on the selected settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->