### PR TITLE
make rainix-sol-artifacts hermetic: own anvil when no ETH_RPC_URL (fixes main red)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,8 +23,6 @@ jobs:
             task: rainix-rs-static
       fail-fast: false
     runs-on: ${{ matrix.os }}
-    env:
-      DEPLOYMENT_KEY: ${{ secrets.PRIVATE_KEY }}
     defaults:
       run:
         working-directory: test/fixture
@@ -65,8 +63,8 @@ jobs:
           restore-keys: |
             foundry-full-${{ runner.os }}-
       - run: nix develop ../.. --command forge soldeer install
+      # rainix-sol-artifacts runs hermetically here: with no ETH_RPC_URL the
+      # task deploys against its own ephemeral anvil, so this job needs no RPC
+      # or key secrets.
       - name: Run ${{ matrix.task }}
-        env:
-          ETH_RPC_URL: ${{ secrets.RPC_URL_ETHEREUM_FORK || vars.RPC_URL_ETHEREUM_FORK }}
-          ETHERSCAN_API_KEY: ${{ secrets.EXPLORER_VERIFICATION_KEY }}
         run: nix develop ../.. --command ${{ matrix.task }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,6 +67,6 @@ jobs:
       - run: nix develop ../.. --command forge soldeer install
       - name: Run ${{ matrix.task }}
         env:
-          ETH_RPC_URL: ${{ secrets.CI_DEPLOY_SEPOLIA_RPC_URL || vars.CI_DEPLOY_SEPOLIA_RPC_URL }}
+          ETH_RPC_URL: ${{ secrets.RPC_URL_ETHEREUM_FORK || vars.RPC_URL_ETHEREUM_FORK }}
           ETHERSCAN_API_KEY: ${{ secrets.EXPLORER_VERIFICATION_KEY }}
         run: nix develop ../.. --command ${{ matrix.task }}

--- a/flake.nix
+++ b/flake.nix
@@ -249,9 +249,25 @@
               trap 'kill "''${anvil_pid}" 2>/dev/null' EXIT
               export ETH_RPC_URL='http://127.0.0.1:18545'
               export DEPLOYMENT_KEY='0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
-              until cast chain-id --rpc-url "''${ETH_RPC_URL}" >/dev/null 2>&1; do
+              # Bounded readiness wait: an anvil that died or never bound the
+              # port must fail here with a clear message, not hang the task
+              # until the surrounding job's timeout.
+              anvil_ready=""
+              for _ in $(seq 1 100); do
+                if ! kill -0 "''${anvil_pid}" 2>/dev/null; then
+                  echo 'rainix-sol-artifacts: anvil exited during startup' >&2
+                  exit 1
+                fi
+                if cast chain-id --rpc-url "''${ETH_RPC_URL}" >/dev/null 2>&1; then
+                  anvil_ready=1
+                  break
+                fi
                 sleep 0.2
               done
+              if [[ -z "''${anvil_ready}" ]]; then
+                echo "rainix-sol-artifacts: anvil not ready on ''${ETH_RPC_URL} after 20s" >&2
+                exit 1
+              fi
             fi
 
             # Deploy all contracts to testnet.

--- a/flake.nix
+++ b/flake.nix
@@ -237,6 +237,23 @@
             # Upload all function selectors to the registry.
             forge selectors up --all
 
+            # With no ETH_RPC_URL the task is hermetic: it runs against its own
+            # ephemeral anvil instance with anvil's first funded dev account as
+            # the deployment key, so it needs no secrets and no external RPC.
+            # An explicit ETH_RPC_URL (a real deploy) always wins and leaves
+            # DEPLOYMENT_KEY untouched. Port 18545 avoids clobbering a dev's
+            # own anvil on the default 8545.
+            if [[ -z "''${ETH_RPC_URL:-}" ]]; then
+              anvil --port 18545 --silent &
+              anvil_pid=$!
+              trap 'kill "''${anvil_pid}" 2>/dev/null' EXIT
+              export ETH_RPC_URL='http://127.0.0.1:18545'
+              export DEPLOYMENT_KEY='0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
+              until cast chain-id --rpc-url "''${ETH_RPC_URL}" >/dev/null 2>&1; do
+                sleep 0.2
+              done
+            fi
+
             # Deploy all contracts to testnet.
             # Assumes the existence of a `Deploy.sol` script in the `script` directory.
             # Echos the deploy pubkey to stdout to make it easy to add gas to the account.

--- a/test/bats/task/skip-simulation.test.bats
+++ b/test/bats/task/skip-simulation.test.bats
@@ -13,12 +13,14 @@ teardown() {
 }
 
 forge_deploy() {
-  forge script script/Deploy.sol:Deploy \
+  # The fixture Deploy.sol reads DEPLOYMENT_KEY itself (consumer convention);
+  # anvil's first funded dev account.
+  DEPLOYMENT_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 \
+    forge script script/Deploy.sol:Deploy \
     -vvvvv \
     --broadcast \
     ${DEPLOY_SKIP_SIMULATION:+--skip-simulation} \
     --rpc-url http://127.0.0.1:8545 \
-    --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 \
     2>&1
 }
 

--- a/test/fixture/script/Deploy.sol
+++ b/test/fixture/script/Deploy.sol
@@ -8,8 +8,14 @@ import {Counter} from "../src/Counter.sol";
 contract Deploy is Script {
     function setUp() public {}
 
+    /// Reads the deployer key from `DEPLOYMENT_KEY`, the same convention as
+    /// the consumer `Deploy.sol` scripts `rainix-sol-artifacts` runs, so the
+    /// fixture exercises the task exactly as consumers do (broadcast included
+    /// — a bare `vm.broadcast()` would hit foundry's default-sender refusal).
     function run() public {
-        vm.broadcast();
+        uint256 deployerPrivateKey = vm.envUint("DEPLOYMENT_KEY");
+        vm.startBroadcast(deployerPrivateKey);
         new Counter();
+        vm.stopBroadcast();
     }
 }


### PR DESCRIPTION
## Problem

The `rainix-sol-artifacts` CI job (runs in `test/fixture/`) depended on a live external RPC:

- **main is red**: the `CI_DEPLOY_SEPOLIA_RPC_URL` secret was deleted, so `ETH_RPC_URL` is empty → `Connection refused`.
- **Repointing at `RPC_URL_ETHEREUM_FORK` (this PR's first commit) cannot work**: the RPC connects, but the first attempt fails (drpc free-plan 408s / unfunded key), and the retry's `--resume` then looks for a recorded broadcast for chain 1 that doesn't exist → `Error: Deployment not found for chain 1`. Any external RPC keeps the job hostage to secrets, key rotation, and rate limits.

## Fix: hermetic by default

`rainix-sol-artifacts` now starts its **own ephemeral anvil** when no `ETH_RPC_URL` is provided (port 18545, killed on exit), with anvil's first funded dev account as `DEPLOYMENT_KEY`. An explicit `ETH_RPC_URL` — a real deploy — always wins and leaves `DEPLOYMENT_KEY` untouched. This mirrors the existing precedent in `test/bats/task/skip-simulation.test.bats`, which already spins anvil with the same dev key.

- `test/fixture/script/Deploy.sol` now reads `DEPLOYMENT_KEY` exactly like consumer deploy scripts, so the fixture exercises the task as consumers run it (bare `vm.broadcast()` hits foundry's default-sender refusal under broadcast).
- `test.yml` drops all secret plumbing from the job (`PRIVATE_KEY`, RPC URL, etherscan key): the artifacts job now needs **no secrets and no external network**.

## Verification (local, repo's own nix shells)

- Hermetic simulation run (the CI path): `rainix-sol-artifacts` exit 0, `SIMULATION COMPLETE`, anvil reaped by trap.
- Hermetic broadcast run (`DEPLOY_BROADCAST=1`): exit 0, `ONCHAIN EXECUTION COMPLETE & SUCCESSFUL`.
- Explicit-RPC mode (own anvil on another port + `ETH_RPC_URL`/`DEPLOYMENT_KEY` set): task exit 0 — explicit config wins as before. The retry loop (where `--resume` lives) is untouched by this diff; with a healthy local chain the first attempt succeeds so the retry path never fires in CI.
- `bats test/bats/task/skip-simulation.test.bats`: 2/2 ok.
- Commit-time pre-commit hooks: all green (yamlfmt, nixfmt, deadnix, statix, nil, shellcheck). The `--all-files` rustfmt failure is pre-existing on an untouched main clone (no repo-root `Cargo.toml`) and untriggered by this diff (no `.rs` changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI so the artifacts job no longer requires external RPC/API secrets and runs hermetically.
  * Enhanced the deployment task to auto-start a local anvil instance (and set the needed RPC/deployment key) when no `ETH_RPC_URL` is provided.
* **Tests**
  * Updated deployment test helpers and fixtures to provide the deployment key via the `DEPLOYMENT_KEY` environment variable, ensuring consistent broadcasting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->