### PR TITLE
rainix-sol test workflow: add RPC_URL_HYPEREVM_FORK secret slot

### DIFF
--- a/.github/workflows/rainix-sol-test.yaml
+++ b/.github/workflows/rainix-sol-test.yaml
@@ -18,6 +18,8 @@ on:
         required: false
       RPC_URL_FLARE_FORK:
         required: false
+      RPC_URL_HYPEREVM_FORK:
+        required: false
       RPC_URL_POLYGON_FORK:
         required: false
 env:
@@ -37,6 +39,7 @@ jobs:
       BASE_SEPOLIA_RPC_URL: ${{ secrets.RPC_URL_BASE_SEPOLIA_FORK || vars.RPC_URL_BASE_SEPOLIA_FORK }}
       ETHEREUM_RPC_URL: ${{ secrets.RPC_URL_ETHEREUM_FORK || vars.RPC_URL_ETHEREUM_FORK }}
       FLARE_RPC_URL: ${{ secrets.RPC_URL_FLARE_FORK || vars.RPC_URL_FLARE_FORK }}
+      HYPEREVM_RPC_URL: ${{ secrets.RPC_URL_HYPEREVM_FORK || vars.RPC_URL_HYPEREVM_FORK }}
       POLYGON_RPC_URL: ${{ secrets.RPC_URL_POLYGON_FORK || vars.RPC_URL_POLYGON_FORK }}
     steps:
       # Shared nix + cachix CI preamble (checkout, nix-quick-install, Cachix,

--- a/.github/workflows/rainix-sol.yaml
+++ b/.github/workflows/rainix-sol.yaml
@@ -18,6 +18,8 @@ on:
         required: false
       RPC_URL_FLARE_FORK:
         required: false
+      RPC_URL_HYPEREVM_FORK:
+        required: false
       RPC_URL_POLYGON_FORK:
         required: false
 jobs:
@@ -36,4 +38,5 @@ jobs:
       RPC_URL_BASE_SEPOLIA_FORK: ${{ secrets.RPC_URL_BASE_SEPOLIA_FORK }}
       RPC_URL_ETHEREUM_FORK: ${{ secrets.RPC_URL_ETHEREUM_FORK }}
       RPC_URL_FLARE_FORK: ${{ secrets.RPC_URL_FLARE_FORK }}
+      RPC_URL_HYPEREVM_FORK: ${{ secrets.RPC_URL_HYPEREVM_FORK }}
       RPC_URL_POLYGON_FORK: ${{ secrets.RPC_URL_POLYGON_FORK }}


### PR DESCRIPTION
The manual sol-artifacts workflow gained a HyperEVM RPC slot in #279, but the shared **test** workflow (`rainix-sol.yaml` → `rainix-sol-test.yaml`) did not — so callers' HyperEVM fork tests can never see `HYPEREVM_RPC_URL` in PR CI and stay env-gated.

This declares `RPC_URL_HYPEREVM_FORK` (optional, like the other fork RPCs) on `rainix-sol.yaml`, forwards it to the test job, and maps it to `HYPEREVM_RPC_URL` alongside the other fork RPC env vars. No behaviour change for callers that don't set the secret.

Unblocks S01-Issuer/st0x.deploy HyperEVM fork tests (RAI-1511).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPs1hCTxusmaSeFKvoc4Kr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added optional HyperEVM fork RPC configuration to automated testing workflows.
  * Supports sourcing the RPC URL from either a configured secret or repository variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->