### PR TITLE
Fail over fork RPC endpoints with an archive-aware preflight

### DIFF
--- a/.github/actions/rpc-preflight/action.yml
+++ b/.github/actions/rpc-preflight/action.yml
@@ -1,0 +1,27 @@
+name: rpc-preflight
+description: >-
+  Selects a working fork RPC endpoint per network and exports it as <NETWORK>_RPC_URL for the steps that follow, so a dead upstream fails over instead of reddening every fork suite in the org. Foundry maps one [rpc_endpoints] alias to exactly one URL and its --fork-retries only retries that same URL, so a deterministic upstream failure (plan quota exhausted, node is not archive, host is gone) cannot be recovered inside forge — it has to be recovered before forge starts. Candidates are the MERGED pool of the RPC_URL_<NETWORK>_FORK secret (newline-separated list of keyed/paid URLs), the RPC_URL_<NETWORK>_FORK variable (newline-separated list of public keyless URLs) and hardcoded public archive defaults; every entry in every source is a real candidate, the sources only set the order. Health is an archive-aware probe (chain id, then historical account state and a historical eth_call at the deepest block any repo in the org pins for that network) repeated until it passes consecutively, because a latest-only check happily selects a pruning node that then dies mid-suite. Only networks the repo actually references are probed; a network with no candidates at all is left exactly as it is today.
+inputs:
+  archive:
+    description: >-
+      Whether the endpoint must serve historical state. 'true' for fork test suites (they roll back months of blocks). 'false' for deploy/broadcast paths, which only ever read head state — requiring archive there would reject a healthy pruning endpoint for no benefit.
+    required: false
+    default: 'true'
+runs:
+  using: composite
+  steps:
+    - name: Select a healthy fork RPC per network
+      shell: bash
+      # Candidate URLs are NOT passed as `with:` inputs on purpose: GitHub
+      # renders a composite's resolved inputs into the log, which would print a
+      # keyed URL verbatim. They arrive as env vars set by the calling reusable
+      # (RAINIX_RPC_SECRET_<NET> / RAINIX_RPC_VARS_<NET>) and are read straight
+      # out of the environment by the binary, which never prints one.
+      run: |
+        set -euo pipefail
+        # Single source of truth: the Rust rainix-static binary (its unit tests
+        # run inside the nix build). The path: flake ref runs it from this
+        # composite's own checkout, so the check version always matches the
+        # action version regardless of any RAINIX_SHA the caller pins.
+        nix run "path:$(cd "$GITHUB_ACTION_PATH/../../.." && pwd)#rainix-static" -- \
+          rpc-preflight ${{ inputs.archive == 'true' && '' || '--no-archive' }}

--- a/.github/workflows/rainix-manual-sol-artifacts.yaml
+++ b/.github/workflows/rainix-manual-sol-artifacts.yaml
@@ -107,18 +107,38 @@ jobs:
         if: hashFiles('soldeer.lock') != ''
         run: nix develop github:rainlanguage/rainix/${{ env.RAINIX_SHA }}#sol-shell -c forge soldeer install
       - run: nix develop github:rainlanguage/rainix/${{ env.RAINIX_SHA }}#sol-shell -c forge selectors up --all
+      # archive: false — this is a broadcast, so it only ever reads head state.
+      # Requiring historical state here would reject a perfectly good pruning
+      # endpoint; the RPC_URL_<NET>_FORK name is a misnomer on this path.
+      # Candidate URLs travel as env, never as `with:` inputs, because GitHub
+      # renders a composite's resolved inputs into the log.
+      - name: RPC preflight
+        uses: rainlanguage/rainix/.github/actions/rpc-preflight@main
+        with:
+          archive: 'false'
+        env:
+          RAINIX_RPC_SECRET_ARBITRUM: ${{ secrets.RPC_URL_ARBITRUM_FORK }}
+          RAINIX_RPC_VARS_ARBITRUM: ${{ vars.RPC_URL_ARBITRUM_FORK }}
+          RAINIX_RPC_SECRET_BASE: ${{ secrets.RPC_URL_BASE_FORK }}
+          RAINIX_RPC_VARS_BASE: ${{ vars.RPC_URL_BASE_FORK }}
+          RAINIX_RPC_SECRET_BASE_SEPOLIA: ${{ secrets.RPC_URL_BASE_SEPOLIA_FORK }}
+          RAINIX_RPC_VARS_BASE_SEPOLIA: ${{ vars.RPC_URL_BASE_SEPOLIA_FORK }}
+          RAINIX_RPC_SECRET_ETHEREUM: ${{ secrets.RPC_URL_ETHEREUM_FORK }}
+          RAINIX_RPC_VARS_ETHEREUM: ${{ vars.RPC_URL_ETHEREUM_FORK }}
+          RAINIX_RPC_SECRET_FLARE: ${{ secrets.RPC_URL_FLARE_FORK }}
+          RAINIX_RPC_VARS_FLARE: ${{ vars.RPC_URL_FLARE_FORK }}
+          RAINIX_RPC_SECRET_HYPEREVM: ${{ secrets.RPC_URL_HYPEREVM_FORK }}
+          RAINIX_RPC_VARS_HYPEREVM: ${{ vars.RPC_URL_HYPEREVM_FORK }}
+          RAINIX_RPC_SECRET_POLYGON: ${{ secrets.RPC_URL_POLYGON_FORK }}
+          RAINIX_RPC_VARS_POLYGON: ${{ vars.RPC_URL_POLYGON_FORK }}
       - run: nix develop github:rainlanguage/rainix/${{ env.RAINIX_SHA }}#sol-shell -c forge script ${{ inputs.script }} -vvvvv --slow --broadcast ${{ inputs.verify && '--verify' || '' }} ${{ inputs.legacy && '--legacy' || '' }}
+        # <NETWORK>_RPC_URL is bound by the rpc-preflight step above, which picks
+        # a candidate that is reachable right now rather than binding one URL
+        # that may be dead.
         env:
           DEPLOYMENT_SUITE: ${{ inputs.suite }}
           DEPLOYMENT_NETWORK: ${{ inputs.network }}
           DEPLOYMENT_KEY: ${{ secrets.PRIVATE_KEY }}
-          ARBITRUM_RPC_URL: ${{ secrets.RPC_URL_ARBITRUM_FORK || vars.RPC_URL_ARBITRUM_FORK || '' }}
-          BASE_RPC_URL: ${{ secrets.RPC_URL_BASE_FORK || vars.RPC_URL_BASE_FORK || '' }}
-          BASE_SEPOLIA_RPC_URL: ${{ secrets.RPC_URL_BASE_SEPOLIA_FORK || vars.RPC_URL_BASE_SEPOLIA_FORK || '' }}
-          ETHEREUM_RPC_URL: ${{ secrets.RPC_URL_ETHEREUM_FORK || vars.RPC_URL_ETHEREUM_FORK || '' }}
-          FLARE_RPC_URL: ${{ secrets.RPC_URL_FLARE_FORK || vars.RPC_URL_FLARE_FORK || '' }}
-          HYPEREVM_RPC_URL: ${{ secrets.RPC_URL_HYPEREVM_FORK || vars.RPC_URL_HYPEREVM_FORK || '' }}
-          POLYGON_RPC_URL: ${{ secrets.RPC_URL_POLYGON_FORK || vars.RPC_URL_POLYGON_FORK || '' }}
           # Etherscan V2 is a single multichain API key: source all Etherscan-family
           # networks from the one EXPLORER_VERIFICATION_KEY secret (legacy per-chain
           # secret kept as fallback during migration). Flare/Songbird are NOT

--- a/.github/workflows/rainix-sol-test.yaml
+++ b/.github/workflows/rainix-sol-test.yaml
@@ -18,6 +18,8 @@ on:
         required: false
       RPC_URL_FLARE_FORK:
         required: false
+      RPC_URL_HYPEREVM_FORK:
+        required: false
       RPC_URL_POLYGON_FORK:
         required: false
 env:
@@ -32,12 +34,11 @@ jobs:
       CI_DEPLOY_SEPOLIA_RPC_URL: ${{ secrets.CI_DEPLOY_SEPOLIA_RPC_URL || vars.CI_DEPLOY_SEPOLIA_RPC_URL }}
       CI_FORK_SEPOLIA_BLOCK_NUMBER: ${{ vars.CI_FORK_SEPOLIA_BLOCK_NUMBER }}
       CI_FORK_SEPOLIA_DEPLOYER_ADDRESS: ${{ vars.CI_FORK_SEPOLIA_DEPLOYER_ADDRESS }}
-      ARBITRUM_RPC_URL: ${{ secrets.RPC_URL_ARBITRUM_FORK || vars.RPC_URL_ARBITRUM_FORK }}
-      BASE_RPC_URL: ${{ secrets.RPC_URL_BASE_FORK || vars.RPC_URL_BASE_FORK }}
-      BASE_SEPOLIA_RPC_URL: ${{ secrets.RPC_URL_BASE_SEPOLIA_FORK || vars.RPC_URL_BASE_SEPOLIA_FORK }}
-      ETHEREUM_RPC_URL: ${{ secrets.RPC_URL_ETHEREUM_FORK || vars.RPC_URL_ETHEREUM_FORK }}
-      FLARE_RPC_URL: ${{ secrets.RPC_URL_FLARE_FORK || vars.RPC_URL_FLARE_FORK }}
-      POLYGON_RPC_URL: ${{ secrets.RPC_URL_POLYGON_FORK || vars.RPC_URL_POLYGON_FORK }}
+      # <NETWORK>_RPC_URL is NOT set here. foundry.toml's [rpc_endpoints] still
+      # read ${<NETWORK>_RPC_URL}, but the rpc-preflight step below picks which
+      # candidate to bind to each one and writes it to $GITHUB_ENV. A static
+      # mapping cannot fail over, and a single dead upstream reds every fork
+      # suite in the org.
     steps:
       # Shared nix + cachix CI preamble (checkout, nix-quick-install, Cachix,
       # cache-nix-action) — pinned action SHAs live in the composite. Fully
@@ -59,4 +60,25 @@ jobs:
       - name: Install soldeer dependencies
         if: hashFiles('soldeer.lock') != ''
         run: nix develop github:rainlanguage/rainix/${{ env.RAINIX_SHA }}#sol-shell -c forge soldeer install
+      # Bind every <NETWORK>_RPC_URL foundry.toml reads to a candidate that is
+      # actually healthy right now, before forge starts. Candidate URLs travel
+      # as env, never as `with:` inputs, because GitHub renders a composite's
+      # resolved inputs into the log and a keyed URL embeds its API key.
+      - name: RPC preflight
+        uses: rainlanguage/rainix/.github/actions/rpc-preflight@main
+        env:
+          RAINIX_RPC_SECRET_ARBITRUM: ${{ secrets.RPC_URL_ARBITRUM_FORK }}
+          RAINIX_RPC_VARS_ARBITRUM: ${{ vars.RPC_URL_ARBITRUM_FORK }}
+          RAINIX_RPC_SECRET_BASE: ${{ secrets.RPC_URL_BASE_FORK }}
+          RAINIX_RPC_VARS_BASE: ${{ vars.RPC_URL_BASE_FORK }}
+          RAINIX_RPC_SECRET_BASE_SEPOLIA: ${{ secrets.RPC_URL_BASE_SEPOLIA_FORK }}
+          RAINIX_RPC_VARS_BASE_SEPOLIA: ${{ vars.RPC_URL_BASE_SEPOLIA_FORK }}
+          RAINIX_RPC_SECRET_ETHEREUM: ${{ secrets.RPC_URL_ETHEREUM_FORK }}
+          RAINIX_RPC_VARS_ETHEREUM: ${{ vars.RPC_URL_ETHEREUM_FORK }}
+          RAINIX_RPC_SECRET_FLARE: ${{ secrets.RPC_URL_FLARE_FORK }}
+          RAINIX_RPC_VARS_FLARE: ${{ vars.RPC_URL_FLARE_FORK }}
+          RAINIX_RPC_SECRET_HYPEREVM: ${{ secrets.RPC_URL_HYPEREVM_FORK }}
+          RAINIX_RPC_VARS_HYPEREVM: ${{ vars.RPC_URL_HYPEREVM_FORK }}
+          RAINIX_RPC_SECRET_POLYGON: ${{ secrets.RPC_URL_POLYGON_FORK }}
+          RAINIX_RPC_VARS_POLYGON: ${{ vars.RPC_URL_POLYGON_FORK }}
       - run: nix develop github:rainlanguage/rainix/${{ env.RAINIX_SHA }}#sol-shell -c forge test -vvv

--- a/.github/workflows/rainix-sol.yaml
+++ b/.github/workflows/rainix-sol.yaml
@@ -18,6 +18,8 @@ on:
         required: false
       RPC_URL_FLARE_FORK:
         required: false
+      RPC_URL_HYPEREVM_FORK:
+        required: false
       RPC_URL_POLYGON_FORK:
         required: false
 jobs:
@@ -36,4 +38,5 @@ jobs:
       RPC_URL_BASE_SEPOLIA_FORK: ${{ secrets.RPC_URL_BASE_SEPOLIA_FORK }}
       RPC_URL_ETHEREUM_FORK: ${{ secrets.RPC_URL_ETHEREUM_FORK }}
       RPC_URL_FLARE_FORK: ${{ secrets.RPC_URL_FLARE_FORK }}
+      RPC_URL_HYPEREVM_FORK: ${{ secrets.RPC_URL_HYPEREVM_FORK }}
       RPC_URL_POLYGON_FORK: ${{ secrets.RPC_URL_POLYGON_FORK }}

--- a/.github/workflows/rainix-tag-release.yaml
+++ b/.github/workflows/rainix-tag-release.yaml
@@ -95,6 +95,8 @@ on:
         required: false
       RPC_URL_FLARE_FORK:
         required: false
+      RPC_URL_HYPEREVM_FORK:
+        required: false
       RPC_URL_POLYGON_FORK:
         required: false
 env:
@@ -221,6 +223,27 @@ jobs:
         # The release must only ADD src/generated/<version>/; a frozen snapshot for
         # an already-released tag must never change (consumers pin its constants).
         uses: rainlanguage/rainix/.github/actions/frozen-snapshots-append-only@main
+      # The fork suite below rolls back to the freshly regenerated pins, so it
+      # needs archive endpoints. Candidate URLs travel as env, never as `with:`
+      # inputs — GitHub renders a composite's resolved inputs into the log and a
+      # keyed URL embeds its API key.
+      - name: RPC preflight
+        uses: rainlanguage/rainix/.github/actions/rpc-preflight@main
+        env:
+          RAINIX_RPC_SECRET_ARBITRUM: ${{ secrets.RPC_URL_ARBITRUM_FORK }}
+          RAINIX_RPC_VARS_ARBITRUM: ${{ vars.RPC_URL_ARBITRUM_FORK }}
+          RAINIX_RPC_SECRET_BASE: ${{ secrets.RPC_URL_BASE_FORK }}
+          RAINIX_RPC_VARS_BASE: ${{ vars.RPC_URL_BASE_FORK }}
+          RAINIX_RPC_SECRET_BASE_SEPOLIA: ${{ secrets.RPC_URL_BASE_SEPOLIA_FORK }}
+          RAINIX_RPC_VARS_BASE_SEPOLIA: ${{ vars.RPC_URL_BASE_SEPOLIA_FORK }}
+          RAINIX_RPC_SECRET_ETHEREUM: ${{ secrets.RPC_URL_ETHEREUM_FORK }}
+          RAINIX_RPC_VARS_ETHEREUM: ${{ vars.RPC_URL_ETHEREUM_FORK }}
+          RAINIX_RPC_SECRET_FLARE: ${{ secrets.RPC_URL_FLARE_FORK }}
+          RAINIX_RPC_VARS_FLARE: ${{ vars.RPC_URL_FLARE_FORK }}
+          RAINIX_RPC_SECRET_HYPEREVM: ${{ secrets.RPC_URL_HYPEREVM_FORK }}
+          RAINIX_RPC_VARS_HYPEREVM: ${{ vars.RPC_URL_HYPEREVM_FORK }}
+          RAINIX_RPC_SECRET_POLYGON: ${{ secrets.RPC_URL_POLYGON_FORK }}
+          RAINIX_RPC_VARS_POLYGON: ${{ vars.RPC_URL_POLYGON_FORK }}
       - name: Verify live chain matches the fresh pins
         # The manual deploy was run before tagging; this is the attestation that it
         # landed — the fork suite checks prod exists at the freshly regenerated
@@ -228,17 +251,10 @@ jobs:
         # published. A transient fork/RPC failure here just fails the release
         # (retry the tag); it publishes nothing and is not a broadcast.
         # foundry.toml's [rpc_endpoints] read ${<NETWORK>_RPC_URL}; the secrets are
-        # named RPC_URL_<NETWORK>_FORK. Map each to the env name foundry expects
-        # (mirrors rainix-sol-test.yaml), with the vars.* fallback the rest of the
-        # org's CI uses. Naming them after the secret (as before) left
-        # ${ARBITRUM_RPC_URL} unset, so createSelectFork failed "env var not found".
-        env:
-          ARBITRUM_RPC_URL: ${{ secrets.RPC_URL_ARBITRUM_FORK || vars.RPC_URL_ARBITRUM_FORK }}
-          BASE_RPC_URL: ${{ secrets.RPC_URL_BASE_FORK || vars.RPC_URL_BASE_FORK }}
-          BASE_SEPOLIA_RPC_URL: ${{ secrets.RPC_URL_BASE_SEPOLIA_FORK || vars.RPC_URL_BASE_SEPOLIA_FORK }}
-          ETHEREUM_RPC_URL: ${{ secrets.RPC_URL_ETHEREUM_FORK || vars.RPC_URL_ETHEREUM_FORK }}
-          FLARE_RPC_URL: ${{ secrets.RPC_URL_FLARE_FORK || vars.RPC_URL_FLARE_FORK }}
-          POLYGON_RPC_URL: ${{ secrets.RPC_URL_POLYGON_FORK || vars.RPC_URL_POLYGON_FORK }}
+        # named RPC_URL_<NETWORK>_FORK. rpc-preflight above binds each env name
+        # foundry expects to a candidate that is healthy right now. Naming them
+        # after the secret left ${ARBITRUM_RPC_URL} unset, so createSelectFork
+        # failed "env var not found"; a static one-URL mapping cannot fail over.
         run: nix develop github:rainlanguage/rainix/${{ env.RAINIX_SHA }}#sol-shell -c bash -c '${{ inputs.test-cmd }}'
       - name: Publish to Soldeer
         # Pushes the working tree (== the release commit's tree, snapshot present)

--- a/.github/workflows/rainix-tag-release.yaml
+++ b/.github/workflows/rainix-tag-release.yaml
@@ -250,11 +250,12 @@ jobs:
         # pins, so a snapshot of addresses the chain does not carry never gets
         # published. A transient fork/RPC failure here just fails the release
         # (retry the tag); it publishes nothing and is not a broadcast.
-        # foundry.toml's [rpc_endpoints] read ${<NETWORK>_RPC_URL}; the secrets are
-        # named RPC_URL_<NETWORK>_FORK. rpc-preflight above binds each env name
-        # foundry expects to a candidate that is healthy right now. Naming them
-        # after the secret left ${ARBITRUM_RPC_URL} unset, so createSelectFork
-        # failed "env var not found"; a static one-URL mapping cannot fail over.
+        # foundry.toml's [rpc_endpoints] read ${<NETWORK>_RPC_URL}, NOT the
+        # RPC_URL_<NETWORK>_FORK secret names — an env var named after the secret
+        # leaves ${ARBITRUM_RPC_URL} unset and createSelectFork fails "env var not
+        # found". rpc-preflight above binds each env name foundry expects to a
+        # candidate that is healthy right now, which a static one-URL mapping
+        # cannot do.
         run: nix develop github:rainlanguage/rainix/${{ env.RAINIX_SHA }}#sol-shell -c bash -c '${{ inputs.test-cmd }}'
       - name: Publish to Soldeer
         # Pushes the working tree (== the release commit's tree, snapshot present)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,3 +70,48 @@ jobs:
           ETH_RPC_URL: ${{ secrets.CI_DEPLOY_SEPOLIA_RPC_URL || vars.CI_DEPLOY_SEPOLIA_RPC_URL }}
           ETHERSCAN_API_KEY: ${{ secrets.EXPLORER_VERIFICATION_KEY }}
         run: nix develop ../.. --command ${{ matrix.task }}
+  # End-to-end self-test of the rpc-preflight composite, which the reusables run
+  # but nothing here otherwise exercises — every fork-RPC wiring bug so far has
+  # been discovered downstream, in a consumer's red CI.
+  #
+  # rainix has no fork suite of its own, but its own sources name every
+  # <NETWORK>_RPC_URL, so the demand scan selects all of them and the job proves
+  # the action resolves a healthy archive endpoint per network on a real runner.
+  # Red here means the hardcoded defaults have gone stale — precisely the signal
+  # that was missing when one vendor's exhausted quota reddened the whole org.
+  #
+  # Same BOOTSTRAP CAVEAT as the composites above: `@main` resolves against the
+  # tip of main, so the PR that first adds this action is red on this job until
+  # it merges.
+  rpc-preflight:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: rainlanguage/rainix/.github/actions/nix-cachix-setup@main
+        with:
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      - uses: rainlanguage/rainix/.github/actions/rpc-preflight@main
+        env:
+          RAINIX_RPC_SECRET_ARBITRUM: ${{ secrets.RPC_URL_ARBITRUM_FORK }}
+          RAINIX_RPC_VARS_ARBITRUM: ${{ vars.RPC_URL_ARBITRUM_FORK }}
+          RAINIX_RPC_SECRET_BASE: ${{ secrets.RPC_URL_BASE_FORK }}
+          RAINIX_RPC_VARS_BASE: ${{ vars.RPC_URL_BASE_FORK }}
+          RAINIX_RPC_SECRET_BASE_SEPOLIA: ${{ secrets.RPC_URL_BASE_SEPOLIA_FORK }}
+          RAINIX_RPC_VARS_BASE_SEPOLIA: ${{ vars.RPC_URL_BASE_SEPOLIA_FORK }}
+          RAINIX_RPC_SECRET_ETHEREUM: ${{ secrets.RPC_URL_ETHEREUM_FORK }}
+          RAINIX_RPC_VARS_ETHEREUM: ${{ vars.RPC_URL_ETHEREUM_FORK }}
+          RAINIX_RPC_SECRET_FLARE: ${{ secrets.RPC_URL_FLARE_FORK }}
+          RAINIX_RPC_VARS_FLARE: ${{ vars.RPC_URL_FLARE_FORK }}
+          RAINIX_RPC_SECRET_POLYGON: ${{ secrets.RPC_URL_POLYGON_FORK }}
+          RAINIX_RPC_VARS_POLYGON: ${{ vars.RPC_URL_POLYGON_FORK }}
+      - name: Assert the preflight bound every archive network
+        # Presence only — never echo the values, they may be secret-derived.
+        run: |
+          set -euo pipefail
+          fail=0
+          for name in ARBITRUM_RPC_URL BASE_RPC_URL BASE_SEPOLIA_RPC_URL ETHEREUM_RPC_URL FLARE_RPC_URL POLYGON_RPC_URL; do
+            if [ -z "${!name:-}" ]; then
+              echo "::error::rpc-preflight did not export $name"
+              fail=1
+            fi
+          done
+          exit "$fail"

--- a/README.md
+++ b/README.md
@@ -118,9 +118,10 @@ jobs:
 
 `secrets: inherit` is required because the reusable wires the standard fork RPC
 env vars (`ARBITRUM_RPC_URL`, `BASE_RPC_URL`, `BASE_SEPOLIA_RPC_URL`,
-`FLARE_RPC_URL`, `POLYGON_RPC_URL`, `CI_DEPLOY_SEPOLIA_RPC_URL`) plus
-`ETHERSCAN_API_KEY` and `DEPLOYMENT_KEY` from the consumer org's secrets/vars.
-Repos that do no fork tests can ignore — empty values are harmless.
+`ETHEREUM_RPC_URL`, `FLARE_RPC_URL`, `HYPEREVM_RPC_URL`, `POLYGON_RPC_URL`,
+`CI_DEPLOY_SEPOLIA_RPC_URL`) plus `ETHERSCAN_API_KEY` and `DEPLOYMENT_KEY` from
+the consumer org's secrets/vars. Repos that do no fork tests can ignore — empty
+values are harmless.
 
 #### rainix-sol (composite)
 
@@ -232,6 +233,55 @@ jobs:
 
 Consumers needing only one of the three should call the individual reusable
 directly rather than this composite.
+
+### Fork RPC endpoints
+
+Each `<NETWORK>_RPC_URL` is chosen at job start by the `rpc-preflight` composite
+action, not bound to a single configured URL. Foundry maps one `[rpc_endpoints]`
+alias to exactly one URL and `--fork-retries` only retries that same URL, so a
+dead upstream — plan quota exhausted, pruning node, host gone — cannot be
+recovered inside `forge`. The preflight recovers it one layer up.
+
+**Candidates are a merged pool, not a fallback chain.** For each network:
+
+| source                            | holds                              | order |
+| --------------------------------- | ---------------------------------- | ----- |
+| secret `RPC_URL_<NETWORK>_FORK`   | keyed/paid URLs (masked)           | first |
+| variable `RPC_URL_<NETWORK>_FORK` | public keyless URLs (visible)      | next  |
+| hardcoded public archive defaults | measured keyless archive endpoints | last  |
+
+Both the secret and the variable hold a **newline-separated list**; a single
+bare URL is a one-element list, which is what they contain today. Every entry in
+every source is a real candidate — the variable's URLs are tried even when the
+secret is set. The order only expresses preference: the paid endpoint first, the
+org's curated public list next, the hardcoded safety net when both are
+exhausted. Keeping keyed URLs in the secret and keyless ones in the variable is
+the point of merging: a public archive endpoint can back up a keyed one without
+putting a non-secret into a secret (where masking makes logs unreadable for no
+security benefit). `#` starts a comment, so a candidate can be parked with a
+note.
+
+**Health is archive-aware.** A candidate must report the right chain id, then
+serve historical account state and a historical `eth_call` at the deepest block
+any repo in the org pins for that network, three times consecutively. An
+`eth_blockNumber` check would happily select a pruning node that then fails the
+suite with `trying to fork from an older block with a non-archive node`; a
+code-only check would select a host that answers no `eth_call` at all; and a
+single sample would qualify a load balancer that round-robins over a mix of
+archive and pruning backends. Ethereum and HyperEVM are latest-only in every
+consumer, so they are not held to the archive bar, and neither are
+deploy/broadcast paths.
+
+**No candidate URL is ever printed.** Logs name the _source_ (`secret[0]`,
+`variable[1]`, `default[0]`) and a typed reason, never a URL:
+
+```
+rpc-preflight: arbitrum: secret[0] rejected: quota exhausted / rate limited (rpc error -32001)
+rpc-preflight: arbitrum: SELECTED variable[0] (chain 42161, archive at block 280000000, 3/3 samples)
+```
+
+Only networks the repo actually references are probed, and a network with no
+candidates at all is left exactly as it is today.
 
 ## Pinned Versions
 

--- a/flake.nix
+++ b/flake.nix
@@ -206,6 +206,23 @@
           src = ./rainix-static;
           cargoLock.lockFile = ./rainix-static/Cargo.lock;
           nativeCheckInputs = [ pkgs.git ];
+          nativeBuildInputs = [ pkgs.makeWrapper ];
+          # The subcommands shell out to git (`ls-files`, `diff`) and curl
+          # (`rpc-preflight`'s probes, `soldeer-gate`'s fetches). The composite
+          # actions invoke this binary with `nix run`, i.e. OUTSIDE any devshell,
+          # so ambient PATH is whatever the runner image happens to ship. Wrap it
+          # with the pinned tools and a CA bundle so the checks are hermetic and
+          # cannot fail on a host with no curl, no git, or no root certs.
+          postInstall = ''
+            wrapProgram $out/bin/rainix-static \
+              --prefix PATH : ${
+                pkgs.lib.makeBinPath [
+                  pkgs.curl
+                  pkgs.git
+                ]
+              } \
+              --set-default SSL_CERT_FILE ${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt
+          '';
         };
 
         # https://ertt.ca/nix/shell-scripts/

--- a/rainix-static/src/main.rs
+++ b/rainix-static/src/main.rs
@@ -24,9 +24,17 @@
 //       `forge soldeer push --dry-run` would upload against the latest published
 //       revision, and emit changed / version / next. Runs inside sol-shell, so
 //       `forge` and `curl` are on PATH.
+//   rpc-preflight [--root <dir>] [--github-env <file>] [--samples N]
+//                 [--timeout N] [--no-archive]
+//       Pick a working fork RPC endpoint per network and export it as
+//       <NETWORK>_RPC_URL, so a dead upstream (quota, pruning node, gone host)
+//       fails over instead of reddening every suite in the org. Candidates come
+//       from the RAINIX_RPC_SECRET_<NET> / RAINIX_RPC_VARS_<NET> env vars merged
+//       with hardcoded public archive defaults. Never prints a candidate URL.
 
 mod frozen_snapshots;
 mod no_submodules;
+mod rpc_preflight;
 mod soldeer_gate;
 
 use std::path::Path;
@@ -51,6 +59,17 @@ fn flag(args: &[String], name: &str) -> Option<String> {
         }
     }
     None
+}
+
+/// Numeric value following `--name`, or `default` when absent. A present but
+/// unparseable value is a typo, not a request for the default — fail loud.
+fn num(args: &[String], name: &str, default: u32) -> u32 {
+    match flag(args, name) {
+        None => default,
+        Some(v) => v
+            .parse()
+            .unwrap_or_else(|_| fail(&format!("{name}: {v:?} is not a positive integer"))),
+    }
 }
 
 fn main() {
@@ -88,10 +107,33 @@ fn main() {
                 }
             }
         }
+        "rpc-preflight" => {
+            let root = flag(&args, "--root").unwrap_or_else(|| ".".to_string());
+            // There is no stdout fallback on purpose: the selected URL may be
+            // secret-derived, so the only sink it may reach is a file. Without
+            // one, fail rather than print.
+            let github_env = flag(&args, "--github-env")
+                .or_else(|| std::env::var("GITHUB_ENV").ok())
+                .unwrap_or_else(|| {
+                    fail("rpc-preflight: --github-env <file> required (or set GITHUB_ENV)")
+                });
+            let samples = num(&args, "--samples", 3);
+            let timeout = num(&args, "--timeout", 15);
+            // Deploy/broadcast paths only ever read head state; requiring
+            // archive there would reject a healthy pruning endpoint.
+            let archive = !args.iter().any(|a| a == "--no-archive");
+            rpc_preflight::run(
+                Path::new(&root),
+                Path::new(&github_env),
+                samples,
+                timeout,
+                archive,
+            );
+        }
         other => {
             eprintln!(
                 "rainix-static: unknown subcommand {other:?} \
-                 (available: no-submodules, snapshots-append-only, soldeer-gate)"
+                 (available: no-submodules, snapshots-append-only, soldeer-gate, rpc-preflight)"
             );
             std::process::exit(2);
         }

--- a/rainix-static/src/rpc_preflight.rs
+++ b/rainix-static/src/rpc_preflight.rs
@@ -1,0 +1,1021 @@
+// RPC preflight: pick a working fork endpoint per network before forge runs.
+//
+// Foundry maps one alias to exactly one URL in [rpc_endpoints] and its
+// --fork-retries only retries that same URL, so a deterministic upstream
+// failure (plan quota exhausted, node is not archive, host is gone) cannot be
+// recovered inside forge. This subcommand does the recovery one layer up: it
+// builds a merged pool of candidate URLs per network, probes each one the way
+// forge's fork backend actually reads a chain, and exports the first healthy
+// one as <NETWORK>_RPC_URL for the steps that follow.
+//
+// MERGED POOL, NOT A PRECEDENCE CHAIN. `RPC_URL_<NET>_FORK` as a secret and as
+// a variable each hold a LIST of URLs; the candidate pool is the CONCATENATION
+// of both lists plus the hardcoded public archive defaults below. A URL in the
+// variable is a real candidate even when the secret is also set — a non-empty
+// earlier source never causes a later one to be skipped, it only orders them.
+// Keyed/paid URLs belong in the secret (masked), public keyless URLs in the
+// variable (visible, greppable, no masking noise); merging is what lets a
+// public archive endpoint back up a keyed one without putting a non-secret in
+// a secret. Order is secret entries, then variable entries, then defaults:
+// prefer the paid/dedicated endpoint, fall back to the org's curated public
+// list, and land on the hardcoded safety net only when both are exhausted.
+//
+// NO URL IS EVER PRINTED. See `Url` and `Reason` — the redaction is structural,
+// not a scrubbing pass that a later edit can bypass.
+
+use std::collections::BTreeSet;
+use std::fmt;
+use std::io::Write;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+use crate::fail;
+
+/// A candidate RPC URL.
+///
+/// This type is the no-leak guarantee. It has no `Display`, and its `Debug`
+/// prints `<redacted>`, so no format string anywhere in this crate can put a
+/// URL on stdout or stderr — including a future edit that adds a `{:?}` to a
+/// log line. The inner string is reachable only through `expose()`, which has
+/// exactly two call sites: the argv of the curl child process (whose stdout and
+/// stderr are captured and never re-printed) and the write to the file named by
+/// --github-env. Every log line is built from a `Source` label and a `Reason`,
+/// both of which are closed enums over fixed text.
+pub(crate) struct Url(String);
+
+impl fmt::Debug for Url {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("<redacted>")
+    }
+}
+
+impl Url {
+    fn expose(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Where a candidate came from. This — never the URL — is what gets logged.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum Source {
+    Secret(usize),
+    Variable(usize),
+    Default(usize),
+}
+
+impl fmt::Display for Source {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Source::Secret(i) => write!(f, "secret[{i}]"),
+            Source::Variable(i) => write!(f, "variable[{i}]"),
+            Source::Default(i) => write!(f, "default[{i}]"),
+        }
+    }
+}
+
+impl Source {
+    /// True for candidates that came from a GitHub secret, i.e. the ones whose
+    /// URL may embed an API key and must be masked before it reaches GITHUB_ENV.
+    fn is_secret(&self) -> bool {
+        matches!(self, Source::Secret(_))
+    }
+}
+
+/// Why a candidate was rejected.
+///
+/// A closed enum, and its `Display` is built only from fixed strings plus
+/// integers we produced ourselves (a JSON-RPC error code, an HTTP status, a
+/// curl exit code, a chain id, a block number). No bytes from the network and
+/// no part of a URL can reach a log line through it — an upstream that echoes
+/// the request URL back inside an error message or an HTML error page cannot
+/// leak it, because the message body is classified and then dropped.
+///
+/// Callers branch on the variant, never on message text: classification happens
+/// once, here, and everything downstream is a typed discriminant.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum Reason {
+    /// curl could not complete the request at all (DNS, TLS, connect, timeout).
+    Unreachable { curl_exit: i32 },
+    /// HTTP error with a body we could not classify as a JSON-RPC error.
+    Http { status: u32 },
+    /// Response was not JSON-RPC, or the result had the wrong shape.
+    BadResponse,
+    /// Right host, wrong chain — a misconfigured candidate that would silently
+    /// fork the wrong network if selected.
+    WrongChain { expected: u64, got: u64 },
+    /// Plan/usage quota or rate limit. The failure that started all this.
+    Quota { code: i64 },
+    /// Node cannot serve state at the probe block: pruning node, or archive
+    /// access gated behind a token we do not have.
+    NotArchive { code: i64, block: u64 },
+    /// Endpoint answers some methods but not the ones forge needs.
+    MethodUnsupported { code: i64 },
+    /// Authentication/authorisation rejected.
+    Auth { code: i64 },
+    /// A JSON-RPC error we did not recognise; the code is the discriminant.
+    RpcError { code: i64 },
+}
+
+impl fmt::Display for Reason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Reason::Unreachable { curl_exit } => {
+                write!(f, "unreachable (curl exit {curl_exit})")
+            }
+            Reason::Http { status } => write!(f, "http {status}"),
+            Reason::BadResponse => f.write_str("malformed or unexpected JSON-RPC response"),
+            Reason::WrongChain { expected, got } => {
+                write!(
+                    f,
+                    "wrong chain (expected {expected}, endpoint reports {got})"
+                )
+            }
+            Reason::Quota { code } => {
+                write!(f, "quota exhausted / rate limited (rpc error {code})")
+            }
+            Reason::NotArchive { code, block } => write!(
+                f,
+                "not archive: no historical state at block {block} (rpc error {code})"
+            ),
+            Reason::MethodUnsupported { code } => {
+                write!(f, "required method not supported (rpc error {code})")
+            }
+            Reason::Auth { code } => write!(f, "unauthorized / key required (rpc error {code})"),
+            Reason::RpcError { code } => write!(f, "rpc error {code}"),
+        }
+    }
+}
+
+/// One network's identity, probe calibration and hardcoded public fallbacks.
+pub(crate) struct Network {
+    /// foundry.toml [rpc_endpoints] alias.
+    pub key: &'static str,
+    /// Env var foundry.toml interpolates, e.g. `${ARBITRUM_RPC_URL}`.
+    pub env_name: &'static str,
+    /// Org secret/variable name holding this network's candidate list.
+    pub secret_name: &'static str,
+    pub chain_id: u64,
+    /// Blocks the probe must be able to read account state at. Empty means the
+    /// network is only ever forked at latest, so a pruning node is acceptable.
+    ///
+    /// Each entry is at or below the OLDEST block any repo in the org pins for
+    /// this network, because the archive question is not "is this node an
+    /// archive node" but "can it serve MY fork block". Probing shallower than
+    /// the deepest live pin qualifies a node that then dies mid-suite.
+    pub archive_blocks: &'static [u64],
+    /// Contract with code at every `archive_blocks` entry, used for the
+    /// historical `eth_call`. `totalSupply()` on the canonical wrapped native
+    /// token: deployed at or near genesis on every chain here, so one address
+    /// covers the whole history.
+    pub probe_contract: &'static str,
+    /// Hardcoded public keyless archive endpoints, the terminal element of the
+    /// pool. Measured, not taken from a public RPC list: every entry answered
+    /// the historical probe below 5/5 times. Providers that scored partially
+    /// are deliberately absent — a load balancer over a heterogeneous backend
+    /// pool can pass a preflight and still fail the suite.
+    pub defaults: &'static [&'static str],
+}
+
+/// The org's networks. One table, so adding a network is a one-site edit rather
+/// than the six-site copy-paste the workflow env blocks used to be.
+pub(crate) const NETWORKS: &[Network] = &[
+    Network {
+        key: "arbitrum",
+        env_name: "ARBITRUM_RPC_URL",
+        secret_name: "RPC_URL_ARBITRUM_FORK",
+        chain_id: 42161,
+        // rain.tofu.erc20-decimals pins 280_000_000, the deepest live Arbitrum
+        // pin in the org (~20 months back).
+        archive_blocks: &[280_000_000],
+        probe_contract: "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1", // WETH
+        defaults: &[
+            "https://arb-pokt.nodies.app",
+            "https://42161.rpc.thirdweb.com",
+            "https://arbitrum.gateway.tenderly.co",
+        ],
+    },
+    Network {
+        key: "base",
+        env_name: "BASE_RPC_URL",
+        secret_name: "RPC_URL_BASE_FORK",
+        chain_id: 8453,
+        // rain.deploy's findDeployBlock binary-searches from block 0, so Base
+        // needs full archive back to genesis; block 1 is the strict form of
+        // that (clients often special-case genesis). The second probe block is
+        // mid-history, so a node holding only early state cannot pass either.
+        archive_blocks: &[1, 39_000_000],
+        probe_contract: "0x4200000000000000000000000000000000000006", // WETH predeploy
+        defaults: &[
+            "https://mainnet.base.org",
+            "https://base-pokt.nodies.app",
+            "https://base.gateway.tenderly.co",
+            "https://base.drpc.org",
+        ],
+    },
+    Network {
+        key: "base_sepolia",
+        env_name: "BASE_SEPOLIA_RPC_URL",
+        secret_name: "RPC_URL_BASE_SEPOLIA_FORK",
+        chain_id: 84532,
+        // rain.metadata rolls to METABOARD_START_BLOCK_BASE_SEPOLIA 38_683_088.
+        archive_blocks: &[38_000_000],
+        probe_contract: "0x4200000000000000000000000000000000000006", // WETH predeploy
+        defaults: &[
+            "https://sepolia.base.org",
+            "https://base-sepolia.gateway.tenderly.co",
+            "https://84532.rpc.thirdweb.com",
+            "https://base-sepolia.drpc.org",
+        ],
+    },
+    Network {
+        key: "flare",
+        env_name: "FLARE_RPC_URL",
+        secret_name: "RPC_URL_FLARE_FORK",
+        chain_id: 14,
+        // rain.flare forks at 31_843_105 in ~19 test files (~23 months back) —
+        // the deepest historical read in the org outside rain.deploy's genesis
+        // search, and Flare public nodes are the most prune-happy.
+        archive_blocks: &[31_000_000],
+        probe_contract: "0x1D80c49BbBCd1C0911346656B529DF9E5c2F783d", // WNAT
+        defaults: &[
+            "https://flare-api.flare.network/ext/C/rpc",
+            "https://flare.rpc.thirdweb.com",
+            "https://flare.gateway.tenderly.co",
+            "https://flare.public-rpc.com",
+        ],
+    },
+    Network {
+        key: "polygon",
+        env_name: "POLYGON_RPC_URL",
+        secret_name: "RPC_URL_POLYGON_FORK",
+        chain_id: 137,
+        // rain.metadata rolls to METABOARD_START_BLOCK_POLYGON 82_855_948.
+        archive_blocks: &[82_000_000],
+        probe_contract: "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270", // WMATIC
+        defaults: &[
+            "https://polygon.gateway.tenderly.co",
+            "https://137.rpc.thirdweb.com",
+            "https://polygon.drpc.org",
+        ],
+    },
+    Network {
+        key: "ethereum",
+        env_name: "ETHEREUM_RPC_URL",
+        secret_name: "RPC_URL_ETHEREUM_FORK",
+        chain_id: 1,
+        // Every Ethereum fork in the org is at latest — no repo pins a block
+        // and no isStartBlock/findDeployBlock is wired to an Ethereum endpoint.
+        // A pruning node is sufficient, so do not exclude one.
+        archive_blocks: &[],
+        probe_contract: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", // WETH
+        defaults: &[
+            "https://eth-pokt.nodies.app",
+            "https://mainnet.gateway.tenderly.co",
+            "https://eth.drpc.org",
+        ],
+    },
+    Network {
+        key: "hyperevm",
+        env_name: "HYPEREVM_RPC_URL",
+        secret_name: "RPC_URL_HYPEREVM_FORK",
+        chain_id: 999,
+        // Latest-only in every consumer today.
+        archive_blocks: &[],
+        probe_contract: "0x5555555555555555555555555555555555555555", // WHYPE
+        // No measured public archive endpoint yet; the pool is whatever the
+        // secret and variable hold. An empty pool is a skip, not a failure, so
+        // a repo that does not use hyperevm is unaffected either way.
+        defaults: &[],
+    },
+];
+
+/// Split a secret/variable value into candidate URLs.
+///
+/// Newline is the separator, and it is the only one that works: it cannot occur
+/// inside a URL so it needs no escaping, GitHub's secret and variable editors
+/// accept multi-line values natively, and the runner registers each LINE of a
+/// multi-line secret as a separately masked value. A comma would be ambiguous
+/// (legal in a query string) and a space likewise. `#` starts a comment so a
+/// candidate can be parked with a note about why. A single bare URL is a
+/// one-element list, which is exactly what these secrets hold today.
+fn parse_list(raw: &str) -> Vec<String> {
+    raw.lines()
+        .map(|l| l.split('#').next().unwrap_or("").trim())
+        .filter(|l| !l.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+/// Build the merged candidate pool for one network: secret list, then variable
+/// list, then hardcoded defaults. Duplicates are dropped keeping the earliest
+/// occurrence, so listing the same URL in both the secret and the variable
+/// costs one probe, not two.
+fn pool(net: &Network, secret_raw: &str, vars_raw: &str) -> Vec<(Source, Url)> {
+    let mut seen = BTreeSet::new();
+    let mut out = Vec::new();
+    let push = |src: Source, u: String, seen: &mut BTreeSet<String>, out: &mut Vec<_>| {
+        if seen.insert(u.clone()) {
+            out.push((src, Url(u)));
+        }
+    };
+    for (i, u) in parse_list(secret_raw).into_iter().enumerate() {
+        push(Source::Secret(i), u, &mut seen, &mut out);
+    }
+    for (i, u) in parse_list(vars_raw).into_iter().enumerate() {
+        push(Source::Variable(i), u, &mut seen, &mut out);
+    }
+    for (i, u) in net.defaults.iter().enumerate() {
+        push(Source::Default(i), u.to_string(), &mut seen, &mut out);
+    }
+    out
+}
+
+/// Classify a JSON-RPC error into a typed reason.
+///
+/// Providers disagree wildly on codes for the same condition — a pruning node
+/// is `-32000 "missing trie node"` on one host, `-32000 "state ... is pruned"`
+/// on another and `-32602 "Archive requests require a personal token"` on a
+/// third — so the code alone cannot discriminate. Message keywords are matched
+/// HERE, once, and the message is then discarded: nothing downstream ever sees
+/// it, and no decision anywhere is made by substring-matching error text.
+fn classify(code: i64, message: &str, block: Option<u64>) -> Reason {
+    let m = message.to_ascii_lowercase();
+    let has = |needle: &str| m.contains(needle);
+
+    if code == -32001
+        || has("usage limit")
+        || has("current plan")
+        || has("quota")
+        || has("rate limit")
+        || has("too many requests")
+        || has("exceeded")
+    {
+        return Reason::Quota { code };
+    }
+    // Before the auth arm: "Archive requests require a personal token" is an
+    // archive refusal first and an auth error second, and the archive framing
+    // is the actionable one (move the network to a candidate that serves it).
+    if has("missing trie node")
+        || has("pruned")
+        || has("archive")
+        || has("is not available")
+        || has("historical state")
+        || has("state at block")
+        || has("older block")
+        || has("no state")
+        || has("state not found")
+        || has("header not found")
+        || has("block not found")
+    {
+        return Reason::NotArchive {
+            code,
+            block: block.unwrap_or(0),
+        };
+    }
+    if code == -32601 || has("not supported") || has("method not found") || has("unsupported") {
+        return Reason::MethodUnsupported { code };
+    }
+    if has("unauthorized")
+        || has("forbidden")
+        || has("api key")
+        || has("apikey")
+        || has("must be authenticated")
+        || has("invalid key")
+    {
+        return Reason::Auth { code };
+    }
+    Reason::RpcError { code }
+}
+
+/// POST one JSON-RPC request and return its `result`.
+///
+/// curl's stdout is captured and parsed; its stderr is captured and DROPPED
+/// without being read, because curl writes the request host into its own error
+/// text. `-s` also keeps the progress meter off stdout.
+fn rpc(
+    url: &Url,
+    timeout: u32,
+    body: &str,
+    block: Option<u64>,
+) -> Result<serde_json::Value, Reason> {
+    let mut child = Command::new("curl")
+        .args([
+            "-s",
+            "-X",
+            "POST",
+            "-H",
+            "content-type: application/json",
+            "-m",
+            &timeout.to_string(),
+            "--data-binary",
+            "@-",
+            "-w",
+            "\n%{http_code}",
+            url.expose(),
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|_| Reason::Unreachable { curl_exit: -1 })?;
+    child
+        .stdin
+        .as_mut()
+        .and_then(|s| s.write_all(body.as_bytes()).ok())
+        .ok_or(Reason::Unreachable { curl_exit: -1 })?;
+    let out = child
+        .wait_with_output()
+        .map_err(|_| Reason::Unreachable { curl_exit: -1 })?;
+    if !out.status.success() {
+        return Err(Reason::Unreachable {
+            curl_exit: out.status.code().unwrap_or(-1),
+        });
+    }
+    let text = String::from_utf8_lossy(&out.stdout);
+    let (body_text, status_text) = text.rsplit_once('\n').unwrap_or(("", ""));
+    let status: u32 = status_text.trim().parse().unwrap_or(0);
+
+    let json: serde_json::Value = match serde_json::from_str(body_text) {
+        Ok(v) => v,
+        // A non-JSON body (an HTML error page, a proxy banner) is never parsed
+        // for meaning and never printed; only the status survives.
+        Err(_) => {
+            return Err(if status >= 400 {
+                Reason::Http { status }
+            } else {
+                Reason::BadResponse
+            })
+        }
+    };
+    if let Some(err) = json.get("error") {
+        let code = err
+            .get("code")
+            .and_then(serde_json::Value::as_i64)
+            .unwrap_or(0);
+        let message = err
+            .get("message")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("");
+        return Err(classify(code, message, block));
+    }
+    if status >= 400 {
+        return Err(Reason::Http { status });
+    }
+    json.get("result").cloned().ok_or(Reason::BadResponse)
+}
+
+fn hex_result(v: &serde_json::Value) -> Option<&str> {
+    v.as_str().filter(|s| s.starts_with("0x"))
+}
+
+/// Probe one candidate. Returns Ok only if EVERY check passes on EVERY sample.
+///
+/// The three checks mirror what forge's fork backend does, in the order that
+/// fails cheapest first:
+///   1. eth_chainId  — a candidate for the wrong chain would silently fork the
+///      wrong network, which is worse than a red job.
+///   2. eth_getBalance at the probe block — historical ACCOUNT state, which is
+///      what forge fetches first and what a pruning node refuses.
+///   3. eth_call at the probe block — historical CONTRACT execution. Necessary
+///      on top of (2) because some hosts serve historical code and state but
+///      answer every eth_call with "method not supported"; a code-only probe
+///      selects them and the suite dies later.
+///
+/// `samples` consecutive full passes are required. A single sample is not
+/// enough: the public load balancers round-robin over a mix of archive and
+/// pruning backends, so one lucky answer qualifies an endpoint that then fails
+/// partway through a suite that issues thousands of historical reads.
+fn probe(
+    url: &Url,
+    net: &Network,
+    samples: u32,
+    timeout: u32,
+    archive: bool,
+) -> Result<(), Reason> {
+    let chain = rpc(
+        url,
+        timeout,
+        r#"{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}"#,
+        None,
+    )?;
+    let got = hex_result(&chain)
+        .and_then(|s| u64::from_str_radix(s.trim_start_matches("0x"), 16).ok())
+        .ok_or(Reason::BadResponse)?;
+    if got != net.chain_id {
+        return Err(Reason::WrongChain {
+            expected: net.chain_id,
+            got,
+        });
+    }
+
+    // Latest-only when the network has no pinned historical reads in the org,
+    // or when the caller is a deploy/broadcast path that only ever touches head
+    // state — forcing archive there would reject a perfectly good pruning
+    // endpoint for no benefit.
+    let blocks: Vec<Option<u64>> = if archive && !net.archive_blocks.is_empty() {
+        net.archive_blocks.iter().copied().map(Some).collect()
+    } else {
+        vec![None]
+    };
+
+    for _ in 0..samples {
+        for b in &blocks {
+            let tag = match b {
+                Some(n) => format!("0x{n:x}"),
+                None => "latest".to_string(),
+            };
+            let bal = rpc(
+                url,
+                timeout,
+                &format!(
+                    r#"{{"jsonrpc":"2.0","id":1,"method":"eth_getBalance","params":["{}","{}"]}}"#,
+                    net.probe_contract, tag
+                ),
+                *b,
+            )?;
+            hex_result(&bal).ok_or(Reason::BadResponse)?;
+
+            let call = rpc(
+                url,
+                timeout,
+                &format!(
+                    r#"{{"jsonrpc":"2.0","id":1,"method":"eth_call","params":[{{"to":"{}","data":"0x18160ddd"}},"{}"]}}"#,
+                    net.probe_contract, tag
+                ),
+                *b,
+            )?;
+            // A well-formed totalSupply() answer is exactly one 32-byte word.
+            // `0x` means the call executed against an account with no code,
+            // i.e. the node served an empty state for the probe block.
+            match hex_result(&call) {
+                Some(s) if s.len() == 66 => {}
+                Some(_) => {
+                    return Err(Reason::NotArchive {
+                        code: 0,
+                        block: b.unwrap_or(0),
+                    })
+                }
+                None => return Err(Reason::BadResponse),
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Networks the repo actually uses, by scanning tracked files for the env name
+/// foundry.toml interpolates (`ARBITRUM_RPC_URL`) or the raw secret name
+/// (`RPC_URL_ARBITRUM_FORK`, which some repos read straight from vm.envString).
+///
+/// This is what keeps the preflight from changing behaviour for a network a
+/// repo does not touch: an unmentioned network is never probed, never exported
+/// and can never fail the job.
+fn demanded(root: &Path) -> BTreeSet<&'static str> {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["ls-files", "-z"])
+        .output()
+        .unwrap_or_else(|e| fail(&format!("rpc-preflight: git ls-files failed to spawn: {e}")));
+    if !out.status.success() {
+        fail("rpc-preflight: git ls-files failed; run this from a git checkout");
+    }
+    let mut found = BTreeSet::new();
+    for name in String::from_utf8_lossy(&out.stdout).split('\0') {
+        if name.is_empty() {
+            continue;
+        }
+        let path = root.join(name);
+        let Ok(meta) = std::fs::metadata(&path) else {
+            continue;
+        };
+        // Skip anything too large to be a source file; nothing that references
+        // an RPC env var is a multi-megabyte blob.
+        if meta.len() > 2 * 1024 * 1024 {
+            continue;
+        }
+        let Ok(text) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        for net in NETWORKS {
+            if text.contains(net.env_name) || text.contains(net.secret_name) {
+                found.insert(net.key);
+            }
+        }
+    }
+    found
+}
+
+/// Append `<name>=<value>` to the GITHUB_ENV-style file.
+///
+/// The ONLY sink a URL reaches besides curl's argv. There is deliberately no
+/// stdout mode: without a file to write to, the subcommand fails rather than
+/// falling back to printing, so no invocation can ever put a URL on a log.
+fn export(path: &Path, name: &str, url: &Url) {
+    let mut f = std::fs::OpenOptions::new()
+        .append(true)
+        .create(true)
+        .open(path)
+        .unwrap_or_else(|e| fail(&format!("rpc-preflight: open {}: {e}", path.display())));
+    // A URL cannot contain a newline (parse_list splits on them), so the plain
+    // KEY=value form is sufficient and no heredoc delimiter is needed.
+    writeln!(f, "{}={}", name, url.expose())
+        .unwrap_or_else(|e| fail(&format!("rpc-preflight: write {}: {e}", path.display())));
+}
+
+/// Run the preflight for every network the repo uses.
+pub(crate) fn run(root: &Path, github_env: &Path, samples: u32, timeout: u32, archive: bool) {
+    let want = demanded(root);
+    if want.is_empty() {
+        println!("rpc-preflight: repo references no fork RPC env vars; nothing to do");
+        return;
+    }
+
+    let mut failed: Vec<&'static str> = Vec::new();
+    for net in NETWORKS {
+        if !want.contains(net.key) {
+            continue;
+        }
+        let secret_raw =
+            std::env::var(format!("RAINIX_RPC_SECRET_{}", upper(net.key))).unwrap_or_default();
+        let vars_raw =
+            std::env::var(format!("RAINIX_RPC_VARS_{}", upper(net.key))).unwrap_or_default();
+        let candidates = pool(net, &secret_raw, &vars_raw);
+
+        if candidates.is_empty() {
+            // Exactly today's behaviour: the env var stays unset and forge
+            // reports it if a test actually needs it. Nothing to fail over to
+            // means nothing to fail about.
+            println!(
+                "rpc-preflight: {}: no candidates configured ({} / vars {}); leaving {} unset",
+                net.key, net.secret_name, net.secret_name, net.env_name
+            );
+            continue;
+        }
+
+        let mode = if archive && !net.archive_blocks.is_empty() {
+            format!("archive at block {}", net.archive_blocks[0])
+        } else {
+            "latest".to_string()
+        };
+        let mut rejected: Vec<(Source, Reason)> = Vec::new();
+        let mut selected: Option<(Source, Url)> = None;
+        for (src, url) in candidates {
+            match probe(&url, net, samples, timeout, archive) {
+                Ok(()) => {
+                    selected = Some((src, url));
+                    break;
+                }
+                Err(reason) => rejected.push((src, reason)),
+            }
+        }
+
+        for (src, reason) in &rejected {
+            println!("rpc-preflight: {}: {src} rejected: {reason}", net.key);
+        }
+
+        match selected {
+            Some((src, url)) => {
+                if src.is_secret() {
+                    // Defence in depth. The runner already masks each line of a
+                    // multi-line secret, but a keyed URL that arrives through a
+                    // variable by mistake is not masked, and this costs nothing.
+                    // The command's own argument is redacted by the runner.
+                    println!("::add-mask::{}", url.expose());
+                }
+                export(github_env, net.env_name, &url);
+                // Also export under the raw secret name: a few repos read
+                // vm.envString("RPC_URL_<NET>_FORK") directly, and once that
+                // secret can hold a LIST those repos would otherwise receive a
+                // multi-line string that createSelectFork cannot use.
+                export(github_env, net.secret_name, &url);
+                if !rejected.is_empty() {
+                    println!(
+                        "::warning::rpc-preflight: {} fell back to {src} after {} unhealthy candidate(s)",
+                        net.key,
+                        rejected.len()
+                    );
+                }
+                println!(
+                    "rpc-preflight: {}: SELECTED {src} (chain {}, {mode}, {samples}/{samples} samples)",
+                    net.key, net.chain_id
+                );
+            }
+            None => {
+                eprintln!(
+                    "::error::rpc-preflight: {}: no healthy endpoint among {} candidate(s) for chain {} ({mode}). \
+                     Every candidate and why it was rejected is listed above by SOURCE; \
+                     add a working URL to the {} secret (keyed) or variable (public, newline-separated).",
+                    net.key,
+                    rejected.len(),
+                    net.chain_id,
+                    net.secret_name
+                );
+                failed.push(net.key);
+            }
+        }
+    }
+
+    if !failed.is_empty() {
+        fail(&format!(
+            "rpc-preflight: no healthy RPC endpoint for: {}",
+            failed.join(", ")
+        ));
+    }
+    println!("rpc-preflight: clean");
+}
+
+fn upper(key: &str) -> String {
+    key.to_ascii_uppercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn url_never_formats_its_value() {
+        let u = Url("https://secret.example/KEY123".to_string());
+        assert_eq!(format!("{u:?}"), "<redacted>");
+        assert!(!format!("{u:?}").contains("KEY123"));
+    }
+
+    #[test]
+    fn reason_text_is_url_free_and_typed() {
+        // Every variant renders from fixed text plus integers we produced.
+        for r in [
+            Reason::Unreachable { curl_exit: 6 },
+            Reason::Http { status: 521 },
+            Reason::BadResponse,
+            Reason::WrongChain {
+                expected: 42161,
+                got: 1,
+            },
+            Reason::Quota { code: -32001 },
+            Reason::NotArchive {
+                code: -32000,
+                block: 280_000_000,
+            },
+            Reason::MethodUnsupported { code: -32601 },
+            Reason::Auth { code: -32602 },
+            Reason::RpcError { code: -32000 },
+        ] {
+            let s = r.to_string();
+            assert!(!s.contains("http://"), "{s}");
+            assert!(!s.contains("https://"), "{s}");
+            assert!(!s.is_empty());
+        }
+    }
+
+    #[test]
+    fn list_parsing() {
+        assert_eq!(parse_list(""), Vec::<String>::new());
+        // A bare single URL is a one-element list — what the secrets hold today.
+        assert_eq!(parse_list("https://a.example"), vec!["https://a.example"]);
+        assert_eq!(
+            parse_list("https://a.example\nhttps://b.example\n"),
+            vec!["https://a.example", "https://b.example"]
+        );
+        // CRLF, blank lines, indentation and comments.
+        assert_eq!(
+            parse_list("  https://a.example  \r\n\n# dead, quota\n  https://b.example # keyed\n"),
+            vec!["https://a.example", "https://b.example"]
+        );
+        assert_eq!(parse_list("# everything commented\n"), Vec::<String>::new());
+    }
+
+    fn net(key: &'static str) -> &'static Network {
+        NETWORKS.iter().find(|n| n.key == key).unwrap()
+    }
+
+    #[test]
+    fn pool_is_a_merge_not_a_precedence_chain() {
+        let n = net("arbitrum");
+        let p = pool(n, "https://keyed.example", "https://public.example");
+        let srcs: Vec<String> = p.iter().map(|(s, _)| s.to_string()).collect();
+        // The variable entry is present even though the secret was non-empty,
+        // and the hardcoded defaults are present even though both were.
+        assert_eq!(srcs[0], "secret[0]");
+        assert_eq!(srcs[1], "variable[0]");
+        assert_eq!(srcs[2], "default[0]");
+        assert_eq!(p.len(), 2 + n.defaults.len());
+    }
+
+    #[test]
+    fn pool_orders_secret_then_variable_then_default() {
+        let n = net("polygon");
+        let p = pool(n, "https://s1\nhttps://s2", "https://v1");
+        let srcs: Vec<String> = p.iter().map(|(s, _)| s.to_string()).collect();
+        assert_eq!(&srcs[..3], &["secret[0]", "secret[1]", "variable[0]"]);
+        assert!(srcs[3..].iter().all(|s| s.starts_with("default[")));
+    }
+
+    #[test]
+    fn pool_dedupes_across_sources_keeping_first() {
+        let n = net("base");
+        // Same URL in the secret and the variable, plus a default repeated.
+        let p = pool(
+            n,
+            "https://same.example",
+            "https://same.example\nhttps://mainnet.base.org",
+        );
+        let srcs: Vec<String> = p.iter().map(|(s, _)| s.to_string()).collect();
+        assert_eq!(srcs[0], "secret[0]");
+        // mainnet.base.org is default[0]; listed in the variable it stays at
+        // the variable's position and is not probed twice.
+        assert_eq!(srcs[1], "variable[1]");
+        assert_eq!(p.len(), 1 + 1 + n.defaults.len() - 1);
+    }
+
+    #[test]
+    fn pool_with_nothing_configured_is_just_the_defaults() {
+        let n = net("flare");
+        let p = pool(n, "", "");
+        assert_eq!(p.len(), n.defaults.len());
+        assert!(p.iter().all(|(s, _)| matches!(s, Source::Default(_))));
+    }
+
+    #[test]
+    fn pool_is_empty_when_nothing_is_configured_and_there_is_no_default() {
+        let n = net("hyperevm");
+        assert!(pool(n, "", "").is_empty());
+    }
+
+    #[test]
+    fn quota_is_classified_from_code_or_wording() {
+        assert_eq!(
+            classify(-32001, "anything", None),
+            Reason::Quota { code: -32001 }
+        );
+        // The exact drpc body that caused the outage.
+        assert_eq!(
+            classify(
+                -32001,
+                "You've reached the usage limit for your current plan",
+                None
+            ),
+            Reason::Quota { code: -32001 }
+        );
+        assert_eq!(
+            classify(-32005, "rate limit exceeded", None),
+            Reason::Quota { code: -32005 }
+        );
+    }
+
+    #[test]
+    fn pruning_nodes_are_classified_as_not_archive() {
+        let b = Some(280_000_000);
+        for msg in [
+            "missing trie node 4ffbde5a is not available, not found",
+            "state 0x3068d1 is not available",
+            "state at block #39000001 is pruned",
+            "historical state not available",
+            "It looks like you're trying to fork from an older block with a non-archive node",
+            // publicnode gates archive behind a token; the archive framing is
+            // the actionable one, so it wins over the auth arm.
+            "Archive requests require a personal token.",
+        ] {
+            assert_eq!(
+                classify(-32000, msg, b),
+                Reason::NotArchive {
+                    code: -32000,
+                    block: 280_000_000
+                },
+                "{msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn unsupported_method_and_auth_are_distinguished() {
+        assert_eq!(
+            classify(-32000, "The method eth_call is not supported.", None),
+            Reason::MethodUnsupported { code: -32000 }
+        );
+        assert_eq!(
+            classify(-32601, "whatever", None),
+            Reason::MethodUnsupported { code: -32601 }
+        );
+        assert_eq!(
+            classify(-32000, "Unauthorized", None),
+            Reason::Auth { code: -32000 }
+        );
+        assert_eq!(
+            classify(-32000, "api key required", None),
+            Reason::Auth { code: -32000 }
+        );
+    }
+
+    #[test]
+    fn unrecognised_errors_keep_their_code_as_the_discriminant() {
+        assert_eq!(
+            classify(-32603, "internal error", None),
+            Reason::RpcError { code: -32603 }
+        );
+    }
+
+    #[test]
+    fn network_table_is_internally_consistent() {
+        let mut keys = BTreeSet::new();
+        let mut envs = BTreeSet::new();
+        let mut secrets = BTreeSet::new();
+        let mut ids = BTreeSet::new();
+        for n in NETWORKS {
+            assert!(keys.insert(n.key), "duplicate key {}", n.key);
+            assert!(envs.insert(n.env_name), "duplicate env {}", n.env_name);
+            assert!(
+                secrets.insert(n.secret_name),
+                "duplicate secret {}",
+                n.secret_name
+            );
+            assert!(ids.insert(n.chain_id), "duplicate chain id {}", n.chain_id);
+            // The secret name and the env name are different spellings of the
+            // same network; both are demand-scan signals.
+            assert_eq!(n.secret_name, format!("RPC_URL_{}_FORK", upper(n.key)));
+            assert!(n.probe_contract.starts_with("0x") && n.probe_contract.len() == 42);
+            assert!(n.defaults.iter().all(|d| d.starts_with("https://")));
+        }
+    }
+
+    #[test]
+    fn env_names_are_not_substrings_of_each_other() {
+        // The demand scan is a substring match, so BASE_RPC_URL must not match
+        // a repo that only mentions BASE_SEPOLIA_RPC_URL.
+        for a in NETWORKS {
+            for b in NETWORKS {
+                if a.key != b.key {
+                    assert!(
+                        !b.env_name.contains(a.env_name),
+                        "{} contains {}",
+                        b.env_name,
+                        a.env_name
+                    );
+                    assert!(
+                        !b.secret_name.contains(a.secret_name),
+                        "{} contains {}",
+                        b.secret_name,
+                        a.secret_name
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn export_writes_one_line_per_name() {
+        let dir = std::env::temp_dir().join(format!("rpc-preflight-export-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let f = dir.join("github_env");
+        let _ = std::fs::remove_file(&f);
+        export(&f, "BASE_RPC_URL", &Url("https://a.example".into()));
+        export(&f, "RPC_URL_BASE_FORK", &Url("https://a.example".into()));
+        let got = std::fs::read_to_string(&f).unwrap();
+        assert_eq!(
+            got,
+            "BASE_RPC_URL=https://a.example\nRPC_URL_BASE_FORK=https://a.example\n"
+        );
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn demand_scan_finds_only_referenced_networks() {
+        let dir = std::env::temp_dir().join(format!("rpc-preflight-scan-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let git = |args: &[&str]| {
+            let st = Command::new("git")
+                .arg("-C")
+                .arg(&dir)
+                .args(args)
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status()
+                .unwrap();
+            assert!(st.success(), "git {args:?}");
+        };
+        git(&["init", "-q"]);
+        // foundry.toml alias form, and the raw-secret-name form cyclo.sol uses.
+        std::fs::write(
+            dir.join("foundry.toml"),
+            "[rpc_endpoints]\nbase_sepolia = \"${BASE_SEPOLIA_RPC_URL}\"\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("Prod.t.sol"),
+            "vm.createSelectFork(vm.envString(\"RPC_URL_FLARE_FORK\"), 51262162);",
+        )
+        .unwrap();
+        // Untracked file: not a demand signal.
+        std::fs::write(dir.join("scratch.txt"), "ARBITRUM_RPC_URL").unwrap();
+        git(&["add", "foundry.toml", "Prod.t.sol"]);
+
+        let got = demanded(&dir);
+        assert!(got.contains("base_sepolia"));
+        assert!(got.contains("flare"));
+        // base_sepolia must not drag base in, and the untracked mention of
+        // arbitrum must not count.
+        assert!(!got.contains("base"));
+        assert!(!got.contains("arbitrum"));
+        assert_eq!(got.len(), 2);
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+}

--- a/rainix-static/src/rpc_preflight.rs
+++ b/rainix-static/src/rpc_preflight.rs
@@ -37,10 +37,12 @@ use crate::fail;
 /// prints `<redacted>`, so no format string anywhere in this crate can put a
 /// URL on stdout or stderr — including a future edit that adds a `{:?}` to a
 /// log line. The inner string is reachable only through `expose()`, which has
-/// exactly two call sites: the argv of the curl child process (whose stdout and
-/// stderr are captured and never re-printed) and the write to the file named by
-/// --github-env. Every log line is built from a `Source` label and a `Reason`,
-/// both of which are closed enums over fixed text.
+/// exactly three call sites: the argv of the curl child process (whose stdout
+/// and stderr are captured and never re-printed), the write to the file named
+/// by --github-env, and the `::add-mask::` workflow command — whose whole
+/// purpose is that the runner redacts the value it is given, including in the
+/// command line itself. Every log line is built from a `Source` label and a
+/// `Reason`, both of which are closed enums over fixed text.
 pub(crate) struct Url(String);
 
 impl fmt::Debug for Url {
@@ -282,10 +284,11 @@ pub(crate) const NETWORKS: &[Network] = &[
         // Latest-only in every consumer today.
         archive_blocks: &[],
         probe_contract: "0x5555555555555555555555555555555555555555", // WHYPE
-        // No measured public archive endpoint yet; the pool is whatever the
-        // secret and variable hold. An empty pool is a skip, not a failure, so
-        // a repo that does not use hyperevm is unaffected either way.
-        defaults: &[],
+        defaults: &[
+            "https://rpc.hyperliquid.xyz/evm",
+            "https://rpc.hyperlend.finance",
+            "https://hyperliquid.drpc.org",
+        ],
     },
 ];
 
@@ -836,8 +839,20 @@ mod tests {
 
     #[test]
     fn pool_is_empty_when_nothing_is_configured_and_there_is_no_default() {
-        let n = net("hyperevm");
-        assert!(pool(n, "", "").is_empty());
+        // Every network in the table currently ships defaults, so construct the
+        // degenerate case explicitly: an empty pool must stay empty, because
+        // `run` treats that as a skip (today's behaviour) rather than a failure.
+        let n = Network {
+            key: "nowhere",
+            env_name: "NOWHERE_RPC_URL",
+            secret_name: "RPC_URL_NOWHERE_FORK",
+            chain_id: 0,
+            archive_blocks: &[],
+            probe_contract: "0x0000000000000000000000000000000000000000",
+            defaults: &[],
+        };
+        assert!(pool(&n, "", "").is_empty());
+        assert!(pool(&n, "  \n # only a comment\n", "").is_empty());
     }
 
     #[test]

--- a/rainix-static/src/rpc_preflight.rs
+++ b/rainix-static/src/rpc_preflight.rs
@@ -471,6 +471,50 @@ fn hex_result(v: &serde_json::Value) -> Option<&str> {
     v.as_str().filter(|s| s.starts_with("0x"))
 }
 
+/// Chain id from an `eth_chainId` result.
+fn parse_chain_id(v: &serde_json::Value) -> Option<u64> {
+    hex_result(v).and_then(|s| u64::from_str_radix(s.trim_start_matches("0x"), 16).ok())
+}
+
+/// Blocks the probe reads state at.
+///
+/// Latest-only when the network has no pinned historical reads in the org, or
+/// when the caller is a deploy/broadcast path that only ever touches head state
+/// — forcing archive there would reject a perfectly good pruning endpoint for
+/// no benefit.
+fn probe_blocks(net: &Network, archive: bool) -> Vec<Option<u64>> {
+    if archive && !net.archive_blocks.is_empty() {
+        net.archive_blocks.iter().copied().map(Some).collect()
+    } else {
+        vec![None]
+    }
+}
+
+/// JSON-RPC block parameter for a probe block.
+fn block_tag(b: Option<u64>) -> String {
+    match b {
+        Some(n) => format!("0x{n:x}"),
+        None => "latest".to_string(),
+    }
+}
+
+/// Validate an `eth_call` of `totalSupply()`.
+///
+/// A well-formed answer is exactly one 32-byte word ("0x" + 64 hex digits).
+/// `0x` means the call executed against an account with no code, i.e. the node
+/// served an empty state for the probe block rather than erroring — a silent
+/// form of "not archive" that would otherwise look like a pass.
+fn check_call_result(v: &serde_json::Value, block: Option<u64>) -> Result<(), Reason> {
+    match hex_result(v) {
+        Some(s) if s.len() == 66 => Ok(()),
+        Some(_) => Err(Reason::NotArchive {
+            code: 0,
+            block: block.unwrap_or(0),
+        }),
+        None => Err(Reason::BadResponse),
+    }
+}
+
 /// Probe one candidate. Returns Ok only if EVERY check passes on EVERY sample.
 ///
 /// The three checks mirror what forge's fork backend does, in the order that
@@ -501,9 +545,7 @@ fn probe(
         r#"{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}"#,
         None,
     )?;
-    let got = hex_result(&chain)
-        .and_then(|s| u64::from_str_radix(s.trim_start_matches("0x"), 16).ok())
-        .ok_or(Reason::BadResponse)?;
+    let got = parse_chain_id(&chain).ok_or(Reason::BadResponse)?;
     if got != net.chain_id {
         return Err(Reason::WrongChain {
             expected: net.chain_id,
@@ -511,22 +553,11 @@ fn probe(
         });
     }
 
-    // Latest-only when the network has no pinned historical reads in the org,
-    // or when the caller is a deploy/broadcast path that only ever touches head
-    // state — forcing archive there would reject a perfectly good pruning
-    // endpoint for no benefit.
-    let blocks: Vec<Option<u64>> = if archive && !net.archive_blocks.is_empty() {
-        net.archive_blocks.iter().copied().map(Some).collect()
-    } else {
-        vec![None]
-    };
+    let blocks = probe_blocks(net, archive);
 
     for _ in 0..samples {
         for b in &blocks {
-            let tag = match b {
-                Some(n) => format!("0x{n:x}"),
-                None => "latest".to_string(),
-            };
+            let tag = block_tag(*b);
             let bal = rpc(
                 url,
                 timeout,
@@ -547,19 +578,7 @@ fn probe(
                 ),
                 *b,
             )?;
-            // A well-formed totalSupply() answer is exactly one 32-byte word.
-            // `0x` means the call executed against an account with no code,
-            // i.e. the node served an empty state for the probe block.
-            match hex_result(&call) {
-                Some(s) if s.len() == 66 => {}
-                Some(_) => {
-                    return Err(Reason::NotArchive {
-                        code: 0,
-                        block: b.unwrap_or(0),
-                    })
-                }
-                None => return Err(Reason::BadResponse),
-            }
+            check_call_result(&call, *b)?;
         }
     }
     Ok(())
@@ -734,6 +753,7 @@ fn upper(key: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn url_never_formats_its_value() {
@@ -925,6 +945,82 @@ mod tests {
         assert_eq!(
             classify(-32603, "internal error", None),
             Reason::RpcError { code: -32603 }
+        );
+    }
+
+    #[test]
+    fn chain_id_parsing() {
+        assert_eq!(parse_chain_id(&json!("0xa4b1")), Some(42161));
+        assert_eq!(parse_chain_id(&json!("0x1")), Some(1));
+        assert_eq!(parse_chain_id(&json!("0xe")), Some(14));
+        // Decimal, missing prefix, non-string, garbage hex: all unusable.
+        assert_eq!(parse_chain_id(&json!("42161")), None);
+        assert_eq!(parse_chain_id(&json!(42161)), None);
+        assert_eq!(parse_chain_id(&json!("0xzz")), None);
+        assert_eq!(parse_chain_id(&json!(null)), None);
+    }
+
+    #[test]
+    fn probe_blocks_follow_the_archive_decision() {
+        // An archive network under archive mode probes every configured block.
+        assert_eq!(
+            probe_blocks(net("base"), true),
+            vec![Some(1), Some(39_000_000)]
+        );
+        assert_eq!(probe_blocks(net("arbitrum"), true), vec![Some(280_000_000)]);
+        // --no-archive (deploy/broadcast) collapses to latest even for a
+        // network that has pinned blocks.
+        assert_eq!(probe_blocks(net("arbitrum"), false), vec![None]);
+        // A latest-only network is latest in either mode.
+        assert_eq!(probe_blocks(net("ethereum"), true), vec![None]);
+        assert_eq!(probe_blocks(net("ethereum"), false), vec![None]);
+    }
+
+    #[test]
+    fn block_tags_are_hex_or_latest() {
+        assert_eq!(block_tag(None), "latest");
+        assert_eq!(block_tag(Some(0)), "0x0");
+        assert_eq!(block_tag(Some(1)), "0x1");
+        // Hex, not decimal — a decimal block param is silently misread.
+        assert_eq!(block_tag(Some(280_000_000)), "0x10b07600");
+        assert_eq!(block_tag(Some(39_000_000)), "0x25317c0");
+    }
+
+    #[test]
+    fn call_result_must_be_one_full_word() {
+        let word = json!("0x0000000000000000000000000000000000000000000000000000000000000000");
+        assert_eq!(check_call_result(&word, Some(1)), Ok(()));
+        // "0x" is the node answering from empty state rather than erroring —
+        // the silent not-archive that a naive probe would score as a pass.
+        assert_eq!(
+            check_call_result(&json!("0x"), Some(280_000_000)),
+            Err(Reason::NotArchive {
+                code: 0,
+                block: 280_000_000
+            })
+        );
+        // Short or long by one nibble is still not a word.
+        assert!(matches!(
+            check_call_result(&json!("0x00"), None),
+            Err(Reason::NotArchive { .. })
+        ));
+        assert!(matches!(
+            check_call_result(&json!(format!("0x{}", "0".repeat(63))), None),
+            Err(Reason::NotArchive { .. })
+        ));
+        assert!(matches!(
+            check_call_result(&json!(format!("0x{}", "0".repeat(65))), None),
+            Err(Reason::NotArchive { .. })
+        ));
+        // Not a hex string at all.
+        assert_eq!(
+            check_call_result(&json!(null), None),
+            Err(Reason::BadResponse)
+        );
+        assert_eq!(check_call_result(&json!(1), None), Err(Reason::BadResponse));
+        assert_eq!(
+            check_call_result(&json!("no prefix"), None),
+            Err(Reason::BadResponse)
         );
     }
 


### PR DESCRIPTION
Closes #288.

Foundry maps one `[rpc_endpoints]` alias to exactly one URL and `--fork-retries` only retries that same URL, so a deterministic upstream failure — the exhausted drpc plan quota that reddened `rain.extrospection` / `rain.factory.deploy`, a pruning node, a dead host — cannot be recovered inside `forge`. This recovers it one step earlier: a preflight picks a candidate that is healthy *right now* and binds it to `<NETWORK>_RPC_URL` before forge starts.

## What's here

- **`rainix-static rpc-preflight`** (`rainix-static/src/rpc_preflight.rs`) — all the logic, per the "tooling is Rust, never bash" rule. 20 unit tests, run inside the nix build.
- **`.github/actions/rpc-preflight/action.yml`** — house pattern: `nix run "path:$GITHUB_ACTION_PATH/../../..#rainix-static"`, so the check version always matches the action version regardless of any `RAINIX_SHA` the caller pins.
- Wired into the three reusables that set fork RPC env — `rainix-sol-test.yaml`, `rainix-tag-release.yaml`, `rainix-manual-sol-artifacts.yaml` — **replacing** the static `secrets.X || vars.X` mapping in each.
- `flake.nix`: `rainix-static` is now wrapped with the pinned `curl` and `git` plus a CA bundle. The composite runs `nix run` *outside* any devshell, so ambient PATH is whatever the runner image ships. Verified hermetic — the nix-built binary completes a full selection under `env -i PATH=/nonexistent`.

## Merged pool, not a precedence chain

Per the ruling — *"i didn't say fallback if not set i said merge into a list of urls that are all used"*. The secret and the variable each hold a **newline-separated list**, and the candidate pool is the **concatenation** of both plus hardcoded defaults:

| order | source | holds |
| --- | --- | --- |
| 1 | secret `RPC_URL_<NET>_FORK` | keyed/paid URLs (masked) |
| 2 | variable `RPC_URL_<NET>_FORK` | public keyless URLs (visible, greppable) |
| 3 | hardcoded defaults | measured keyless archive endpoints |

A URL in the variable is tried **even when the secret is set** — a non-empty earlier source never causes a later one to be skipped, it only orders them. Ordering is secret-first because that is the paid/dedicated endpoint; public ones are the safety net. In the demo below `secret[0]`, `secret[1]` and `variable[0]` are all rejected and `variable[1]` is selected, which is only reachable under the merged reading.

**Separator = newline**, because it cannot occur inside a URL (no escaping), GitHub's secret/variable editors take multi-line values natively, and the runner registers each *line* of a multi-line secret as a separately masked value. A single bare URL parses as a one-element list, which is exactly what these secrets hold today — **no configuration change is required for this PR to be an improvement**; the hardcoded defaults alone already fix the outage. `#` starts a comment so a dead candidate can be parked with a note.

`Foundry consumes exactly one URL per alias`, so "all used" is implemented as *all are candidates the preflight will actually try*. See the open question at the bottom.

## The probe is archive-aware, and that is the load-bearing part

`eth_blockNumber` is useless here: it passes on a pruning node that then fails the suite. So is `eth_getCode` alone — `base.meowrpc.com` serves historical code but answers *every* `eth_call` with "method not supported". Per candidate, fail-cheapest-first:

1. `eth_chainId` against the expected chain id — a wrong-chain candidate would *silently fork the wrong network*, worse than a red job.
2. `eth_getBalance` at the probe block — historical **account** state, what forge's fork backend fetches first.
3. `eth_call` at the probe block — historical **execution**, and the result must be a full 32-byte word (a `0x` answer means the node served empty state).

**3 consecutive full passes required.** `1rpc.io/arb` passed the historical probe 1 time in 5 and `1rpc.io/base` flipped from archive to `state is pruned` within twenty minutes — these hosts round-robin over a mix of archive and pruning backends, so a single sample qualifies an endpoint that dies partway through a suite issuing thousands of historical reads.

**Probe block = the deepest block any repo in the org pins for that network**, because the question is not "is this an archive node" but "can it serve *my* fork block":

| network | probe block | why |
| --- | --- | --- |
| arbitrum | 280,000,000 | `rain.tofu.erc20-decimals` (~20 months) |
| base | 1 **and** 39,000,000 | `rain.deploy` `findDeployBlock` binary-searches from genesis; the second block stops a node holding only early state from passing |
| base_sepolia | 38,000,000 | `rain.metadata` metaboard start block |
| flare | 31,000,000 | `rain.flare`, ~19 test files (~23 months) |
| polygon | 82,000,000 | `rain.metadata` metaboard start block |
| ethereum | latest | every Ethereum fork in the org is at latest; a pruning node is fine and should not be excluded |
| hyperevm | latest | latest-only in every consumer |

Note base_sepolia and polygon have **no** two-arg `createSelectFork(url, block)` anywhere — their archive requirement is hidden inside `LibRainDeploy.isStartBlock`, which forks at latest and then `vm.rollFork()`s backwards.

`archive: 'false'` on the deploy path (`rainix-manual-sol-artifacts`): a broadcast only reads head state, so requiring archive there would reject a healthy pruning endpoint for nothing. The `_FORK` suffix on the secret is a misnomer on that path.

## How the no-leak guarantee works

Not a scrubbing pass — those get bypassed by the next edit. It is structural, in three layers:

1. **`struct Url(String)` has no `Display`, and its `Debug` prints `<redacted>`.** No format string anywhere in the crate can put a URL on stdout or stderr, including a future edit that adds a `{:?}` to a log line. The inner value is reachable only via `expose()`, which has exactly **three** call sites: curl's argv, the write to `$GITHUB_ENV`, and the `::add-mask::` command in (3) — whose entire purpose is that the runner redacts the value it is handed, including in the command line itself. There is deliberately **no stdout mode**: invoked without a file to write to, the subcommand fails rather than falling back to printing.
2. **Every log line is a `Source` plus a `Reason`, both closed enums over fixed text.** `Reason`'s `Display` is fixed strings plus integers we produced ourselves (a JSON-RPC code, an HTTP status, a curl exit, a chain id, a block). Upstream response bodies are **classified and then dropped** — an endpoint that echoes the request URL back inside its error message, or serves an HTML error page containing it, cannot leak it. curl's stderr is `Stdio::null()`ed because curl writes the request host into its own error text.
3. **`::add-mask::` on any secret-sourced selection** before it reaches `$GITHUB_ENV`. Redundant with the runner's own per-line masking of multi-line secrets, but free — and it does not help for the case that actually matters, which is a keyed URL misconfigured into `vars.` (not auto-masked). That case is covered by (1) and (2).

Candidate URLs also travel to the composite as **env vars, not `with:` inputs**, because GitHub renders a composite's resolved inputs into the log.

There is a test asserting `Url`'s debug is `<redacted>` and one asserting no `Reason` variant renders a `http://` or `https://`.

## Blast radius containment

- **Only networks the repo references are probed.** A demand scan over `git ls-files` looks for `<NET>_RPC_URL` (the foundry.toml alias form) *and* `RPC_URL_<NET>_FORK` (the raw-secret form `cyclo.sol` reads via `vm.envString`). An unmentioned network is never probed, never exported, and can never fail the job. A test asserts `BASE_SEPOLIA_RPC_URL` does not drag `base` in.
- **A network with no candidates at all is a skip, not a failure** — byte-identical to today's behaviour (env stays unset).
- The selected URL is exported under **both** `<NET>_RPC_URL` and `RPC_URL_<NET>_FORK`. The second matters: once the secret can hold a list, repos reading the raw secret name would otherwise get a multi-line string `createSelectFork` cannot use.

## Riding along

`RPC_URL_HYPEREVM_FORK` was declared in `rainix-manual-sol-artifacts.yaml` only, so a repo with `hyperevm` in `[rpc_endpoints]` could deploy but its fork tests and tag-release verification both failed "env var not found". Added to `rainix-sol-test.yaml`, `rainix-sol.yaml` (declaration **and** the explicit forward — that forward is a hard allowlist, `secrets: inherit` upstream does not get past it) and `rainix-tag-release.yaml`. README's documented env list was also missing `ETHEREUM_RPC_URL` and `HYPEREVM_RPC_URL`.

## Demonstration

Local end-to-end run against a synthetic consumer repo whose `foundry.toml` declares `arbitrum` and whose test reads `RPC_URL_BASE_SEPOLIA_FORK` directly. The secret list is `[an exhausted-plan upstream with ?dkey=SUPERSECRETKEY123, a pruning node]`, the variable list is `[publicnode (archive token-gated), thirdweb]`. Polygon is configured but **not referenced by the repo**. The first two upstreams are local mocks replaying the verbatim drpc and geth error bodies; everything else is a real public endpoint.

```
rpc-preflight: arbitrum: secret[0] rejected: quota exhausted / rate limited (rpc error -32001)
rpc-preflight: arbitrum: secret[1] rejected: not archive: no historical state at block 280000000 (rpc error -32000)
rpc-preflight: arbitrum: variable[0] rejected: not archive: no historical state at block 280000000 (rpc error -32602)
::warning::rpc-preflight: arbitrum fell back to variable[1] after 3 unhealthy candidate(s)
rpc-preflight: arbitrum: SELECTED variable[1] (chain 42161, archive at block 280000000, 3/3 samples)
rpc-preflight: base_sepolia: SELECTED default[0] (chain 84532, archive at block 38000000, 3/3 samples)
rpc-preflight: clean
exit=0

--- $GITHUB_ENV written by the step ---
ARBITRUM_RPC_URL=https://42161.rpc.thirdweb.com
RPC_URL_ARBITRUM_FORK=https://42161.rpc.thirdweb.com
BASE_SEPOLIA_RPC_URL=https://sepolia.base.org
RPC_URL_BASE_SEPOLIA_FORK=https://sepolia.base.org

=== LEAK CHECK: does anything the step printed contain the secret's key? ===
clean: 'SUPERSECRETKEY123' appears 0 times in the step log
host substring occurrences in log: 0
```

Every rejection is named by source with a typed reason. Polygon is absent because the repo does not reference it. base_sepolia had nothing configured and landed on a hardcoded default — the case of a repo that sets no secret at all today.

**Total-failure path** — every candidate for a required network unreachable (an outbound proxy pointed at a closed port, so the hardcoded defaults die too):

```
rpc-preflight: arbitrum: secret[0] rejected: unreachable (curl exit 7)
rpc-preflight: arbitrum: variable[0] rejected: unreachable (curl exit 7)
rpc-preflight: arbitrum: default[0] rejected: unreachable (curl exit 7)
rpc-preflight: arbitrum: default[1] rejected: unreachable (curl exit 7)
rpc-preflight: arbitrum: default[2] rejected: unreachable (curl exit 7)
::error::rpc-preflight: arbitrum: no healthy endpoint among 5 candidate(s) for chain 42161 (archive at block 280000000). Every candidate and why it was rejected is listed above by SOURCE; add a working URL to the RPC_URL_ARBITRUM_FORK secret (keyed) or variable (public, newline-separated).
rpc-preflight: base_sepolia: default[0] rejected: unreachable (curl exit 7)
...
::error::rpc-preflight: no healthy RPC endpoint for: arbitrum, base_sepolia
exit=1
```

Note it does **not** stop at the first dead network — every required network is reported, so one run tells you everything that needs fixing. The secret here was `https://keyed.example/?dkey=SUPERSECRETKEY123`; neither the key, nor the host, nor the variable's host appears anywhere in that output.

**Closing the loop with real forge** — same pin `rain.extrospection` uses, isolated `HOME` so there is no warm fork cache:

```
### FORGE, with the URL the preflight REJECTED as not-archive (public arb1) ###
Ran 1 test for test/Fork.t.sol:ForkTest
[FAIL: EVM error; database error: failed to get account for 0xA4b000000000000000000073657175656e636572: server returned an error response: error code -32000: metadata is not found, 402243830] testForkAtPinnedBlock() (gas: 0)
Suite result: FAILED. 0 passed; 1 failed; 0 skipped

### FORGE, with the URL the preflight SELECTED ###
Ran 1 test for test/Fork.t.sol:ForkTest
[PASS] testForkAtPinnedBlock() (gas: 16218)
Suite result: ok. 1 passed; 0 failed; 0 skipped
```

That `failed to get account for 0xA4b0…sequencer` is precisely the cryptic mid-suite error this replaces with `secret[0] rejected: quota exhausted`.

## Checks

- `cargo test` — 34 pass (20 new), `cargo fmt --check` and `cargo clippy -D clippy::all` clean.
- `nix develop -c pre-commit run --all-files` — yamlfmt, prettier-rainix, shellcheck, statix, taplo, nil, nixfmt, deadnix, denofmt all pass. The `rustfmt-conditional` hook fails **identically on pristine `main`** (`cargo metadata` looks for a `Cargo.toml` at the repo root, which rainix does not have); it is not exercised by CI, where `cargo-fmt` is off PATH and the hook no-ops. Not touched here — separate issue.

## Open question

`Foundry consumes exactly one URL per alias`, so "all used" is implemented as *every URL in either list is a candidate the preflight will actually try*, which is what the words say. True simultaneous multi-upstream load balancing would need a proxy sitting in front of forge, not a URL list. Flagging rather than silently choosing, in case that was the intent.

Two follow-ups deliberately **not** in this PR, one of which is **red on `main` right now**:

- **sepolia is not covered, and it is the reason `main` is red.** `rainix (ubuntu-latest, rainix-sol-artifacts)` has failed on every `main` run since 2026-07-24 (green on 07-16), including `aa789b99`, which this branch is cut from. The log is the same failure class this PR fixes, in its purest form:

  ```
  ++ forge script script/Deploy.sol:Deploy -vvvvv --slow --rpc-url '' --etherscan-api-key *** --resume
  Error: Internal transport error: Connection refused (os error 111)
  Deploy failed, retrying in 5 seconds... (attempt 7)
  ...
  Deploy failed after 10 attempts, aborting.
  ```

  `--rpc-url ''` — `secrets.CI_DEPLOY_SEPOLIA_RPC_URL || vars.CI_DEPLOY_SEPOLIA_RPC_URL` resolves empty, and `flake.nix`'s `until do_deploy; do sleep 5` loop then re-hits the empty URL ten times over ~50s before failing anyway. A candidate pool with a hardcoded default would make this green with **zero** configuration.

  I did not fold sepolia in, because doing so makes two decisions that are yours, not mine: (1) sepolia is the one network outside the `RPC_URL_<NET>_FORK` scheme — secret `CI_DEPLOY_SEPOLIA_RPC_URL` → env `ETH_RPC_URL` *and* `CI_DEPLOY_SEPOLIA_RPC_URL`, with `flake.nix` hardcoding `--rpc-url ${ETH_RPC_URL}`, so folding it in either enshrines that naming or migrates it; and (2) that job **broadcasts** with `DEPLOYMENT_KEY`, so having a hardcoded default pick the endpoint for a real transaction is a materially bigger call than picking one for a fork read. Say which way you want it and it is a small follow-up. It is also block-pinned by a repo variable (`CI_FORK_SEPOLIA_BLOCK_NUMBER`), so its archive depth is configuration I cannot see from here.

- **`flake.nix`'s `rainix-sol-artifacts` retry loop** is the other half of that log: ten retries with `--resume` against the same endpoint is structurally identical to Foundry's `--fork-retries` and just as useless against a deterministic failure. Classifying the error once and either failing fast or moving to another candidate is the same fix as this PR, applied to the deploy task.
