### PR TITLE
One formatter owns .mjs/.cjs: denofmt keeps them, prettier-rainix excludes them

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -537,6 +537,19 @@
                 "javascript"
                 "json"
               ];
+              # One owner per file type: the `javascript` type also matches
+              # .mjs/.cjs, which denofmt owns (its excludes carve out only
+              # .ts/.js/.json/.svelte). With both hooks live — a frontend repo
+              # running the bundle over all files — the two styles disagree and
+              # rewrite each other forever, so no whole-tree check can ever
+              # pass. Committed .mjs across the org is denofmt-styled (it runs
+              # live in rust-shell CI where this hook no-ops), so denofmt keeps
+              # them and this hook excludes them: every type claimed by two
+              # hooks must be excluded by one of them.
+              excludes = [
+                ".*\.mjs$"
+                ".*\.cjs$"
+              ];
             };
 
             # Block consumers from shipping their own prettier, prettier


### PR DESCRIPTION
Closes #290.

One line of policy plus its comment: `prettier-rainix` now excludes `.mjs`/`.cjs`, making denofmt their single owner. Full diagnosis and org-wide measurement in #290; the short form: the `javascript` type matches `.mjs`/`.cjs`, both hooks claimed it, their styles disagree on real code, and with both live (a frontend repo, default shell, whole-tree run) they rewrite each other forever — reproduced as a three-round loop in thedavidmeister/recipes. Nobody had ever executed the collision before: rust repos run all-files from rust-shell where prettier no-ops, frontend repos ran no all-files step, and one `.mjs` existed in the org outside recipes.

**Direction chosen for zero churn:** every committed `.mjs`/`.cjs` in the org is denofmt-styled, because denofmt is the owner that actually runs (live in rust-shell CI). Handing them to prettier instead would reformat consumers' committed scripts and leave `.mjs` entirely unchecked in rust-shell CI, where prettier no-ops. This way no consumer's tree changes at all.

The invariant the comment encodes for the next hook added: **every type claimed by two hooks must be excluded by one of them.**

Unblocks: the whole-tree `pre-commit run --all-files` CI step for frontend repos (thedavidmeister/recipes#190), which is the same drift protection `rainix-rs-static` already gives rust repos, with prettier active because catching the prettier bundle's own restyling is the point.

## QA
- Discriminating tests: n/a — a hook-config exclude has no test harness in this repo; the discriminating check is the reproduction in #290: before this change `pre-commit run prettier-rainix --all-files` rewrites 6 `.mjs` in recipes and denofmt rewrites 3 back (loop); with this exclude prettier skips them and the loop cannot occur.
- Mutations applied: n/a — one declarative excludes list; its only failure mode (wrong regex → prettier still claims the files) is exactly what the recipes reproduction detects on the consumer side once the pin bumps.
- Oracle: the materialized `.pre-commit-config.yaml` in consumers (denofmt's own excludes list, whose carve-out style this mirrors), and pre-commit's documented `excludes` semantics — independent of this diff.
- Category check: issue asks that one formatter own `.mjs`/`.cjs` so a formatting fixpoint exists; covered — denofmt owns them, prettier excludes them, invariant documented at the definition site. Refs thedavidmeister/recipes#190 because its deferred CI step lands once consumers pick this up.

`nix-instantiate --parse` clean on the edited flake.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pre-commit formatting checks to exclude `.mjs` and `.cjs` files.
  * Added documentation clarifying the formatting rule’s file scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->