### PR TITLE
Fix RPC preflight archive mode

### DIFF
--- a/.github/actions/rpc-preflight/action.yml
+++ b/.github/actions/rpc-preflight/action.yml
@@ -12,6 +12,8 @@ runs:
   steps:
     - name: Select a healthy fork RPC per network
       shell: bash
+      env:
+        RAINIX_RPC_ARCHIVE: ${{ inputs.archive }}
       # Candidate URLs are NOT passed as `with:` inputs on purpose: GitHub
       # renders a composite's resolved inputs into the log, which would print a
       # keyed URL verbatim. They arrive as env vars set by the calling reusable
@@ -19,9 +21,15 @@ runs:
       # out of the environment by the binary, which never prints one.
       run: |
         set -euo pipefail
+        # Keep this in bash rather than a GitHub &&/|| expression: an empty
+        # "archive" argument is falsey there and falls through to --no-archive.
+        rpc_args=(rpc-preflight)
+        if [[ "$RAINIX_RPC_ARCHIVE" != "true" ]]; then
+          rpc_args+=(--no-archive)
+        fi
         # Single source of truth: the Rust rainix-static binary (its unit tests
         # run inside the nix build). The path: flake ref runs it from this
         # composite's own checkout, so the check version always matches the
         # action version regardless of any RAINIX_SHA the caller pins.
         nix run "path:$(cd "$GITHUB_ACTION_PATH/../../.." && pwd)#rainix-static" -- \
-          rpc-preflight ${{ inputs.archive == 'true' && '' || '--no-archive' }}
+          "${rpc_args[@]}"

--- a/flake.nix
+++ b/flake.nix
@@ -446,6 +446,7 @@
             bats test/bats/devshell/default/gh.test.bats
             bats test/bats/devshell/default/age.test.bats
             bats test/bats/devshell/default/prettier-bundle.test.bats
+            bats test/bats/action/rpc-preflight.test.bats
             bats test/bats/task/skip-simulation.test.bats
             bats test/bats/task/subgraph-build.test.bats
             bats test/bats/task/subgraph-deploy-version.test.bats

--- a/test/bats/action/rpc-preflight.test.bats
+++ b/test/bats/action/rpc-preflight.test.bats
@@ -1,0 +1,37 @@
+setup() {
+  repo_root="$BATS_TEST_DIRNAME/../../.."
+  action="$repo_root/.github/actions/rpc-preflight/action.yml"
+  action_script="$(yq -r '.runs.steps[0].run' "$action")"
+}
+
+run_preflight_action() {
+  local archive="$1"
+
+  RAINIX_RPC_ARCHIVE="$archive" \
+    GITHUB_ACTION_PATH="$repo_root/.github/actions/rpc-preflight" \
+    ACTION_SCRIPT="$action_script" \
+    bash -c '
+      nix() {
+        printf "nix"
+        printf " <%s>" "$@"
+        printf "\n"
+      }
+      export -f nix
+      bash -c "$ACTION_SCRIPT"
+    '
+}
+
+@test "archive mode does not pass --no-archive" {
+  run run_preflight_action true
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *" <--> <rpc-preflight>" ]]
+  [[ "$output" != *"<--no-archive>"* ]]
+}
+
+@test "non-archive mode passes --no-archive" {
+  run run_preflight_action false
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *" <--> <rpc-preflight> <--no-archive>" ]]
+}


### PR DESCRIPTION
## Problem

The RPC preflight composite used GitHub's `&&`/`||` pseudo-ternary to choose the optional `--no-archive` flag:

```yaml
${{ inputs.archive == 'true' && '' || '--no-archive' }}
```

The intended archive branch returns an empty string, which is falsey, so the expression falls through to `--no-archive` in both modes. Fork-test workflows therefore checked only latest state even though archive validation was enabled by default.

This explains the Raindex Polygon failure: preflight selected an endpoint as `latest`, then Forge requested historical state at the pinned deployment block and received `historical state ... is not available`.

## Solution

- Pass the composite input through a step environment variable rather than interpolating it into shell syntax.
- Build a non-empty Bash argument vector and append `--no-archive` only when `archive` is not `true`.
- Add a Bats regression that executes the action's exact `run` block with a stubbed `nix` command and verifies both argument paths.
- Run the regression as part of `default-shell-test` on Linux and macOS.

## Behavior

| Action input | `rainix-static` arguments | Probe mode |
| --- | --- | --- |
| `archive: 'true'` (default) | `rpc-preflight` | Historical archive blocks |
| `archive: 'false'` | `rpc-preflight --no-archive` | Latest state only |

Deploy and broadcast workflows that explicitly opt out of archive checks keep their existing behavior. Fork suites now receive the archive-aware behavior already documented by the action.

## Validation

- Exact action-script harness on macOS Bash:
  - `archive=true` produces `rpc-preflight`
  - `archive=false` produces `rpc-preflight --no-archive`
- `nix develop --command bats test/bats/action/rpc-preflight.test.bats`
- `NIXPKGS_ALLOW_INSECURE=1 nix flake check --impure`
- `nix develop --command pre-commit run --files .github/actions/rpc-preflight/action.yml flake.nix test/bats/action/rpc-preflight.test.bats`
- `reuse lint` in a clean clone
- Simplification pass: reuse and efficiency reviewers reported no findings; the test-coverage finding was fixed with the Bats regression.
- Staged review round 1: two Codex reviews and two `opencode-go/deepseek-v4-flash` read-only reviews; no actionable findings remained.

## Rollout and dependencies

Merge order:

1. This Rainix PR
2. rainlanguage/raindex#2829
3. ST0x-Technology/st0x.rest.api#171

After this PR reaches `main`, rerun **all jobs** on Raindex #2829. Re-running only the failed job would reuse the original reusable-workflow commit; an all-jobs rerun resolves `rainlanguage/rainix/.github/workflows/rainix-sol.yaml@main` again and picks up this fix.

The Rainix repository's live RPC self-test intentionally invokes the composite at `@main`, so this branch cannot exercise the new action against real provider secrets before merge. The added local regression covers the exact argument-routing defect; the post-merge Raindex all-jobs rerun verifies the archive provider selection against the incident workflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RPC preflight archive handling so archive mode runs correctly, while non-archive mode explicitly disables archiving.

* **Tests**
  * Added coverage for archive and non-archive RPC preflight behavior.
  * Included the new checks in the default shell test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->