### PR TITLE
prompt-cap: the agent-context-cap check, pointed at a repo's prompt files

### DIFF
--- a/.github/actions/prompt-cap/action.yml
+++ b/.github/actions/prompt-cap/action.yml
@@ -1,0 +1,30 @@
+name: prompt-cap
+description: >-
+  Caps the bytes of the prompt files a repo points this at. agent-context-cap caps what Claude Code loads before turn one; a runner prompt is the same tax paid harder — a shell script reads it whole, so every byte sits in the window for every turn of a run that can be hundreds of turns long, and nothing else in CI measures it. Same traversal, three differences: the roots are the caller's glob and the cap is on their TOTAL (a per-file cap is evaded by splitting the file, and a new prompt file must be charged rather than escape by not being named); nothing is stripped, because no loader drops anything from a file a script reads whole; and any repo file the prompt NAMES is charged with it, since telling the agent to read a file puts it in the window as surely as an `@import` does. That reaches one hop: an import expands transitively because the loader expands it, and here there is no loader, so what a named file goes on to mention is free. A path in a code span or fence is not charged either, nor is one that resolves to no file, nor one outside the repo. Which files are prompts is per-repo, so this is opt-in rather than wired into the shared static jobs. A glob that matches nothing is an error, not a pass.
+inputs:
+  paths:
+    description: >-
+      Globs naming the prompt files, one per line (commas also work), relative to the repo root. `*` and `?` match within one path segment, `**` spans directories. Prefer a glob wide enough to catch a prompt that does not exist yet — that is what makes splitting a file pointless.
+    required: true
+  cap:
+    description: >-
+      Maximum TOTAL bytes across everything the globs match, plus every repo file those prompts name. Set it BELOW what they weigh today: the point is the cut. Lowering it later is the ratchet; raising it is a line in a PR diff.
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Check prompt byte cap
+      shell: bash
+      env:
+        # Via env, not interpolated into the script: the globs are multi-line
+        # caller input and must never be pasted into the shell text.
+        RAINIX_PROMPT_PATHS: ${{ inputs.paths }}
+        RAINIX_PROMPT_CAP: ${{ inputs.cap }}
+      run: |
+        set -euo pipefail
+        # Single source of truth: the Rust rainix-static binary (its unit tests
+        # run inside the nix build). The path: flake ref runs it from this
+        # composite's own checkout, so the check version always matches the
+        # action version regardless of any RAINIX_SHA the caller pins.
+        nix run "path:$(cd "$GITHUB_ACTION_PATH/../../.." && pwd)#rainix-static" -- \
+          prompt-cap --paths "$RAINIX_PROMPT_PATHS" --cap "$RAINIX_PROMPT_CAP"

--- a/flake.nix
+++ b/flake.nix
@@ -447,6 +447,7 @@
             bats test/bats/devshell/default/age.test.bats
             bats test/bats/devshell/default/prettier-bundle.test.bats
             bats test/bats/action/rpc-preflight.test.bats
+            bats test/bats/action/prompt-cap.test.bats
             bats test/bats/task/skip-simulation.test.bats
             bats test/bats/task/subgraph-build.test.bats
             bats test/bats/task/subgraph-deploy-version.test.bats

--- a/rainix-static/src/agent_context_cap.rs
+++ b/rainix-static/src/agent_context_cap.rs
@@ -32,6 +32,7 @@
 //! - Block-level HTML comments, which are stripped before injection, so a
 //!   maintainer note costs nothing and is not charged for.
 
+use crate::context_bytes::{self, Charge, Contributor, Walk};
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
@@ -70,53 +71,50 @@ const _: () = assert!(
 /// anything deeper is not in the launch context and must not be charged.
 const MAX_IMPORT_DEPTH: usize = 4;
 
-/// One file that lands in the launch context, and what it costs.
-#[derive(Debug, PartialEq, Eq)]
-pub(crate) struct Contributor {
-    pub(crate) bytes: u64,
-    /// Path as reported to the user, plus why it is loaded.
-    pub(crate) label: String,
+/// What Claude Code loads and how: `@path` imports, resolved as written, with
+/// block HTML comments dropped because it strips them before injection.
+fn charge() -> Charge {
+    Charge {
+        tokens: import_tokens,
+        resolve: resolve_import,
+        strip: strip_block_html_comments,
+        verb: "imported by",
+        max_depth: MAX_IMPORT_DEPTH,
+    }
 }
 
 /// Total launch-loaded bytes and the per-file breakdown, largest first. Public
 /// for tests; `check` is what the subcommand calls.
 pub(crate) fn collect(dir: &Path) -> Vec<Contributor> {
-    let mut seen: BTreeSet<PathBuf> = BTreeSet::new();
-    let mut out: Vec<Contributor> = Vec::new();
+    let charge = charge();
+    let mut walk = Walk::new(dir, &charge);
 
     // Project memory. Both locations are alternatives for the same thing; if a
     // repo somehow has both, both are loaded, so both are charged.
     for rel in ["CLAUDE.md", ".claude/CLAUDE.md"] {
-        let p = dir.join(rel);
-        if let Some(text) = read_loaded(&p, &mut seen) {
-            out.push(Contributor {
-                bytes: text.len() as u64,
-                label: rel.to_string(),
-            });
-            expand_imports(dir, &p, &text, rel, 1, &mut seen, &mut out);
-        }
+        walk.root_file(&dir.join(rel), rel);
     }
 
     // Unscoped rules load at launch with project-memory priority. Scoped ones
-    // (`paths:` frontmatter) load only when a matching file is read.
+    // (`paths:` frontmatter) load only when a matching file is read. A rule is
+    // charged as a LEAF — `take`/`push`, not `root_file` — because that is what
+    // #299 measured; following `@path` out of a rule would raise every repo's
+    // total, which is a cap change and not a refactor.
     for p in rules_files(&dir.join(".claude/rules")) {
-        let Some(text) = read_loaded(&p, &mut seen) else {
+        let Some(text) = walk.take(&p) else {
             continue;
         };
-        let rel = display_path(dir, &p);
+        let rel = context_bytes::display_path(dir, &p);
         if is_path_scoped(&text) {
             continue;
         }
-        out.push(Contributor {
-            bytes: text.len() as u64,
-            label: format!(
-                "{rel} (unscoped rule — add `paths:` frontmatter to make it load on demand)"
-            ),
-        });
+        walk.push(
+            text.len() as u64,
+            format!("{rel} (unscoped rule — add `paths:` frontmatter to make it load on demand)"),
+        );
     }
 
-    out.sort_by(|a, b| b.bytes.cmp(&a.bytes).then_with(|| a.label.cmp(&b.label)));
-    out
+    walk.finish()
 }
 
 /// Returns `(total_bytes, offenders)`. Offenders is empty when clean. A total
@@ -124,7 +122,7 @@ pub(crate) fn collect(dir: &Path) -> Vec<Contributor> {
 /// `>` fails.
 pub(crate) fn check(dir: &Path) -> (u64, Vec<String>) {
     let contributors = collect(dir);
-    let total: u64 = contributors.iter().map(|c| c.bytes).sum();
+    let total = context_bytes::total(&contributors);
     if total <= CAP_BYTES {
         return (total, Vec::new());
     }
@@ -135,9 +133,7 @@ pub(crate) fn check(dir: &Path) -> (u64, Vec<String>) {
          a floor-only ratchet). Every file below is in the context window on every turn, \
          whether or not the turn needs it:"
     )];
-    for c in &contributors {
-        lines.push(format!("  {:>7}  {}", c.bytes, c.label));
-    }
+    lines.extend(context_bytes::breakdown(&contributors));
     lines.push(
         "Cut by asking of each line: would a capable agent looking at this repo get this WRONG, \
          or merely take a moment to find it? Directory layouts, dependency lists, architecture \
@@ -153,62 +149,6 @@ pub(crate) fn check(dir: &Path) -> (u64, Vec<String>) {
     (total, lines)
 }
 
-/// Content of a regular file that has not been counted yet, as it lands in
-/// context: block-level HTML comments stripped, because Claude Code strips them
-/// before injection. `None` for anything absent, non-regular, unreadable or
-/// already counted — an absent file is a PASS, this check caps context, it
-/// never requires any file to exist.
-///
-/// The `is_file` guard rejects non-regular paths — a directory, a fifo — up
-/// front rather than relying on the read to fail on them. Belt and braces: a
-/// directory would fail the read anyway, but a fifo would BLOCK it, and a CI
-/// job that hangs costs a runner for its whole timeout.
-fn read_loaded(path: &Path, seen: &mut BTreeSet<PathBuf>) -> Option<String> {
-    if !path.is_file() {
-        return None;
-    }
-    // Canonicalize so the same file reached two ways is charged once (and so an
-    // import cycle terminates).
-    let key = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
-    if !seen.insert(key) {
-        return None;
-    }
-    std::fs::read_to_string(path)
-        .ok()
-        .map(|s| strip_block_html_comments(&s))
-}
-
-/// Charge every `@path` import reachable from `text`, depth-first, stopping at
-/// `MAX_IMPORT_DEPTH` hops. A path that does not resolve to a file contributes
-/// nothing (it is not loaded); flagging it is the separate path-existence check.
-fn expand_imports(
-    root: &Path,
-    from: &Path,
-    text: &str,
-    from_label: &str,
-    depth: usize,
-    seen: &mut BTreeSet<PathBuf>,
-    out: &mut Vec<Contributor>,
-) {
-    if depth > MAX_IMPORT_DEPTH {
-        return;
-    }
-    for token in import_tokens(text) {
-        let Some(target) = resolve_import(from, &token) else {
-            continue;
-        };
-        let Some(body) = read_loaded(&target, seen) else {
-            continue;
-        };
-        let label = format!("{} (imported by {from_label})", display_path(root, &target));
-        out.push(Contributor {
-            bytes: body.len() as u64,
-            label: label.clone(),
-        });
-        expand_imports(root, &target, &body, &label, depth + 1, seen, out);
-    }
-}
-
 /// `@path` tokens in `text`, ignoring anything inside a code span or fence
 /// (a backticked `@README` is literal text, not an import).
 ///
@@ -216,7 +156,7 @@ fn expand_imports(
 /// costs nothing, so over-matching is harmless while under-matching would leave
 /// the cap evadable.
 fn import_tokens(text: &str) -> Vec<String> {
-    let masked = mask_code(text);
+    let masked = context_bytes::mask_code(text);
     let chars: Vec<char> = masked.chars().collect();
     let mut out = Vec::new();
     let mut i = 0;
@@ -245,8 +185,9 @@ fn import_tokens(text: &str) -> Vec<String> {
 
 /// Absolute path an import token names, or `None` when it cannot be resolved.
 /// Relative paths resolve against the IMPORTING file's directory, not the
-/// working directory.
-fn resolve_import(from: &Path, token: &str) -> Option<PathBuf> {
+/// working directory. An import may leave the repo (`~/`, an absolute path), so
+/// the repo root is not a bound here and is unused.
+fn resolve_import(_root: &Path, from: &Path, token: &str) -> Option<PathBuf> {
     if let Some(rest) = token.strip_prefix("~/") {
         return Some(PathBuf::from(std::env::var("HOME").ok()?).join(rest));
     }
@@ -255,90 +196,6 @@ fn resolve_import(from: &Path, token: &str) -> Option<PathBuf> {
         return Some(p.to_path_buf());
     }
     Some(from.parent()?.join(p))
-}
-
-/// Blank out fenced code blocks and inline code spans so a *quoted* `@path` is
-/// not read as an import. Offsets are not preserved — only import scanning uses
-/// this, never the byte measurement.
-fn mask_code(text: &str) -> String {
-    let mut out = String::with_capacity(text.len());
-    let mut fence: Option<String> = None;
-    for line in text.lines() {
-        let marker = fence_marker(line.trim_start());
-        match (&fence, &marker) {
-            // Inside a fence: a run of the same char, at least as long, closes.
-            (Some(open), Some(m)) if m.starts_with(&open[..1]) && m.len() >= open.len() => {
-                fence = None;
-            }
-            (Some(_), _) => {}
-            (None, Some(m)) => fence = Some(m.clone()),
-            (None, None) => {
-                out.push_str(&mask_spans(line));
-            }
-        }
-        out.push('\n');
-    }
-    out
-}
-
-/// The opening/closing run of a fence line (3+ backticks or tildes), if any.
-fn fence_marker(trimmed: &str) -> Option<String> {
-    let c = trimmed.chars().next()?;
-    if c != '`' && c != '~' {
-        return None;
-    }
-    let run: String = trimmed.chars().take_while(|&x| x == c).collect();
-    (run.len() >= 3).then_some(run)
-}
-
-/// Blank inline code spans within one line. An unmatched backtick run is
-/// literal, per CommonMark, so it is left alone.
-fn mask_spans(line: &str) -> String {
-    let chars: Vec<char> = line.chars().collect();
-    let mut out = String::with_capacity(line.len());
-    let mut i = 0;
-    while i < chars.len() {
-        if chars[i] != '`' {
-            out.push(chars[i]);
-            i += 1;
-            continue;
-        }
-        let open_start = i;
-        while i < chars.len() && chars[i] == '`' {
-            i += 1;
-        }
-        let n = i - open_start;
-        let mut j = i;
-        let mut close = None;
-        while j < chars.len() {
-            if chars[j] == '`' {
-                let run_start = j;
-                while j < chars.len() && chars[j] == '`' {
-                    j += 1;
-                }
-                if j - run_start == n {
-                    close = Some(j);
-                    break;
-                }
-            } else {
-                j += 1;
-            }
-        }
-        match close {
-            Some(end) => {
-                for _ in open_start..end {
-                    out.push(' ');
-                }
-                i = end;
-            }
-            None => {
-                for _ in 0..n {
-                    out.push('`');
-                }
-            }
-        }
-    }
-    out
 }
 
 /// Drop HTML comments that occupy whole lines — Claude Code strips block-level
@@ -431,19 +288,6 @@ fn is_path_scoped(text: &str) -> bool {
     }
     // No closing delimiter: not frontmatter at all.
     false
-}
-
-/// Path relative to the repo root when possible, so reports are readable and
-/// stable across checkouts.
-fn display_path(root: &Path, p: &Path) -> String {
-    let rooted = std::fs::canonicalize(root);
-    let target = std::fs::canonicalize(p);
-    if let (Ok(r), Ok(t)) = (rooted, target) {
-        if let Ok(rel) = t.strip_prefix(&r) {
-            return rel.display().to_string();
-        }
-    }
-    p.display().to_string()
 }
 
 #[cfg(test)]

--- a/rainix-static/src/context_bytes.rs
+++ b/rainix-static/src/context_bytes.rs
@@ -1,0 +1,438 @@
+//! Shared engine for the byte-cap checks: charge a set of root files, follow
+//! the references out of them, and report largest-first.
+//!
+//! `agent-context-cap` (rainlanguage/rainix#299) and `prompt-cap`
+//! (rainlanguage/rainix#310) cap different things loaded by different loaders,
+//! but the traversal is one algorithm: read a root, charge its bytes as the
+//! loader sees them, find the file references in it, resolve them against the
+//! file they were found in, charge those too, stop at a depth bound, and never
+//! charge the same file twice however many ways it is reached.
+//!
+//! Reimplementing that is how a second check ends up subtly different from the
+//! first: the resolve-against-the-importer rule, the code-span and fence
+//! masking, and the cycle dedup are exactly the parts that look obvious and are
+//! not. So they live here once, and what differs is a [`Charge`]: which
+//! references count, how they resolve, and what the loader strips before the
+//! text lands in the window.
+//!
+//! What is NOT shared is the cap. Each caller owns its own number and its own
+//! failure prose, because where the number lives is the whole mechanism —
+//! `agent_context_cap::CAP_BYTES` can be a compile-time ratchet precisely
+//! because it lives in this repo, and `prompt-cap`'s number cannot, because
+//! which files are prompts is per-repo.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+/// One file that lands in the window, and what it costs.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct Contributor {
+    pub(crate) bytes: u64,
+    /// Path as reported to the user, plus why it is loaded.
+    pub(crate) label: String,
+}
+
+/// What a caller charges and what it follows. The three things that differ
+/// between the checks, and nothing else.
+pub(crate) struct Charge {
+    /// The reference tokens in a file's text. Given the RAW text, so a matcher
+    /// decides for itself what masking means for its syntax ([`mask_code`] is
+    /// here for the markdown answer). Deliberately liberal is safe: a token
+    /// that does not resolve costs nothing.
+    pub(crate) tokens: fn(&str) -> Vec<String>,
+    /// The file a token names, or `None` when it names nothing chargeable.
+    /// `from` is the file the token was found in — relative references resolve
+    /// against it, not against the working directory.
+    pub(crate) resolve: fn(root: &Path, from: &Path, token: &str) -> Option<PathBuf>,
+    /// Text as the loader injects it. Bytes the loader drops before injection
+    /// are not in the window, so charging them would bill for context that
+    /// never loads.
+    pub(crate) strip: fn(&str) -> String,
+    /// How a followed file is labelled: "<path> (<verb> <parent>)".
+    pub(crate) verb: &'static str,
+    /// How many hops of references to follow. A bound belongs to the loader
+    /// being modelled, so it is the caller's number.
+    pub(crate) max_depth: usize,
+}
+
+/// A traversal in progress: what has been charged, and what has been seen so
+/// it is not charged again.
+pub(crate) struct Walk<'a> {
+    root: &'a Path,
+    charge: &'a Charge,
+    seen: BTreeSet<PathBuf>,
+    out: Vec<Contributor>,
+}
+
+impl<'a> Walk<'a> {
+    pub(crate) fn new(root: &'a Path, charge: &'a Charge) -> Walk<'a> {
+        Walk {
+            root,
+            charge,
+            seen: BTreeSet::new(),
+            out: Vec::new(),
+        }
+    }
+
+    /// Content of a regular file that has not been charged yet, as it lands in
+    /// context. `None` for anything absent, non-regular, unreadable or already
+    /// counted — an absent file is a PASS, these checks cap what loads, they
+    /// never require a file to exist.
+    ///
+    /// The `is_file` guard rejects non-regular paths — a directory, a fifo — up
+    /// front rather than relying on the read to fail on them. Belt and braces:
+    /// a directory would fail the read anyway, but a fifo would BLOCK it, and a
+    /// CI job that hangs costs a runner for its whole timeout.
+    ///
+    /// Marks the file seen, so a caller that reads a file and then decides NOT
+    /// to charge it has still spent it.
+    pub(crate) fn take(&mut self, path: &Path) -> Option<String> {
+        if !path.is_file() {
+            return None;
+        }
+        // Canonicalize so the same file reached two ways is charged once (and
+        // so a reference cycle terminates).
+        let key = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+        if !self.seen.insert(key) {
+            return None;
+        }
+        std::fs::read_to_string(path)
+            .ok()
+            .map(|s| (self.charge.strip)(&s))
+    }
+
+    /// Charge bytes against a label already decided by the caller.
+    pub(crate) fn push(&mut self, bytes: u64, label: String) {
+        self.out.push(Contributor { bytes, label });
+    }
+
+    /// Charge `path` under `label`, then everything it references, transitively.
+    /// A file already charged, absent or non-regular is a no-op.
+    pub(crate) fn root_file(&mut self, path: &Path, label: &str) {
+        let Some(text) = self.take(path) else {
+            return;
+        };
+        self.push(text.len() as u64, label.to_string());
+        self.follow(path, &text, label, 1);
+    }
+
+    /// Charge every reference reachable from `text`, depth-first, stopping at
+    /// `max_depth` hops. A token that does not resolve to a chargeable file
+    /// contributes nothing — it is not loaded.
+    fn follow(&mut self, from: &Path, text: &str, from_label: &str, depth: usize) {
+        if depth > self.charge.max_depth {
+            return;
+        }
+        for token in (self.charge.tokens)(text) {
+            let Some(target) = (self.charge.resolve)(self.root, from, &token) else {
+                continue;
+            };
+            let Some(body) = self.take(&target) else {
+                continue;
+            };
+            let label = format!(
+                "{} ({} {from_label})",
+                display_path(self.root, &target),
+                self.charge.verb
+            );
+            self.push(body.len() as u64, label.clone());
+            self.follow(&target, &body, &label, depth + 1);
+        }
+    }
+
+    /// The contributors, largest first, so the biggest cut is the first line
+    /// read. Ties break on label for a deterministic report.
+    pub(crate) fn finish(self) -> Vec<Contributor> {
+        let mut out = self.out;
+        out.sort_by(|a, b| b.bytes.cmp(&a.bytes).then_with(|| a.label.cmp(&b.label)));
+        out
+    }
+}
+
+/// Total charged bytes.
+pub(crate) fn total(contributors: &[Contributor]) -> u64 {
+    contributors.iter().map(|c| c.bytes).sum()
+}
+
+/// The per-file breakdown lines, in the order given.
+pub(crate) fn breakdown(contributors: &[Contributor]) -> Vec<String> {
+    contributors
+        .iter()
+        .map(|c| format!("  {:>7}  {}", c.bytes, c.label))
+        .collect()
+}
+
+/// Path relative to the repo root when possible, so reports are readable and
+/// stable across checkouts.
+pub(crate) fn display_path(root: &Path, p: &Path) -> String {
+    let rooted = std::fs::canonicalize(root);
+    let target = std::fs::canonicalize(p);
+    if let (Ok(r), Ok(t)) = (rooted, target) {
+        if let Ok(rel) = t.strip_prefix(&r) {
+            return rel.display().to_string();
+        }
+    }
+    p.display().to_string()
+}
+
+/// Blank out fenced code blocks and inline code spans so a *quoted* path is not
+/// read as a reference. Offsets are not preserved — only reference scanning
+/// uses this, never the byte measurement.
+pub(crate) fn mask_code(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut fence: Option<String> = None;
+    for line in text.lines() {
+        let marker = fence_marker(line.trim_start());
+        match (&fence, &marker) {
+            // Inside a fence: a run of the same char, at least as long, closes.
+            (Some(open), Some(m)) if m.starts_with(&open[..1]) && m.len() >= open.len() => {
+                fence = None;
+            }
+            (Some(_), _) => {}
+            (None, Some(m)) => fence = Some(m.clone()),
+            (None, None) => {
+                out.push_str(&mask_spans(line));
+            }
+        }
+        out.push('\n');
+    }
+    out
+}
+
+/// The opening/closing run of a fence line (3+ backticks or tildes), if any.
+fn fence_marker(trimmed: &str) -> Option<String> {
+    let c = trimmed.chars().next()?;
+    if c != '`' && c != '~' {
+        return None;
+    }
+    let run: String = trimmed.chars().take_while(|&x| x == c).collect();
+    (run.len() >= 3).then_some(run)
+}
+
+/// Blank inline code spans within one line. An unmatched backtick run is
+/// literal, per CommonMark, so it is left alone.
+fn mask_spans(line: &str) -> String {
+    let chars: Vec<char> = line.chars().collect();
+    let mut out = String::with_capacity(line.len());
+    let mut i = 0;
+    while i < chars.len() {
+        if chars[i] != '`' {
+            out.push(chars[i]);
+            i += 1;
+            continue;
+        }
+        let open_start = i;
+        while i < chars.len() && chars[i] == '`' {
+            i += 1;
+        }
+        let n = i - open_start;
+        let mut j = i;
+        let mut close = None;
+        while j < chars.len() {
+            if chars[j] == '`' {
+                let run_start = j;
+                while j < chars.len() && chars[j] == '`' {
+                    j += 1;
+                }
+                if j - run_start == n {
+                    close = Some(j);
+                    break;
+                }
+            } else {
+                j += 1;
+            }
+        }
+        match close {
+            Some(end) => {
+                for _ in open_start..end {
+                    out.push(' ');
+                }
+                i = end;
+            }
+            None => {
+                for _ in 0..n {
+                    out.push('`');
+                }
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static N: AtomicUsize = AtomicUsize::new(0);
+
+    fn tmp_dir() -> PathBuf {
+        let d = std::env::temp_dir().join(format!(
+            "rainix-static-ctxbytes-test-{}-{}",
+            std::process::id(),
+            N.fetch_add(1, Ordering::SeqCst)
+        ));
+        std::fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    fn write(dir: &Path, rel: &str, body: &str) {
+        let p = dir.join(rel);
+        std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+        std::fs::write(p, body).unwrap();
+    }
+
+    /// A minimal caller: every whitespace-delimited token is a reference, paths
+    /// resolve against the file they were found in, nothing is stripped.
+    fn plain() -> Charge {
+        fn tokens(text: &str) -> Vec<String> {
+            mask_code(text)
+                .split_whitespace()
+                .map(str::to_string)
+                .collect()
+        }
+        fn resolve(_root: &Path, from: &Path, token: &str) -> Option<PathBuf> {
+            Some(from.parent()?.join(token))
+        }
+        Charge {
+            tokens,
+            resolve,
+            strip: |s| s.to_string(),
+            verb: "referenced by",
+            max_depth: 2,
+        }
+    }
+
+    fn walk_root(dir: &Path, rel: &str) -> Vec<Contributor> {
+        let charge = plain();
+        let mut w = Walk::new(dir, &charge);
+        w.root_file(&dir.join(rel), rel);
+        w.finish()
+    }
+
+    #[test]
+    fn references_are_charged_transitively_within_the_depth_bound() {
+        let d = tmp_dir();
+        write(&d, "root.txt", "a.txt");
+        write(&d, "a.txt", "b.txt");
+        write(&d, "b.txt", "c.txt");
+        write(&d, "c.txt", &"z".repeat(9999));
+        // depth 2: root -> a (hop 1) -> b (hop 2), and c is a hop too far.
+        assert_eq!(total(&walk_root(&d, "root.txt")), 5 + 5 + 5);
+    }
+
+    #[test]
+    fn references_resolve_against_the_file_they_are_found_in() {
+        let d = tmp_dir();
+        write(&d, "root.txt", "docs/a.txt");
+        // `b.txt` inside docs/a.txt means docs/b.txt, NOT ./b.txt
+        write(&d, "docs/a.txt", "b.txt");
+        write(&d, "docs/b.txt", &"b".repeat(500));
+        write(&d, "b.txt", &"w".repeat(9999));
+        assert_eq!(total(&walk_root(&d, "root.txt")), 10 + 5 + 500);
+    }
+
+    #[test]
+    fn a_cycle_terminates_and_each_file_is_charged_once() {
+        let d = tmp_dir();
+        write(&d, "root.txt", "a.txt");
+        write(&d, "a.txt", "root.txt a.txt");
+        assert_eq!(total(&walk_root(&d, "root.txt")), 5 + 14);
+    }
+
+    #[test]
+    fn an_unresolvable_reference_costs_nothing() {
+        let d = tmp_dir();
+        write(&d, "root.txt", "nope/gone.txt");
+        assert_eq!(total(&walk_root(&d, "root.txt")), 13);
+    }
+
+    #[test]
+    fn a_directory_is_not_a_file_and_is_not_charged() {
+        let d = tmp_dir();
+        write(&d, "root.txt", "sub");
+        std::fs::create_dir_all(d.join("sub")).unwrap();
+        assert_eq!(total(&walk_root(&d, "root.txt")), 3);
+    }
+
+    #[test]
+    fn contributors_are_largest_first_and_say_what_pulled_them_in() {
+        let d = tmp_dir();
+        write(&d, "root.txt", "a.txt");
+        write(&d, "a.txt", &"x".repeat(100));
+        let c = walk_root(&d, "root.txt");
+        assert_eq!(c[0].bytes, 100);
+        assert_eq!(c[0].label, "a.txt (referenced by root.txt)");
+        assert_eq!(c[1].label, "root.txt");
+        assert_eq!(
+            breakdown(&c),
+            vec![
+                "      100  a.txt (referenced by root.txt)".to_string(),
+                "        5  root.txt".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn strip_decides_what_is_measured() {
+        fn tokens(_: &str) -> Vec<String> {
+            Vec::new()
+        }
+        fn resolve(_: &Path, _: &Path, _: &str) -> Option<PathBuf> {
+            None
+        }
+        let d = tmp_dir();
+        write(&d, "root.txt", "keep DROP keep");
+        let charge = Charge {
+            tokens,
+            resolve,
+            strip: |s| s.replace("DROP", ""),
+            verb: "referenced by",
+            max_depth: 1,
+        };
+        let mut w = Walk::new(&d, &charge);
+        w.root_file(&d.join("root.txt"), "root.txt");
+        assert_eq!(total(&w.finish()), 10);
+    }
+
+    #[test]
+    fn take_spends_a_file_even_when_the_caller_does_not_charge_it() {
+        let d = tmp_dir();
+        write(&d, "a.txt", "body");
+        let charge = plain();
+        let mut w = Walk::new(&d, &charge);
+        assert_eq!(w.take(&d.join("a.txt")).as_deref(), Some("body"));
+        assert!(
+            w.take(&d.join("a.txt")).is_none(),
+            "a second read of the same file must not be charged twice"
+        );
+    }
+
+    #[test]
+    fn masking_hides_quoted_paths_from_the_matcher() {
+        let text = "~~~\na.md\n~~~\n``b.md``\nc.md\n";
+        let masked = mask_code(text);
+        assert!(!masked.contains("a.md"), "fenced: {masked:?}");
+        assert!(!masked.contains("b.md"), "code span: {masked:?}");
+        assert!(masked.contains("c.md"), "prose: {masked:?}");
+    }
+
+    #[test]
+    fn an_unmatched_backtick_run_is_literal() {
+        assert_eq!(mask_code("a ` b.md\n"), "a ` b.md\n");
+    }
+
+    #[test]
+    fn display_path_is_relative_to_the_root_when_it_can_be() {
+        let d = tmp_dir();
+        write(&d, "docs/a.md", "x");
+        assert_eq!(display_path(&d, &d.join("docs/a.md")), "docs/a.md");
+        let other = tmp_dir();
+        write(&other, "b.md", "x");
+        assert_eq!(
+            display_path(&d, &other.join("b.md")),
+            other.join("b.md").display().to_string(),
+            "outside the root there is nothing to relativize against"
+        );
+    }
+}

--- a/rainix-static/src/main.rs
+++ b/rainix-static/src/main.rs
@@ -23,6 +23,17 @@
 //       rules, subdirectory CLAUDE.md, CLAUDE.local.md. Prints the per-file
 //       breakdown on failure. The cap is a floor-only ratchet that may only
 //       ever be lowered. A repo with no agent context passes.
+//   prompt-cap --paths <globs> --cap <bytes> [--root <dir>]
+//       the same check as agent-context-cap, over the prompt files a repo
+//       points it at: a prompt is read whole at launch and re-read on every
+//       turn of the run, so its bytes are paid per turn. The cap is on the
+//       TOTAL over the matched glob (a per-file cap is evaded by splitting the
+//       file), and any repo file a prompt NAMES is charged with it — one hop,
+//       since telling the agent to read a file loads it, while what that file
+//       mentions is nobody's instruction.
+//       Nothing is stripped: a shell script reads the bytes on disk. Which
+//       files are prompts and what they may weigh is per-repo, so both are an
+//       input, and a glob matching nothing is an error rather than a pass.
 //   snapshots-append-only [--base <ref>] [--root <dir>]
 //       fail if the branch modifies or deletes an existing per-tag deploy-pin
 //       snapshot under <root>/<tag>/ (default root src/generated, base
@@ -43,8 +54,10 @@
 //       with hardcoded public archive defaults. Never prints a candidate URL.
 
 mod agent_context_cap;
+mod context_bytes;
 mod frozen_snapshots;
 mod no_submodules;
+mod prompt_cap;
 mod rpc_preflight;
 mod soldeer_gate;
 
@@ -114,6 +127,30 @@ fn main() {
                 std::process::exit(1);
             }
         }
+        "prompt-cap" => {
+            let root = flag(&args, "--root").unwrap_or_else(|| ".".to_string());
+            let patterns = prompt_cap::parse_patterns(
+                &flag(&args, "--paths")
+                    .unwrap_or_else(|| fail("prompt-cap: --paths <globs> required, one per line")),
+            );
+            let cap =
+                flag(&args, "--cap").unwrap_or_else(|| fail("prompt-cap: --cap <bytes> required"));
+            let cap: u64 = cap.parse().unwrap_or_else(|_| {
+                fail(&format!("prompt-cap: --cap {cap:?} is not a byte count"))
+            });
+            match prompt_cap::check(Path::new(&root), &patterns, cap) {
+                Err(e) => fail(&format!("prompt-cap: {e}")),
+                Ok((total, offenders)) if offenders.is_empty() => {
+                    println!("prompt-cap: clean — {total} bytes of prompt (cap {cap})")
+                }
+                Ok((_, offenders)) => {
+                    for line in offenders {
+                        println!("{line}");
+                    }
+                    std::process::exit(1);
+                }
+            }
+        }
         "soldeer-gate" => {
             let pkg = flag(&args, "--package")
                 .unwrap_or_else(|| fail("soldeer-gate: --package <name> required"));
@@ -159,8 +196,8 @@ fn main() {
         other => {
             eprintln!(
                 "rainix-static: unknown subcommand {other:?} \
-                 (available: no-submodules, agent-context-cap, snapshots-append-only, \
-                 soldeer-gate, rpc-preflight)"
+                 (available: no-submodules, agent-context-cap, prompt-cap, \
+                 snapshots-append-only, soldeer-gate, rpc-preflight)"
             );
             std::process::exit(2);
         }

--- a/rainix-static/src/prompt_cap.rs
+++ b/rainix-static/src/prompt_cap.rs
@@ -176,9 +176,9 @@ fn expand(
 /// span or fence — a path shown as an example is documentation, not a load.
 ///
 /// A candidate must contain `.` or `/`: prose is full of bare words, and a
-/// reference to a file all but always carries an extension or a directory. Over
-/// -matching beyond that is safe, since a token resolving to nothing costs
-/// nothing, so wrapping punctuation is trimmed rather than parsed.
+/// reference to a file all but always carries an extension or a directory.
+/// Matching too much beyond that is safe, since a token resolving to nothing
+/// costs nothing, so wrapping punctuation is trimmed rather than parsed.
 pub(crate) fn reference_tokens(text: &str) -> Vec<String> {
     context_bytes::mask_code(text)
         .split_whitespace()

--- a/rainix-static/src/prompt_cap.rs
+++ b/rainix-static/src/prompt_cap.rs
@@ -1,0 +1,613 @@
+//! `prompt-cap` — byte cap on the prompt files a repo points this at
+//! (rainlanguage/rainix#310).
+//!
+//! `agent-context-cap` caps what Claude Code loads before turn one. A runner
+//! prompt is the same tax paid harder: a shell script reads it whole, so every
+//! byte sits in the window for every turn of a run that can be hundreds of
+//! turns long, and nothing else in CI measures it — to every other check a
+//! prompt is inert data. So it is the same check, over the same traversal
+//! ([`crate::context_bytes`]), with three things different.
+//!
+//! **Roots are a glob, and the cap is on their TOTAL.** Which files are prompts
+//! is per-repo, so the caller names them; a glob rather than a list because a
+//! per-file cap is evaded by splitting the file, and because a new prompt file
+//! must be charged rather than escape by not being named.
+//!
+//! **Nothing is stripped.** A shell script reads the bytes on disk; there is no
+//! loader dropping HTML comments the way Claude Code does.
+//!
+//! **A reference is any repo file the prompt names**, not declared syntax, and
+//! it reaches ONE hop. Moving text into `docs/foo.md` and writing "read it
+//! first" puts those bytes in the window exactly as `@docs/foo.md` does, so
+//! they are charged. What `docs/foo.md` goes on to mention is not charged: an
+//! import expands transitively because the LOADER expands it, and no loader is
+//! involved here. Following further reads paths out of shell scripts, lock
+//! files and logs and bills a prompt for the whole repo, which is a number
+//! nobody can act on.
+//!
+//! Charging what a prompt names over-charges where `agent-context-cap` cannot:
+//! a path in a prompt may be an instruction to read, an example, or somewhere
+//! to WRITE. Three guards keep it honest — code spans and fences are masked, so
+//! documenting a path costs nothing; a token that resolves to no file costs
+//! nothing; and a file outside the repo (or generated at run time) is never
+//! charged. The failure message says so, because "presumed loaded" is a claim
+//! the reader must be able to check.
+//!
+//! The cap itself comes from the consuming repo, since the files and their
+//! weights are per-repo. That repo can raise it — accepted: the raise is a line
+//! in its own workflow call, in a PR diff, where a reviewer sees it. Floor-only
+//! is stated intent here, not a mechanism. `agent_context_cap::CAP_BYTES` keeps
+//! its compile-time ratchet, which works only because that number lives here.
+
+use crate::context_bytes::{self, Charge, Walk};
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+/// One hop. A prompt telling the agent to read a file is why that file is in
+/// the window; the paths THAT file happens to contain are nobody's instruction.
+/// A repo that wants a whole directory charged widens the glob, which is the
+/// honest way to say so.
+const MAX_REFERENCE_DEPTH: usize = 1;
+
+/// What a prompt costs and what it drags in: any named repo file, resolved
+/// against the naming file and then the repo root, with nothing stripped.
+fn charge() -> Charge {
+    Charge {
+        tokens: reference_tokens,
+        resolve: resolve_reference,
+        strip: |s| s.to_string(),
+        verb: "referenced by",
+        max_depth: MAX_REFERENCE_DEPTH,
+    }
+}
+
+/// Split the `--paths` value into glob patterns: one per line, or comma
+/// separated, so a YAML block scalar and a one-liner both pass through
+/// unchanged. Blank lines and `#` comments are dropped.
+pub(crate) fn parse_patterns(spec: &str) -> Vec<String> {
+    spec.split(['\n', ','])
+        .map(|p| p.trim().trim_start_matches("./").trim())
+        .filter(|p| !p.is_empty() && !p.starts_with('#'))
+        .map(str::to_string)
+        .collect()
+}
+
+/// True when `name` matches one glob segment: `*` any run of characters, `?`
+/// exactly one, everything else literal. Neither wildcard crosses a `/`, since
+/// a segment never contains one — `**` is what spans directories.
+pub(crate) fn segment_matches(pattern: &str, name: &str) -> bool {
+    let p: Vec<char> = pattern.chars().collect();
+    let n: Vec<char> = name.chars().collect();
+    let (mut i, mut j) = (0, 0);
+    // Where to resume from if the current `*` turns out to have matched too
+    // little: the classic backtracking match, linear in practice.
+    let mut star: Option<usize> = None;
+    let mut retry = 0;
+    while j < n.len() {
+        if i < p.len() && (p[i] == '?' || p[i] == n[j]) {
+            i += 1;
+            j += 1;
+        } else if i < p.len() && p[i] == '*' {
+            star = Some(i);
+            i += 1;
+            retry = j;
+        } else if let Some(s) = star {
+            i = s + 1;
+            retry += 1;
+            j = retry;
+        } else {
+            return false;
+        }
+    }
+    p[i..].iter().all(|&c| c == '*')
+}
+
+/// Files under `root` matching any pattern, as paths relative to `root`, sorted
+/// and each listed once however many patterns hit it.
+///
+/// `**` spans any number of directories (including none); a plain segment only
+/// descends where it matches, so a pattern with no `**` never walks the tree.
+/// `.git` is never entered: nothing in it is a prompt, and it is the one
+/// directory big enough for the walk to be felt.
+pub(crate) fn matching(root: &Path, patterns: &[String]) -> Vec<PathBuf> {
+    let mut out = BTreeSet::new();
+    for pattern in patterns {
+        let segments: Vec<&str> = pattern.split('/').filter(|s| !s.is_empty()).collect();
+        if segments.is_empty() {
+            continue;
+        }
+        expand(
+            root,
+            &segments,
+            Path::new(""),
+            &mut BTreeSet::new(),
+            &mut out,
+        );
+    }
+    out.into_iter().collect()
+}
+
+/// Walk `dir` for the remaining `segments`, accumulating matches as paths
+/// relative to the search root. `guard` holds the canonical directories already
+/// entered under a `**`, so a symlink loop terminates instead of hanging the
+/// job until the runner timeout.
+fn expand(
+    dir: &Path,
+    segments: &[&str],
+    rel: &Path,
+    guard: &mut BTreeSet<PathBuf>,
+    out: &mut BTreeSet<PathBuf>,
+) {
+    let Some((head, tail)) = segments.split_first() else {
+        return;
+    };
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    if *head == "**" {
+        // Zero directories consumed: the rest of the pattern may match here.
+        expand(dir, tail, rel, guard, out);
+    }
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        let path = entry.path();
+        let child_rel = rel.join(&name);
+        if path.is_dir() {
+            if name == ".git" {
+                continue;
+            }
+            let key = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+            if *head == "**" {
+                if guard.insert(key) {
+                    expand(&path, segments, &child_rel, guard, out);
+                }
+            } else if !tail.is_empty() && segment_matches(head, &name) {
+                expand(&path, tail, &child_rel, guard, out);
+            }
+            // A trailing `**` takes every file under here, by the same rule:
+            // two stars match any name.
+        } else if tail.is_empty() && segment_matches(head, &name) && path.is_file() {
+            out.insert(child_rel);
+        }
+    }
+}
+
+/// Tokens in a prompt that might name a file, ignoring anything inside a code
+/// span or fence — a path shown as an example is documentation, not a load.
+///
+/// A candidate must contain `.` or `/`: prose is full of bare words, and a
+/// reference to a file all but always carries an extension or a directory. Over
+/// -matching beyond that is safe, since a token resolving to nothing costs
+/// nothing, so wrapping punctuation is trimmed rather than parsed.
+pub(crate) fn reference_tokens(text: &str) -> Vec<String> {
+    context_bytes::mask_code(text)
+        .split_whitespace()
+        .map(|t| {
+            t.trim_matches(|c: char| {
+                matches!(
+                    c,
+                    '(' | ')'
+                        | '['
+                        | ']'
+                        | '{'
+                        | '}'
+                        | '<'
+                        | '>'
+                        | '"'
+                        | '\''
+                        | '`'
+                        | '*'
+                        | '_'
+                        | ','
+                        | ';'
+                        | ':'
+                        | '!'
+                        | '?'
+                )
+            })
+            .trim_end_matches('.')
+        })
+        .filter(|t| !t.is_empty() && t.contains(['.', '/']))
+        .map(str::to_string)
+        .collect()
+}
+
+/// The repo file a token names, or `None`. Tried against the directory of the
+/// file the token was found in, then against the repo root — a prompt names
+/// paths both ways, and the root is what a runner's working directory is.
+///
+/// Only files INSIDE the repo are charged. A path that escapes it (absolute,
+/// `..`, a symlink out) is a file this check cannot measure or ask anyone to
+/// cut, so it costs nothing here.
+pub(crate) fn resolve_reference(root: &Path, from: &Path, token: &str) -> Option<PathBuf> {
+    let bases = [from.parent()?.to_path_buf(), root.to_path_buf()];
+    let canonical_root = std::fs::canonicalize(root).ok()?;
+    bases.iter().find_map(|base| {
+        let target = std::fs::canonicalize(base.join(token)).ok()?;
+        (target.is_file() && target.starts_with(&canonical_root)).then_some(target)
+    })
+}
+
+/// Total charged bytes and the offender lines (empty when clean). A total
+/// exactly AT the cap passes — the cap is the largest permitted size, so only
+/// `>` fails. `Err` when the caller has named nothing measurable.
+pub(crate) fn check(
+    root: &Path,
+    patterns: &[String],
+    cap: u64,
+) -> Result<(u64, Vec<String>), String> {
+    if patterns.is_empty() {
+        return Err("--paths named no globs — point this at the repo's prompt files".to_string());
+    }
+    let files = matching(root, patterns);
+    if files.is_empty() {
+        return Err(format!(
+            "no file matched {} — fix the globs or drop the step; as written it caps nothing",
+            patterns.join(" ")
+        ));
+    }
+
+    let charge = charge();
+    let mut walk = Walk::new(root, &charge);
+    for rel in &files {
+        walk.root_file(&root.join(rel), &rel.display().to_string());
+    }
+    let contributors = walk.finish();
+    let total = context_bytes::total(&contributors);
+    if total <= cap {
+        return Ok((total, Vec::new()));
+    }
+
+    let over = total - cap;
+    let mut lines = vec![format!(
+        "ERROR: the prompt files matching {} load {total} bytes — {over} over the {cap}-byte cap. \
+         A prompt is read whole at launch and re-read on every turn of the run, so a byte here is \
+         paid once per turn, by every run. Cut {over} bytes:",
+        patterns.join(" ")
+    )];
+    lines.extend(context_bytes::breakdown(&contributors));
+    lines.push(
+        "Any repo file the prompt NAMES is charged with it, because telling the agent to read a \
+         file puts that file in the window as surely as pasting it in — one hop only, so what \
+         that file goes on to mention is free. A path inside a code span or fence is not charged, \
+         nor is one that resolves to no file, nor one outside the repo or written at run time — \
+         so a reference that is documentation, an example, or an output path costs nothing. Cut \
+         by asking what the run would get WRONG without each line. \
+         Lowering the cap where the workflow sets it is the ratchet; raising it is a line in a \
+         PR diff. See rainlanguage/rainix#310."
+            .to_string(),
+    );
+    Ok((total, lines))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static N: AtomicUsize = AtomicUsize::new(0);
+
+    fn tmp_dir() -> PathBuf {
+        let d = std::env::temp_dir().join(format!(
+            "rainix-static-promptcap-test-{}-{}",
+            std::process::id(),
+            N.fetch_add(1, Ordering::SeqCst)
+        ));
+        std::fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    fn write(dir: &Path, rel: &str, body: &str) {
+        let p = dir.join(rel);
+        std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+        std::fs::write(p, body).unwrap();
+    }
+
+    fn globs(list: &[&str]) -> Vec<String> {
+        list.iter().map(|s| s.to_string()).collect()
+    }
+
+    /// Cap of 0 so any charge fails: what is charged is the question, not what
+    /// the number is.
+    fn total(dir: &Path, patterns: &[&str]) -> u64 {
+        check(dir, &globs(patterns), 0).unwrap().0
+    }
+
+    fn matched(dir: &Path, patterns: &[&str]) -> Vec<String> {
+        matching(dir, &globs(patterns))
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect()
+    }
+
+    // ---- globs -----------------------------------------------------------
+
+    #[test]
+    fn patterns_parse_from_lines_and_commas() {
+        assert_eq!(
+            parse_patterns("*.txt\nprompts/*.md"),
+            globs(&["*.txt", "prompts/*.md"])
+        );
+        assert_eq!(parse_patterns("*.txt, *.md"), globs(&["*.txt", "*.md"]));
+        assert_eq!(
+            parse_patterns("  ./*.txt \n\n# a comment\n"),
+            globs(&["*.txt"])
+        );
+        assert!(parse_patterns("\n#nothing\n").is_empty());
+    }
+
+    #[test]
+    fn segment_wildcards() {
+        assert!(segment_matches("*", "anything"));
+        assert!(segment_matches("*prompt*.txt", "campaign-prompt.txt"));
+        assert!(segment_matches("?.md", "a.md"));
+        assert!(segment_matches("a*b*c", "azzbzzc"));
+        assert!(segment_matches("prompt.txt", "prompt.txt"));
+        assert!(!segment_matches("?.md", "ab.md"));
+        assert!(!segment_matches("*.txt", "a.txtx"));
+        assert!(!segment_matches("a*b*c", "azzbzz"));
+        assert!(!segment_matches("prompt.txt", "Prompt.txt"), "case matters");
+    }
+
+    #[test]
+    fn a_glob_matches_files_not_directories() {
+        let d = tmp_dir();
+        write(&d, "a-prompt.txt", "x");
+        std::fs::create_dir_all(d.join("b-prompt.txt")).unwrap();
+        assert_eq!(matched(&d, &["*prompt*"]), vec!["a-prompt.txt"]);
+    }
+
+    #[test]
+    fn a_star_does_not_cross_a_directory_boundary() {
+        let d = tmp_dir();
+        write(&d, "a.txt", "x");
+        write(&d, "sub/b.txt", "x");
+        assert_eq!(matched(&d, &["*.txt"]), vec!["a.txt"]);
+        assert_eq!(matched(&d, &["sub/*.txt"]), vec!["sub/b.txt"]);
+    }
+
+    #[test]
+    fn double_star_spans_any_depth_including_none() {
+        let d = tmp_dir();
+        write(&d, "a.txt", "x");
+        write(&d, "one/b.txt", "x");
+        write(&d, "one/two/c.txt", "x");
+        assert_eq!(
+            matched(&d, &["**/*.txt"]),
+            vec!["a.txt", "one/b.txt", "one/two/c.txt"]
+        );
+    }
+
+    #[test]
+    fn a_trailing_double_star_takes_every_file_under_it() {
+        let d = tmp_dir();
+        write(&d, "prompts/a.txt", "x");
+        write(&d, "prompts/deep/b.md", "x");
+        write(&d, "elsewhere.txt", "x");
+        assert_eq!(
+            matched(&d, &["prompts/**"]),
+            vec!["prompts/a.txt", "prompts/deep/b.md"]
+        );
+    }
+
+    #[test]
+    fn a_file_matched_by_two_patterns_is_listed_once() {
+        let d = tmp_dir();
+        write(&d, "a.txt", "x");
+        assert_eq!(matched(&d, &["*.txt", "a.*", "**/*.txt"]), vec!["a.txt"]);
+    }
+
+    #[test]
+    fn the_git_directory_is_never_walked() {
+        let d = tmp_dir();
+        write(&d, ".git/objects/pack.txt", "x");
+        write(&d, "a.txt", "x");
+        assert_eq!(matched(&d, &["**/*.txt"]), vec!["a.txt"]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_symlinked_directory_cycle_terminates() {
+        let d = tmp_dir();
+        write(&d, "deep/a.txt", "x");
+        std::os::unix::fs::symlink(d.join("deep"), d.join("deep/self")).unwrap();
+        assert_eq!(matched(&d, &["**/*.txt"]), vec!["deep/a.txt"]);
+    }
+
+    // ---- what is charged --------------------------------------------------
+
+    #[test]
+    fn every_matched_file_is_charged_so_splitting_one_prompt_changes_nothing() {
+        let d = tmp_dir();
+        write(&d, "one-prompt.txt", &"x".repeat(300));
+        assert_eq!(total(&d, &["*prompt*.txt"]), 300);
+        // the same text, split three ways, still costs 300
+        std::fs::remove_file(d.join("one-prompt.txt")).unwrap();
+        write(&d, "a-prompt.txt", &"x".repeat(100));
+        write(&d, "b-prompt.txt", &"x".repeat(100));
+        write(&d, "c-prompt.txt", &"x".repeat(100));
+        assert_eq!(total(&d, &["*prompt*.txt"]), 300);
+    }
+
+    #[test]
+    fn a_file_the_prompt_names_is_charged_but_not_what_that_file_mentions() {
+        let d = tmp_dir();
+        write(&d, "prompt.txt", "First read docs/style.md then work.\n");
+        write(
+            &d,
+            "docs/style.md",
+            &format!("Also read deep.md\n{}", "s".repeat(1000)),
+        );
+        // Charging deep.md would bill the prompt for a path nobody instructed
+        // anyone to read — that route ends at a lock file or a log.
+        write(&d, "docs/deep.md", &"d".repeat(500));
+        let body = std::fs::metadata(d.join("prompt.txt")).unwrap().len();
+        assert_eq!(total(&d, &["prompt.txt"]), body + 1018);
+    }
+
+    #[test]
+    fn a_reference_resolves_against_the_repo_root_too() {
+        let d = tmp_dir();
+        // `style.md` names the root file, not one beside the prompt.
+        write(&d, "prompts/p.txt", "Read style.md\n");
+        write(&d, "style.md", &"s".repeat(400));
+        assert_eq!(total(&d, &["prompts/*.txt"]), 14 + 400);
+    }
+
+    #[test]
+    fn a_quoted_path_is_documentation_and_costs_nothing() {
+        let d = tmp_dir();
+        let body = "Write results to `out.md`.\n\n```\nout.md\n```\n";
+        write(&d, "prompt.txt", body);
+        write(&d, "out.md", &"o".repeat(9999));
+        assert_eq!(total(&d, &["prompt.txt"]), body.len() as u64);
+    }
+
+    #[test]
+    fn a_bare_word_is_prose_even_when_a_file_shares_its_name() {
+        let d = tmp_dir();
+        let body = "Keep notes as you go\n";
+        write(&d, "prompt.txt", body);
+        write(&d, "notes", &"n".repeat(9999));
+        assert_eq!(total(&d, &["prompt.txt"]), body.len() as u64);
+    }
+
+    #[test]
+    fn a_path_that_resolves_to_nothing_costs_nothing() {
+        let d = tmp_dir();
+        let body = "Read docs/missing.md and {{WORK_DIR}}/notes.md\n";
+        write(&d, "prompt.txt", body);
+        assert_eq!(total(&d, &["prompt.txt"]), body.len() as u64);
+    }
+
+    #[test]
+    fn a_file_outside_the_repo_is_not_charged() {
+        let d = tmp_dir();
+        let other = tmp_dir();
+        write(&other, "outside.md", &"o".repeat(9999));
+        let body = format!(
+            "Read {} and ../{}/outside.md\n",
+            other.join("outside.md").display(),
+            other.file_name().unwrap().to_string_lossy()
+        );
+        write(&d, "prompt.txt", &body);
+        assert_eq!(total(&d, &["prompt.txt"]), body.len() as u64);
+    }
+
+    #[test]
+    fn a_directory_named_by_a_prompt_is_not_charged() {
+        let d = tmp_dir();
+        let body = "Work in docs/ then stop\n";
+        write(&d, "prompt.txt", body);
+        write(&d, "docs/a.md", &"a".repeat(9999));
+        assert_eq!(total(&d, &["prompt.txt"]), body.len() as u64);
+    }
+
+    #[test]
+    fn a_file_referenced_by_two_prompts_is_charged_once() {
+        let d = tmp_dir();
+        write(&d, "a-prompt.txt", "read shared.md\n");
+        write(&d, "b-prompt.txt", "read shared.md\n");
+        write(&d, "shared.md", &"s".repeat(1000));
+        assert_eq!(total(&d, &["*prompt*.txt"]), 15 + 15 + 1000);
+    }
+
+    #[test]
+    fn a_prompt_that_names_itself_is_charged_once() {
+        let d = tmp_dir();
+        write(&d, "prompt.txt", "see prompt.txt above\n");
+        assert_eq!(total(&d, &["prompt.txt"]), 21);
+    }
+
+    #[test]
+    fn a_chain_of_references_is_charged_one_hop_deep() {
+        let d = tmp_dir();
+        write(&d, "prompt.txt", "read l1.md\n");
+        for i in 1..=4 {
+            write(&d, &format!("l{i}.md"), &format!("read l{}.md\n", i + 1));
+        }
+        write(&d, "l5.md", &"z".repeat(9999));
+        assert_eq!(total(&d, &["prompt.txt"]), 11 + 11);
+    }
+
+    #[test]
+    fn nothing_is_stripped_from_a_prompt() {
+        let d = tmp_dir();
+        // No loader drops these bytes: a shell script reads the file whole.
+        let body = "<!--\nnote to self\n-->\nkeep\n";
+        write(&d, "prompt.txt", body);
+        assert_eq!(total(&d, &["prompt.txt"]), body.len() as u64);
+    }
+
+    #[test]
+    fn size_is_bytes_not_chars() {
+        let d = tmp_dir();
+        let body = "€".repeat(100);
+        write(&d, "prompt.txt", &body);
+        assert_eq!(total(&d, &["prompt.txt"]), 300);
+    }
+
+    // ---- the cap ----------------------------------------------------------
+
+    #[test]
+    fn under_and_exactly_at_cap_pass_and_one_byte_over_fails() {
+        let d = tmp_dir();
+        write(&d, "prompt.txt", &"x".repeat(100));
+        assert!(check(&d, &globs(&["prompt.txt"]), 101)
+            .unwrap()
+            .1
+            .is_empty());
+        assert!(check(&d, &globs(&["prompt.txt"]), 100)
+            .unwrap()
+            .1
+            .is_empty());
+        assert!(!check(&d, &globs(&["prompt.txt"]), 99).unwrap().1.is_empty());
+    }
+
+    #[test]
+    fn failure_names_total_cap_overage_and_every_contributor_largest_first() {
+        let d = tmp_dir();
+        write(&d, "prompt.txt", "read big.md\n");
+        write(&d, "big.md", &"b".repeat(2000));
+        let (total, off) = check(&d, &globs(&["prompt.txt"]), 500).unwrap();
+        assert_eq!(total, 12 + 2000);
+        let joined = off.join("\n");
+        assert!(joined.contains("2012 bytes"), "{joined}");
+        assert!(joined.contains("500-byte cap"), "{joined}");
+        assert!(joined.contains("1512 over"), "{joined}");
+        assert!(
+            joined.contains("big.md (referenced by prompt.txt)"),
+            "{joined}"
+        );
+        let big_at = joined.find("  2000  big.md").unwrap();
+        let prompt_at = joined.find("  12  prompt.txt").unwrap();
+        assert!(big_at < prompt_at, "largest first: {joined}");
+    }
+
+    #[test]
+    fn the_failure_states_what_a_named_path_costs_and_what_it_does_not() {
+        let d = tmp_dir();
+        write(&d, "prompt.txt", "x");
+        let off = check(&d, &globs(&["prompt.txt"]), 0).unwrap().1;
+        let joined = off.join("\n");
+        assert!(joined.contains("NAMES"), "{joined}");
+        assert!(joined.contains("code span"), "{joined}");
+        assert!(joined.contains("outside the repo"), "{joined}");
+    }
+
+    #[test]
+    fn a_glob_matching_nothing_is_an_error_not_a_pass() {
+        let d = tmp_dir();
+        write(&d, "prompt.txt", "x");
+        let e = check(&d, &globs(&["prompts/*.txt"]), 10).unwrap_err();
+        assert!(e.contains("no file matched"), "{e}");
+        assert!(e.contains("prompts/*.txt"), "{e}");
+    }
+
+    #[test]
+    fn no_globs_at_all_is_an_error_not_a_pass() {
+        let d = tmp_dir();
+        let e = check(&d, &[], 10).unwrap_err();
+        assert!(e.contains("named no globs"), "{e}");
+    }
+}

--- a/test/bats/action/prompt-cap.test.bats
+++ b/test/bats/action/prompt-cap.test.bats
@@ -1,0 +1,93 @@
+setup() {
+  repo_root="$BATS_TEST_DIRNAME/../../.."
+  action="$repo_root/.github/actions/prompt-cap/action.yml"
+  action_script="$(yq -r '.runs.steps[0].run' "$action")"
+  work="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$work"
+}
+
+# The action script with `nix` stubbed to echo its argv, so what reaches the
+# binary is asserted without building it.
+run_cap_action() {
+  RAINIX_PROMPT_PATHS="$1" \
+    RAINIX_PROMPT_CAP="$2" \
+    GITHUB_ACTION_PATH="$repo_root/.github/actions/prompt-cap" \
+    ACTION_SCRIPT="$action_script" \
+    bash -c '
+      nix() {
+        printf "nix"
+        printf " <%s>" "$@"
+        printf "\n"
+      }
+      export -f nix
+      bash -c "$ACTION_SCRIPT"
+    '
+}
+
+@test "the inputs reach the binary as one argument each" {
+  run run_cap_action '*prompt*.txt' 60000
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"<prompt-cap> <--paths> <*prompt*.txt> <--cap> <60000>" ]]
+}
+
+@test "a glob is passed through unexpanded rather than matched by the shell" {
+  cd "$work"
+  touch a-prompt.txt b-prompt.txt
+
+  run run_cap_action '*prompt*.txt' 60000
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"<--paths> <*prompt*.txt>"* ]]
+  [[ "$output" != *"a-prompt.txt"* ]]
+}
+
+@test "a multi-line paths input stays one argument" {
+  run run_cap_action 'a.txt
+prompts/**' 10
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"<--paths> <a.txt"$'\n'"prompts/**>"* ]]
+}
+
+# The binary itself, as CI invokes it: rainix-static is on PATH in every shell.
+
+@test "prompt files within cap exit 0" {
+  printf 'xxxxx' >"$work/a-prompt.txt"
+
+  run rainix-static prompt-cap --root "$work" --paths '*prompt*' --cap 10
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"clean — 5 bytes"* ]]
+}
+
+@test "prompt files over cap exit 1, largest first, with the total and overage" {
+  printf 'read notes.md\n' >"$work/a-prompt.txt"
+  head -c 100 /dev/zero | tr '\0' 'n' >"$work/notes.md"
+
+  run rainix-static prompt-cap --root "$work" --paths '*prompt*' --cap 10
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"114 bytes"* ]]
+  [[ "$output" == *"104 over"* ]]
+  [[ "$output" == *"notes.md (referenced by a-prompt.txt)"* ]]
+}
+
+@test "a glob matching nothing exits 1 rather than passing" {
+  run rainix-static prompt-cap --root "$work" --paths 'nope/*.txt' --cap 10
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"no file matched"* ]]
+}
+
+@test "a missing cap exits 1 rather than defaulting to one" {
+  printf 'x' >"$work/a-prompt.txt"
+
+  run rainix-static prompt-cap --root "$work" --paths '*prompt*'
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"--cap"* ]]
+}


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rainix/issues/310

`prompt-cap`: the `agent-context-cap` check, generalised so a repo can point it at its prompt files. One traversal, two callers, each with its own cap.

- `rainix-static/src/context_bytes.rs` (new) — the shared engine: read a root, charge it as the loader sees it, resolve its references against the file they were found in, charge those, stop at a depth bound, never charge one file twice. Holds no cap.
- `rainix-static/src/agent_context_cap.rs` — refactored onto it. `CAP_BYTES` and its `const _: () = assert!` are untouched, and all of #299's tests are unchanged and green.
- `rainix-static/src/prompt_cap.rs` (new) — roots from globs, cap on their total, nothing stripped, any repo file a prompt names charged with it.
- `.github/actions/prompt-cap/action.yml` — composite action, opt-in, not wired into the shared static jobs.
- `test/bats/action/prompt-cap.test.bats` + its line in `default-shell-test`.

## Where the seam falls

The issue said "generalise `collect`". Having read it, the seam is one level lower, and the difference matters.

`collect` is not the algorithm — it is twelve lines of policy (which roots; then the `.claude/rules` scan). The reusable part is what it calls: `read_loaded` + `expand_imports`, plus the masking, `display_path`, and the breakdown rows. Parameterising `collect` itself would mean passing the rules block in as a callback that reads a file, inspects its text, decides not to charge it, and still marks it seen — that is the body, not a parameter.

So `context_bytes` owns the traversal (`Walk::take` / `push` / `root_file` / `finish`) and a `Charge` describing what differs. Each check keeps its own small `collect`.

Two things belong in `Charge` that the issue's parameter list did not name:

- **Resolution, not just matching.** `@~/x.md` and absolute imports legitimately leave the repo, and `agent-context-cap` charges them. For a prompt, a file outside the repo is explicitly uncharged. Same matcher shape, different resolver.
- **The depth bound.** `MAX_IMPORT_DEPTH = 4` is Claude Code's limit — there is a test asserting exactly that — so it is that caller's number, not the engine's.

The cap is exactly where the issue put it: `context_bytes` has none, `CAP_BYTES` keeps its compile-time ratchet, `prompt-cap` takes its number from the consuming repo.

Evidence the generalisation is real and not a fork: mutating the shared traversal reddens tests in **both** callers — the depth bound kills 3 tests across all three modules, the visited-set kills 5.

## One hop, not transitive — found by running it

The issue asked for transitive reference following. Built that way first, then ran it over `issue-pr-cron`:

```
ERROR: the prompt files matching *prompt*.txt load 4962436 bytes — 4902436 over the 60000-byte cap.
  3573196  pr-review-report-rs/src/main.rs (referenced by campaign.log (referenced by campaign-run.sh (referenced by flake.nix (referenced by campaign-prompt.txt))))
   252401  human-queue.json (referenced by backfill-human-queue-history.sh (referenced by flake.nix (referenced by campaign-prompt.txt)))
   244002  README.md (referenced by campaign.log (...))
```

4.96 MB charged against 149 KB of actual prompt: `campaign-prompt.txt` names `flake.nix`, which names `campaign-run.sh`, which names `campaign.log`, and a log file names half the repo.

An `@path` import expands transitively because the LOADER expands it — a mechanical fact. A prompt has no loader. "The prompt tells the agent to read X, so X is in the window" is true at hop 1 and false at hop 2: what a shell script, a lock file or a log happens to mention is nobody's instruction. So `MAX_REFERENCE_DEPTH = 1`.

Both anti-evasion cases the issue names still hold: splitting one prompt into three is defeated by the **glob** (all three match), and "moved the text into `docs/foo.md` and said read it" is caught at hop 1. A repo that wants a whole directory charged widens its glob, which is the honest way to say so.

Same run, one hop:

```
ERROR: the prompt files matching *prompt*.txt load 170610 bytes — 110610 over the 60000-byte cap.
    95487  campaign-prompt.txt
    45526  review-prompt.txt
    13721  flake.nix (referenced by campaign-prompt.txt)
     6213  QA-GUIDE.md (referenced by campaign-prompt.txt)
     4089  campaign-worker-prompt.txt
     4075  review-auditor-prompt.txt
     1499  flake.lock (referenced by campaign-prompt.txt)
```

170,610 bytes against 149,177 of actual prompt: the 21 KB difference is three files `campaign-prompt.txt` names by hand. That is a number a human can act on. 4.96 MB was not.

## Composite action, not a reusable workflow

- In this repo the two shapes already mean different things: a composite is one check (`no-submodules`, `agent-context-cap`, `frozen-snapshots-append-only`, `no-custom-natspec`), a reusable workflow is a whole pipeline for a repo type (`rainix-rs-static`, `rainix-sol-static`). This is one check.
- A reusable workflow is always a separate job — its own runner, its own nix install, its own Cachix warm — to stat a few files. `rainix-rs-static` folds `pre-commit` in as a step and not a job for exactly this reason ("to reuse this job's warm Nix store rather than re-paying runner setup").
- Composability runs one way only: a workflow can call a composite, a composite cannot call a workflow. Picking the workflow shape would forbid ever folding this into an existing job.
- The nix+cachix preamble a workflow would need takes `secrets: inherit`, for a check that needs no secrets.
- Per-repo inputs work identically in both, so the inputs do not decide it.

The honest cost: a composite needs the calling job to already have checkout + nix. A repo with no such job pays a preamble either way, and unlike a workflow it can drop the step into a job it already runs.

## Usage

```yaml
- uses: rainlanguage/rainix/.github/actions/prompt-cap@main
  with:
    paths: |
      *prompt*.txt
    cap: 60000
```

## Known limits, stated rather than discovered

- Charging is presumption, not observation: any repo file a prompt names is charged, whether the run reads it, ignores it, or writes to it.
- Masking means a prompt that puts its paths in backticks pays nothing for them. Same escape hatch #299 accepted for `@path`, and it is what keeps documenting a path free.
- `.claude/rules/**` are still charged as leaves, as #299 measured them. Following `@path` out of a rule would raise every repo's total — a cap change, not a refactor, so it is not in this PR.
- `**` walks the tree. `.git` is skipped; nothing else is.
- Untracked files match a glob. In CI the checkout is clean, so this only shows up locally.

## Unrelated defect this PR ran into

`default-shell-test` reports green while bats tests inside it fail. `mkTask`'s body has no `set -e`, so the task exits with the status of the LAST `bats` line and every earlier file's failures are swallowed. On `main` at 3b296eb (job 95122027476) three `prettier-bundle` tests are `not ok` and the job is green; the same three are `not ok` on this branch. Not caused by this PR and not fixed in it — adding `set -e` would redden CI on an unrelated failure — but it does mean the new bats file's CI signal is weaker than its local one, so its 7 tests were also run directly (`nix develop .# -c bats test/bats/action/prompt-cap.test.bats`, 7/7 ok) and appear as `ok 1..7` in this branch's job log.

## QA

- Discriminating tests: 29 new (`prompt_cap` 26, `context_bytes` 11 — 108 total, all green). None can pass on base: base has no `context_bytes` and no `prompt_cap`, and `rainix-static prompt-cap` on base exits 2 "unknown subcommand" (verified on a stashed tree). The refactor's oracle is the opposite — every `agent_context_cap` test is byte-identical to base and still passes, which is what "behaviour-preserving" has to mean.
- Mutations applied: 17 applied, 17 killed, one equivalent mutant found and removed from the source. `context_bytes.rs`: depth bound `> max_depth` → `> max_depth + 1` → 3 tests across all three modules; visited-set `if !seen.insert(key)` → `if false` → 5 tests; `sort_by` largest-first → smallest-first → 3 tests. `prompt_cap.rs`: `starts_with(canonical_root)` dropped → `a_file_outside_the_repo_is_not_charged`; `total <= cap` → `<= cap + 1` → `under_and_exactly_at_cap_pass_and_one_byte_over_fails`; `.git` skip → `if false` → `the_git_directory_is_never_walked`; `guard.insert(key)` → `true` → `a_symlinked_directory_cycle_terminates`; token filter `contains(['.','/'])` dropped → `a_bare_word_is_prose_even_when_a_file_shares_its_name`; `mask_code(text)` → `text` → `a_quoted_path_is_documentation_and_costs_nothing`; `strip` identity → `trim` → `nothing_is_stripped_from_a_prompt`; root fallback base dropped → `a_reference_resolves_against_the_repo_root_too`; `files.is_empty()` → `false` → `a_glob_matching_nothing_is_an_error_not_a_pass`; `'?'` arm dropped → `segment_wildcards`; `**` recursion `segments` → `tail` → `double_star_spans_any_depth_including_none` + `a_trailing_double_star_takes_every_file_under_it`; `**` zero-consume `tail` → `segments` → same pair. `agent_context_cap.rs`: `strip: strip_block_html_comments` → identity → `block_html_comments_are_stripped_because_they_never_load`. The equivalent mutant: a redundant `*head == "**" ||` in the file-match arm survived because `segment_matches("**", name)` is already always true — the clause was deleted rather than pinned.
- Oracle: byte counts are written by the test (`"x".repeat(n)`) and asserted as literal sums, never recomputed with the code under test. Glob semantics come from POSIX/gitignore convention, not from the matcher. The refactor's oracle is #299's unchanged suite. The one-hop decision's oracle is a real run over `issue-pr-cron`, quoted above.
- Category check: issue asks (a) generalise rather than copy — done, with the seam named and the divergence argued; (b) cap NOT shared — `CAP_BYTES` and its assert untouched, `context_bytes` holds none; (c) charge the total over a glob — done; (d) follow path references out of the prompt — done at one hop, with the transitive version built, measured and rejected on evidence; (e) shape decided and stated — composite, argued above; (f) failure output largest-first with total, cap and overage — done. Divergence from the issue on (d) is deliberate and argued; everything else is as asked.
