### PR TITLE
Give explorer verification a 10 minute window instead of 25 seconds

### DIFF
--- a/.github/workflows/rainix-manual-sol-artifacts.yaml
+++ b/.github/workflows/rainix-manual-sol-artifacts.yaml
@@ -133,7 +133,21 @@ jobs:
           RAINIX_RPC_VARS_HYPEREVM: ${{ vars.RPC_URL_HYPEREVM_FORK }}
           RAINIX_RPC_SECRET_POLYGON: ${{ secrets.RPC_URL_POLYGON_FORK }}
           RAINIX_RPC_VARS_POLYGON: ${{ vars.RPC_URL_POLYGON_FORK }}
-      - run: nix develop github:rainlanguage/rainix/${{ env.RAINIX_SHA }}#sol-shell -c forge script ${{ inputs.script }} -vvvvv --slow --broadcast ${{ inputs.verify && '--verify' || '' }} ${{ inputs.legacy && '--legacy' || '' }}
+      # Verification races the explorer's indexer. The submission goes out
+      # seconds after the broadcast, and an explorer that has not indexed the
+      # address yet answers `Unable to locate ContractCode`, which foundry
+      # retries — so the retry window IS the tolerance for indexing lag. The
+      # default 5/5 is 6 attempts over 25 seconds, which a cold explorer on a
+      # chain this deployer has never touched does not fit inside. 40/15 is 41
+      # attempts over 10 minutes. Only a failed attempt sleeps, so an explorer
+      # that answers first time costs nothing, and what is retried at all is
+      # narrow: the no-code-at-this-address answers, and an HTTP call that did
+      # not come back. Any other error an explorer returns — a bad key, a
+      # rejected source — still fails the run on the first response, unwaited.
+      # The `--watch` status poll that
+      # follows a successful submission is hard-coded in foundry (8 tries, 15
+      # seconds apart) and these flags do not reach it.
+      - run: nix develop github:rainlanguage/rainix/${{ env.RAINIX_SHA }}#sol-shell -c forge script ${{ inputs.script }} -vvvvv --slow --broadcast ${{ inputs.verify && '--verify --retries 40 --delay 15' || '' }} ${{ inputs.legacy && '--legacy' || '' }}
         # <NETWORK>_RPC_URL is bound by the rpc-preflight step above, which picks
         # a candidate that is reachable right now rather than binding one URL
         # that may be dead.

--- a/.github/workflows/rainix-manual-sol-artifacts.yaml
+++ b/.github/workflows/rainix-manual-sol-artifacts.yaml
@@ -133,20 +133,9 @@ jobs:
           RAINIX_RPC_VARS_HYPEREVM: ${{ vars.RPC_URL_HYPEREVM_FORK }}
           RAINIX_RPC_SECRET_POLYGON: ${{ secrets.RPC_URL_POLYGON_FORK }}
           RAINIX_RPC_VARS_POLYGON: ${{ vars.RPC_URL_POLYGON_FORK }}
-      # Verification races the explorer's indexer. The submission goes out
-      # seconds after the broadcast, and an explorer that has not indexed the
-      # address yet answers `Unable to locate ContractCode`, which foundry
-      # retries — so the retry window IS the tolerance for indexing lag. The
-      # default 5/5 is 6 attempts over 25 seconds, which a cold explorer on a
-      # chain this deployer has never touched does not fit inside. 40/15 is 41
-      # attempts over 10 minutes. Only a failed attempt sleeps, so an explorer
-      # that answers first time costs nothing, and what is retried at all is
-      # narrow: the no-code-at-this-address answers, and an HTTP call that did
-      # not come back. Any other error an explorer returns — a bad key, a
-      # rejected source — still fails the run on the first response, unwaited.
-      # The `--watch` status poll that
-      # follows a successful submission is hard-coded in foundry (8 tries, 15
-      # seconds apart) and these flags do not reach it.
+      # 41 submission attempts over 10 minutes, against foundry's default 6 over
+      # 25s, which a cold explorer does not fit inside. Only a failed attempt
+      # sleeps, and only the no-code and no-answer cases retry at all.
       - run: nix develop github:rainlanguage/rainix/${{ env.RAINIX_SHA }}#sol-shell -c forge script ${{ inputs.script }} -vvvvv --slow --broadcast ${{ inputs.verify && '--verify --retries 40 --delay 15' || '' }} ${{ inputs.legacy && '--legacy' || '' }}
         # <NETWORK>_RPC_URL is bound by the rpc-preflight step above, which picks
         # a candidate that is reachable right now rather than binding one URL

--- a/.github/workflows/rainix-manual-sol-verify.yaml
+++ b/.github/workflows/rainix-manual-sol-verify.yaml
@@ -101,6 +101,21 @@ jobs:
       # submissions across a network list burn through it and come back
       # `Max calls per sec rate limit reached`, which reads as a verification
       # failure for a contract the explorer never actually rejected.
+      #
+      # `--retries 40 --delay 15` is 41 submission attempts over 10 minutes per
+      # network, against foundry's default 5/5 — 6 attempts over 25 seconds.
+      # This is the repair path for a deploy whose verification lost the race
+      # with the explorer's indexer, so it is dispatched at exactly the moment
+      # the explorer is coldest, and a window shorter than the lag reproduces
+      # the failure it exists to fix. Only a failed attempt sleeps, so a
+      # network whose explorer answers first time costs nothing, and the window
+      # is only ever spent where the explorer keeps saying the address holds no
+      # code or keeps failing to answer at all — a bad key or a rejected source
+      # still fails that network on the first response. The no-code answer is
+      # also what a mistyped `address` looks like, and every attempt logs it, so
+      # such a run says why long before it exits. Worst case is the whole list
+      # stuck that way: 10 minutes each, 70 for the seven-network default,
+      # inside the 6 hour job ceiling.
       - name: Verify
         run: |
           # `required: true` only says a value was passed, not that it says
@@ -125,7 +140,7 @@ jobs:
           do
             echo "::group::$VERIFY_CONTRACT on $network"
             nix develop github:rainlanguage/rainix/${{ env.RAINIX_SHA }}#sol-shell -c \
-              forge verify-contract --chain "$network" "$VERIFY_ADDRESS" "$VERIFY_CONTRACT" --watch \
+              forge verify-contract --chain "$network" "$VERIFY_ADDRESS" "$VERIFY_CONTRACT" --watch --retries 40 --delay 15 \
               || failed="$failed $network"
             echo '::endgroup::'
             sleep 15

--- a/.github/workflows/rainix-manual-sol-verify.yaml
+++ b/.github/workflows/rainix-manual-sol-verify.yaml
@@ -113,9 +113,13 @@ jobs:
       # code or keeps failing to answer at all — a bad key or a rejected source
       # still fails that network on the first response. The no-code answer is
       # also what a mistyped `address` looks like, and every attempt logs it, so
-      # such a run says why long before it exits. Worst case is the whole list
-      # stuck that way: 10 minutes each, 70 for the seven-network default,
-      # inside the 6 hour job ceiling.
+      # such a run says why long before it exits. The 10 minutes is submission
+      # retries alone. A network also carries the 15 second pacing sleep below,
+      # and up to 2 more minutes of `--watch` polling — foundry's own hard-coded
+      # 8 checks at 15 seconds — wherever a submission does land, on the last
+      # attempt, and then never leaves the explorer's queue. Every network stuck
+      # in the worst of that is 85 minutes 45 seconds for the seven-network
+      # default, inside the 6 hour job ceiling.
       - name: Verify
         run: |
           # `required: true` only says a value was passed, not that it says

--- a/.github/workflows/rainix-manual-sol-verify.yaml
+++ b/.github/workflows/rainix-manual-sol-verify.yaml
@@ -103,23 +103,9 @@ jobs:
       # failure for a contract the explorer never actually rejected.
       #
       # `--retries 40 --delay 15` is 41 submission attempts over 10 minutes per
-      # network, against foundry's default 5/5 — 6 attempts over 25 seconds.
-      # This is the repair path for a deploy whose verification lost the race
-      # with the explorer's indexer, so it is dispatched at exactly the moment
-      # the explorer is coldest, and a window shorter than the lag reproduces
-      # the failure it exists to fix. Only a failed attempt sleeps, so a
-      # network whose explorer answers first time costs nothing, and the window
-      # is only ever spent where the explorer keeps saying the address holds no
-      # code or keeps failing to answer at all — a bad key or a rejected source
-      # still fails that network on the first response. The no-code answer is
-      # also what a mistyped `address` looks like, and every attempt logs it, so
-      # such a run says why long before it exits. The 10 minutes is submission
-      # retries alone. A network also carries the 15 second pacing sleep below,
-      # and up to 2 more minutes of `--watch` polling — foundry's own hard-coded
-      # 8 checks at 15 seconds — wherever a submission does land, on the last
-      # attempt, and then never leaves the explorer's queue. Every network stuck
-      # in the worst of that is 85 minutes 45 seconds for the seven-network
-      # default, inside the 6 hour job ceiling.
+      # network, against foundry's default 6 over 25 seconds. This is the repair
+      # path for a deploy that lost the race with the explorer's indexer, so it
+      # runs when the explorer is coldest. Only a failed attempt sleeps.
       - name: Verify
         run: |
           # `required: true` only says a value was passed, not that it says


### PR DESCRIPTION
Closes https://github.com/rainlanguage/rainix/issues/331

## The retry window IS the tolerance for indexing lag

Foundry's `RetryArgs` (`crates/verify/src/retry.rs` at the pinned toolchain, forge 1.7.2-nightly `43923a4ebf29bf934803ba6bc10ff30fcddf1446`) defaults to `retries: 5, delay: 5`, and `Retry::run_async` counts `retries` as attempts *after* the first — so the default is **6 attempts with 5 sleeps of 5s = a 25 second window**.

Inside that window, `crates/verify/src/etherscan/mod.rs` retries a very narrow set of outcomes:

- `Unable to locate ContractCode at …` / `The address is not a smart contract` / `Address is not a smart-contract` — the explorer has no code at that address yet;
- an HTTP call that did not come back.

Everything else is decided on the first response: `Contract source code already verified` returns success, and any other error the explorer returns hits `std::process::exit(1)` with no retry at all. So `--retries`/`--delay` buy exactly one thing — time for the explorer's indexer to catch up — and buy it only when it is needed.

Separately, the `--watch` status poll that runs *after* a successful submission uses a hard-coded `RETRY_CHECK_ON_VERIFY = { retries: 8, delay: 15 }`. These flags do not reach it.

## The two failures, measured

[rain.deploy run 32163985945](https://github.com/rainlanguage/rain.deploy/actions/runs/32163985945), `MigrationRegistry`, is the sharpest data point because both chains are in one log:

| chain | first submit | outcome |
| --- | --- | --- |
| Ethereum mainnet | `17:09:41.5` | accepted at `17:10:07.7`, **26.2s later, on attempt 6 of 6** — the last one in the window. Then `Pending in queue`, then `Pass - Verified`. |
| HyperEVM (999) | `17:10:23.2` | 6 attempts, `17:10:49.1`, all `Unable to locate ContractCode`. Run red. |

[run 32163707332](https://github.com/rainlanguage/rain.deploy/actions/runs/32163707332), `AddressRegistry` on HyperEVM: broadcast complete `17:06:22.53`, first submit `17:06:22.61` — 80 milliseconds later — 6 attempts, dead at `17:06:48.5`.

Ethereum mainnet is the warmest explorer there is and it cleared the default window by **1.3 seconds on the final attempt**. The default was never sized for this; it just usually got away with it.

## The values: `--retries 40 --delay 15`

**41 attempts, 40 sleeps of 15 seconds = a 10 minute window.** 24× the default's 25s, and 23× the 26.2s Ethereum actually needed.

Sized for the issue's stated case — a cold explorer on a chain the deployer has never touched — rather than for a warm re-deploy:

- **10 minutes** is far past any plausible *indexing* lag. That is the point of the ceiling as much as the floor: if an explorer has not seen a contract 10 minutes after the broadcast, that is an outage or a wrong address, not a race, and no retry count fixes either. Ten minutes is long enough that a red run means something.
- **15 seconds** is not arbitrary. It is foundry's own explorer-poll cadence (`RETRY_CHECK_ON_VERIFY.delay`), and it is the spacing `rainix-manual-sol-verify.yaml` already `sleep`s between networks precisely because the Etherscan V2 key is one key charged across every chain. At 4 requests/minute per contract this is gentler on that key than the 12/minute the default 5s delay produces.
- Both are inside foundry's accepted ranges (`retries` is `1..`, `delay` is `0..=180`), verified against the pinned binary below.

Fixed config, not new `workflow_call` inputs, per the issue: indexing latency is a property of explorers, not of the repo deploying, so a consumer has nothing useful to say about the value.

Worst cases this implies. `rainix-manual-sol-artifacts` waits at most 10 minutes per contract the explorer cannot see. `rainix-manual-sol-verify` is the longer one, and 10 minutes per network is not the whole of it: a network also carries the existing 15s pacing sleep, and up to 2 more minutes of `--watch` polling (foundry's hard-coded 8 checks at 15s) wherever a submission lands on the last attempt and then sits in the explorer's queue forever. Seven networks in the worst of that is 7 × (600 + 120 + 15) = 85m45s — inside GitHub's 6 hour job ceiling, and visible from the first second, because every attempt logs the explorer's answer.

## `rainix-manual-sol-verify.yaml` has the same gap

Yes. `forge verify-contract --watch` is the *same* `VerifyArgs` struct down the *same* `args.retry.into_retry().run_async(…)` submission loop, with the same clap defaults of 5/5. Same flags added.

It matters more there, not less: this workflow is the repair path for a deploy whose verification lost the race, so it is dispatched at the moment the explorer is coldest. A 25 second window here reproduces the failure the workflow exists to fix.

## Consumers, and why a fast explorer cannot be hurt

Enumerated by walking the workflow tree of every non-archived repo in rainlanguage, gildlab, cyclofinance, S01-Issuer, ST0x-Technology, h20liquidity, raincommercial and rain-archive. GitHub code search is not a safe way to build this list: `"rainix-manual-sol-artifacts.yaml" org:rainlanguage` returns four fewer rainlanguage repos than actually call it — rain.deploy, the repo whose failures opened #331, among them — and being org-scoped it never sees the cross-org caller at all.

**13 caller workflows across 12 repos, all `uses: …@main`, all `workflow_dispatch` only:**

- `rainix-manual-sol-artifacts.yaml`: rain.deploy, raindex, rainlang, rain.metadata, rain.extrospection, rain.extrospection.deploy, rain.factory.deploy, rain.flare, rain.math.float, rain.tofu.erc20-decimals, rain.verify, and **S01-Issuer/st0x.deploy** (cross-org).
- `rainix-manual-sol-verify.yaml`: rain.deploy only.

(`rain.factory.deploy/.github/workflows/package-release.yaml` names the reusable in a comment and does not call it.)

Not one of them passes a verification-timing input, so no call site changes. And:

1. **st0x.deploy passes `verify: false`** — it ships stored 0.1.1 creation bytecode that does not match current source. The flags are inside the `${{ inputs.verify && … }}` branch, so that dispatch's command line is byte-identical to today's. An audited production deploy sees no change whatsoever.
2. **A first-attempt success costs zero extra wall clock.** `Retry::run_async` only sleeps in the `Err` arm; `res => return res` exits on the first `Ok`. Observed, not just read: run 32163985945's Ethereum leg went straight from a successful submission into the watch phase.
3. **Nothing else is slowed.** The `--watch` poll is hard-coded at 8×15s. Real explorer errors — a bad key, a rejected source — still fail on the first response.
4. **No PR or push CI gets longer.** Every consumer is `workflow_dispatch` only; these two reusables are never on a merge path.

## QA

- **Discriminating tests:** rainix has no harness that executes a reusable workflow's command line — `test/bats` covers devshells and composite actions, and a reusable is only observable by dispatching it from a consumer (same finding as #330). So the discriminating evidence is taken one level down, at the CLI the workflow invokes, inside rainix's own pinned `sol-shell`:

  ```
  $ nix develop .#sol-shell -c forge script --retries 40 --delay 15
  error: the following required arguments were not provided:
    <PATH>

  $ nix develop .#sol-shell -c forge verify-contract --retries 40 --delay 15
  error: the following required arguments were not provided:
    <ADDRESS>
  ```

  Both parsers accept the pair; the only complaint is the missing positional. Note the first: `forge script` accepts the flags with no `--verify`, so the conditional placement is a deliberate choice about st0x.deploy's command line, not a workaround for a parse error.

- **Mutations applied:**
  - `--delay 181` → `error: invalid value '181' for '--delay <DELAY>': 181 is not in 0..=180`. **Killed.** This is the load-bearing one: it proves the value is parsed and range-checked by *forge* rather than tolerated and dropped, and — since every probe runs through `nix develop …#sol-shell -c` exactly as the workflows do — that the wrapper forwards these flags instead of eating them. Without it the accept-case above is evidence of nothing.
  - `--retries 0` → `error: invalid value '0' for '--retries <RETRIES>': 0 is not in 1..18446744073709551615`. **Killed**, and the same pass-through proof for `forge verify-contract`.
  - Drop `--retries`, keep `--delay 15` → 6 attempts over 75s. No test kills this; killed by reading `RetryArgs`, where count and spacing are independent fields — 75s is still short of the target, so both flags are load-bearing and neither is decoration.
  - Hoist the flags out of the `inputs.verify &&` branch → still parses (mutant 1 above), so nothing goes red, but st0x.deploy's `verify: false` dispatch silently acquires two flags. Killed by placement, and this is the mutant worth naming: it is the one that survives every check except reading the consumers.
  - `verify: false` through the changed expression → `false && '…' || ''` is `''`, the same construct and the same result as the pre-change line; only the literal in the taken-when-true branch is longer.

- **Oracle:** foundry's source at the exact pinned commit and the two rain.deploy run logs. Neither is derived from anything in this repo, and the log timings (26.2s and 25.9s windows, six attempts, 5s gaps) independently confirm the `retries + 1` attempt-count reading of `Retry::run_async` before it was used to size anything.

- **Category check:** #331 asks for (A) fixed retry values on the deploy reusable, (B) the same on the verify reusable if it has the same gap, (C) headroom sized for a cold explorer rather than a warm one. A and B are the diff, C is the section above. The issue explicitly parks whether a verification failure should fail the deploy job at all; that is untouched here.

- `nix develop -c pre-commit run --all-files` — yamlfmt and shellcheck pass on both files.
