### PR TITLE
feat(rpc-preflight): model sepolia, reject endpoints that throttle under load

### DIFF
--- a/.github/workflows/rainix-manual-sol-artifacts.yaml
+++ b/.github/workflows/rainix-manual-sol-artifacts.yaml
@@ -68,6 +68,8 @@ on:
         required: false
       RPC_URL_POLYGON_FORK:
         required: false
+      RPC_URL_SEPOLIA_FORK:
+        required: false
       CI_DEPLOY_ARBITRUM_ETHERSCAN_API_KEY:
         required: false
       CI_DEPLOY_BASE_ETHERSCAN_API_KEY:
@@ -133,6 +135,8 @@ jobs:
           RAINIX_RPC_VARS_HYPEREVM: ${{ vars.RPC_URL_HYPEREVM_FORK }}
           RAINIX_RPC_SECRET_POLYGON: ${{ secrets.RPC_URL_POLYGON_FORK }}
           RAINIX_RPC_VARS_POLYGON: ${{ vars.RPC_URL_POLYGON_FORK }}
+          RAINIX_RPC_SECRET_SEPOLIA: ${{ secrets.RPC_URL_SEPOLIA_FORK }}
+          RAINIX_RPC_VARS_SEPOLIA: ${{ vars.RPC_URL_SEPOLIA_FORK }}
       # 41 submission attempts over 10 minutes, against foundry's default 6 over
       # 25s, which a cold explorer does not fit inside. Only a failed attempt
       # sleeps, and only the no-code and no-answer cases retry at all.

--- a/.github/workflows/rainix-sol-test.yaml
+++ b/.github/workflows/rainix-sol-test.yaml
@@ -22,6 +22,8 @@ on:
         required: false
       RPC_URL_POLYGON_FORK:
         required: false
+      RPC_URL_SEPOLIA_FORK:
+        required: false
 env:
   RAINIX_SHA: 864816f68b114f7596f8e1f6f00315ef48783072
 jobs:
@@ -81,4 +83,6 @@ jobs:
           RAINIX_RPC_VARS_HYPEREVM: ${{ vars.RPC_URL_HYPEREVM_FORK }}
           RAINIX_RPC_SECRET_POLYGON: ${{ secrets.RPC_URL_POLYGON_FORK }}
           RAINIX_RPC_VARS_POLYGON: ${{ vars.RPC_URL_POLYGON_FORK }}
+          RAINIX_RPC_SECRET_SEPOLIA: ${{ secrets.RPC_URL_SEPOLIA_FORK }}
+          RAINIX_RPC_VARS_SEPOLIA: ${{ vars.RPC_URL_SEPOLIA_FORK }}
       - run: nix develop github:rainlanguage/rainix/${{ env.RAINIX_SHA }}#sol-shell -c forge test -vvv

--- a/.github/workflows/rainix-sol.yaml
+++ b/.github/workflows/rainix-sol.yaml
@@ -22,6 +22,8 @@ on:
         required: false
       RPC_URL_POLYGON_FORK:
         required: false
+      RPC_URL_SEPOLIA_FORK:
+        required: false
 jobs:
   static:
     uses: ./.github/workflows/rainix-sol-static.yaml
@@ -40,3 +42,4 @@ jobs:
       RPC_URL_FLARE_FORK: ${{ secrets.RPC_URL_FLARE_FORK }}
       RPC_URL_HYPEREVM_FORK: ${{ secrets.RPC_URL_HYPEREVM_FORK }}
       RPC_URL_POLYGON_FORK: ${{ secrets.RPC_URL_POLYGON_FORK }}
+      RPC_URL_SEPOLIA_FORK: ${{ secrets.RPC_URL_SEPOLIA_FORK }}

--- a/.github/workflows/rainix-tag-release.yaml
+++ b/.github/workflows/rainix-tag-release.yaml
@@ -125,6 +125,8 @@ on:
         required: false
       RPC_URL_POLYGON_FORK:
         required: false
+      RPC_URL_SEPOLIA_FORK:
+        required: false
 env:
   RAINIX_SHA: 864816f68b114f7596f8e1f6f00315ef48783072
 jobs:
@@ -225,6 +227,8 @@ jobs:
           RAINIX_RPC_VARS_HYPEREVM: ${{ vars.RPC_URL_HYPEREVM_FORK }}
           RAINIX_RPC_SECRET_POLYGON: ${{ secrets.RPC_URL_POLYGON_FORK }}
           RAINIX_RPC_VARS_POLYGON: ${{ vars.RPC_URL_POLYGON_FORK }}
+          RAINIX_RPC_SECRET_SEPOLIA: ${{ secrets.RPC_URL_SEPOLIA_FORK }}
+          RAINIX_RPC_VARS_SEPOLIA: ${{ vars.RPC_URL_SEPOLIA_FORK }}
       - name: Verify live chain matches the fresh pins
         # The manual deploy was run before tagging; this is the attestation that it
         # landed — the fork suite checks prod exists at the freshly regenerated

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,12 +101,14 @@ jobs:
           RAINIX_RPC_VARS_FLARE: ${{ vars.RPC_URL_FLARE_FORK }}
           RAINIX_RPC_SECRET_POLYGON: ${{ secrets.RPC_URL_POLYGON_FORK }}
           RAINIX_RPC_VARS_POLYGON: ${{ vars.RPC_URL_POLYGON_FORK }}
+          RAINIX_RPC_SECRET_SEPOLIA: ${{ secrets.RPC_URL_SEPOLIA_FORK }}
+          RAINIX_RPC_VARS_SEPOLIA: ${{ vars.RPC_URL_SEPOLIA_FORK }}
       - name: Assert the preflight bound every archive network
         # Presence only — never echo the values, they may be secret-derived.
         run: |
           set -euo pipefail
           fail=0
-          for name in ARBITRUM_RPC_URL BASE_RPC_URL BASE_SEPOLIA_RPC_URL ETHEREUM_RPC_URL FLARE_RPC_URL POLYGON_RPC_URL; do
+          for name in ARBITRUM_RPC_URL BASE_RPC_URL BASE_SEPOLIA_RPC_URL ETHEREUM_RPC_URL FLARE_RPC_URL POLYGON_RPC_URL SEPOLIA_RPC_URL; do
             if [ -z "${!name:-}" ]; then
               echo "::error::rpc-preflight did not export $name"
               fail=1

--- a/README.md
+++ b/README.md
@@ -119,9 +119,16 @@ jobs:
 `secrets: inherit` is required because the reusable wires the standard fork RPC
 env vars (`ARBITRUM_RPC_URL`, `BASE_RPC_URL`, `BASE_SEPOLIA_RPC_URL`,
 `ETHEREUM_RPC_URL`, `FLARE_RPC_URL`, `HYPEREVM_RPC_URL`, `POLYGON_RPC_URL`,
-`CI_DEPLOY_SEPOLIA_RPC_URL`) plus `ETHERSCAN_API_KEY` and `DEPLOYMENT_KEY` from
-the consumer org's secrets/vars. Repos that do no fork tests can ignore — empty
-values are harmless.
+`SEPOLIA_RPC_URL`, `CI_DEPLOY_SEPOLIA_RPC_URL`) plus `ETHERSCAN_API_KEY` and
+`DEPLOYMENT_KEY` from the consumer org's secrets/vars. Repos that do no fork
+tests can ignore — empty values are harmless.
+
+`CI_DEPLOY_SEPOLIA_RPC_URL` and the `ETH_RPC_URL` it is bound to are LEGACY and
+scheduled for removal (rainlanguage/rainix#340). `ETH_RPC_URL` reads as though
+it means Ethereum mainnet but resolves to the Sepolia-era deploy secret, so a
+test trusting the name forks the wrong network. New code wants
+`ETHEREUM_RPC_URL` or `SEPOLIA_RPC_URL` — whichever it actually means — both of
+which the preflight health-checks before binding.
 
 #### rainix-sol (composite)
 
@@ -271,6 +278,27 @@ single sample would qualify a load balancer that round-robins over a mix of
 archive and pruning backends. Ethereum and HyperEVM are latest-only in every
 consumer, so they are not held to the archive bar, and neither are
 deploy/broadcast paths.
+
+**Health also covers load, not just correctness.** Chain id, historical state
+and historical `eth_call` are all correctness questions, and an endpoint that is
+throttled rather than broken answers every one of them perfectly — then returns
+`408 Request timeout on the free plan` the moment `forge` opens real fork
+traffic (rainlanguage/rainix#340). Each candidate is therefore also hit with
+`--burst` simultaneous `eth_call`s (16 by default), repeated for as many rounds
+as there are samples, and is rejected when a majority of any one round comes
+back throttled.
+
+Rounds rather than a single burst, because these endpoints meter a token bucket:
+the first burst after an idle period is served out of a full bucket and passes
+even on an endpoint that then collapses. A majority rather than any single
+failure, because every healthy public endpoint sheds the occasional request
+under load, and rejecting on one would make the preflight flakier than the
+outage it exists to prevent. `--burst 0` disables the check.
+
+Because public rate limits are per-IP, the hardcoded default _order_ is only a
+preference and cannot be right for every runner — the burst is what makes the
+selection safe, by rejecting whichever candidate is throttled for the runner
+running right now.
 
 **No candidate URL is ever printed.** Logs name the _source_ (`secret[0]`,
 `variable[1]`, `default[0]`) and a typed reason, never a URL:

--- a/rainix-static/src/main.rs
+++ b/rainix-static/src/main.rs
@@ -51,7 +51,7 @@
 //       checkout with tags; runs inside sol-shell, so `forge`, `curl` and `git`
 //       are on PATH.
 //   rpc-preflight [--root <dir>] [--github-env <file>] [--samples N]
-//                 [--timeout N] [--no-archive]
+//                 [--timeout N] [--burst N] [--no-archive]
 //       Pick a working fork RPC endpoint per network and export it as
 //       <NETWORK>_RPC_URL, so a dead upstream (quota, pruning node, gone host)
 //       fails over instead of reddening every suite in the org. Candidates come
@@ -203,6 +203,17 @@ fn main() {
                 });
             let samples = num(&args, "--samples", 3);
             let timeout = num(&args, "--timeout", 15);
+            // Simultaneous requests per load round, used to test for plan
+            // throttling. The sequential checks are paced by their own round
+            // trips, which is a request rate no throttle reacts to, so without
+            // a burst an endpoint that is merely rate-limited looks perfectly
+            // healthy. `--samples` rounds of this size are run back to back,
+            // because the first burst after an idle period comes out of a full
+            // token bucket and passes even on an endpoint that then collapses.
+            // 16 is the smallest size that separated the throttled endpoints
+            // from the healthy ones when the table was measured; 0 disables the
+            // load check entirely.
+            let burst = num(&args, "--burst", 16);
             // Deploy/broadcast paths only ever read head state; requiring
             // archive there would reject a healthy pruning endpoint.
             let archive = !args.iter().any(|a| a == "--no-archive");
@@ -212,6 +223,7 @@ fn main() {
                 samples,
                 timeout,
                 archive,
+                burst,
             );
         }
         other => {

--- a/rainix-static/src/rpc_preflight.rs
+++ b/rainix-static/src/rpc_preflight.rs
@@ -481,7 +481,10 @@ fn classify(code: i64, message: &str, block: Option<u64>) -> Reason {
 /// `result` beside it, so a healthy response that happens to carry a `message`
 /// field is never misread as a failure.
 fn error_fields(json: &serde_json::Value) -> Option<(i64, &str)> {
-    if let Some(err) = json.get("error") {
+    // An explicit `"error": null` is NOT an error: serde_json returns
+    // `Some(Value::Null)` for it, and providers echo it beside a healthy
+    // `result`. Filtering it out here keeps such a response a success.
+    if let Some(err) = json.get("error").filter(|err| !err.is_null()) {
         // `error` as a bare string carries no code of its own; 0 is the
         // "no code supplied" discriminant, exactly as for a missing field.
         if let Some(message) = err.as_str() {
@@ -1441,6 +1444,12 @@ mod tests {
         );
         assert_eq!(error_fields(&json!({})), None);
         assert_eq!(error_fields(&json!({"code": 30})), None);
+        // An explicit `"error": null` beside a real result. serde_json's `get`
+        // returns `Some(Value::Null)` here, so an unfiltered read would default
+        // code/message to 0/"" and reject a healthy endpoint as RpcError{0}.
+        assert_eq!(error_fields(&json!({"result": "0x1", "error": null})), None);
+        // The same null with no result at all is still not an error envelope.
+        assert_eq!(error_fields(&json!({"error": null})), None);
     }
 
     #[test]

--- a/rainix-static/src/rpc_preflight.rs
+++ b/rainix-static/src/rpc_preflight.rs
@@ -270,10 +270,69 @@ pub(crate) const NETWORKS: &[Network] = &[
         // A pruning node is sufficient, so do not exclude one.
         archive_blocks: &[],
         probe_contract: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", // WETH
+        // eth-pokt.nodies.app is demoted to LAST per rainlanguage/rainix#340:
+        // from GitHub runners it answers the light probe and then returns
+        // `408 {"message":"Request timeout on the free plan..."}` under real
+        // fork traffic, which took out a rain.factory.deploy dispatch and a
+        // rain.metadata test run.
+        //
+        // THE TWO VANTAGE POINTS DISAGREE, so read the order as a preference
+        // rather than a ranking. Sustained-load measurement from one non-CI
+        // host on 2026-08-20 (60s rest, then four consecutive bursts of 16)
+        // says almost the opposite of the CI evidence above:
+        //
+        //   eth.drpc.org                 16/16 16/16 16/16 16/16
+        //   eth-pokt.nodies.app          16/16 16/16 16/16 16/16
+        //   mainnet.gateway.tenderly.co  15/16  0/16 14/16  1/16
+        //
+        // Public rate limits are per-IP, so a measurement from here does not
+        // predict a GitHub runner and vice versa — neither source is wrong and
+        // no static order can be right for both. drpc leads because it is the
+        // only endpoint with no evidence against it from EITHER vantage;
+        // tenderly is kept ahead of pokt because #340's demotion of pokt rests
+        // on the environment that actually matters (CI), even though it looks
+        // best from here. What makes this safe either way is the burst check in
+        // `probe`: whichever of these is throttled for the runner running right
+        // now is rejected and failed over. Reorder on CI evidence, not on a
+        // local measurement.
         defaults: &[
-            "https://eth-pokt.nodies.app",
-            "https://mainnet.gateway.tenderly.co",
             "https://eth.drpc.org",
+            "https://mainnet.gateway.tenderly.co",
+            "https://eth-pokt.nodies.app",
+        ],
+    },
+    Network {
+        key: "sepolia",
+        env_name: "SEPOLIA_RPC_URL",
+        secret_name: "RPC_URL_SEPOLIA_FORK",
+        chain_id: 11155111,
+        // The `RPC_URL_SEPOLIA_FORK` org secret existed with nothing consuming
+        // it (rainlanguage/rainix#340): no entry here meant it was never
+        // demand-scanned, never probed and never exported. Modelling it is what
+        // makes the secret reachable.
+        //
+        // Latest-only: no repo in the org forks Sepolia at a pinned block,
+        // precisely because the secret has never been consumable, so there is
+        // no live pin to protect and no reason to reject a pruning node. Per
+        // the rule on `archive_blocks`, add the deepest pin here the moment a
+        // consumer appears — probing shallower than a live pin is the failure
+        // this field exists to prevent.
+        archive_blocks: &[],
+        probe_contract: "0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14", // WETH9
+        // Measured 2026-08-20, same method as the rest of the table: 5/5 on the
+        // sequential probe, then a 16-way burst. publicnode and thirdweb each
+        // went 5/5 and 16/16; tenderly went 5/5 but shed 3/16 to `-32005 rate
+        // limit exceeded`, so it is ordered last of the three.
+        //
+        // Deliberately absent, all measured the same day and all rejected:
+        // 1rpc.io/sepolia scored 4/5 and then 8/16 (`cu limit exceeded`, served
+        // with HTTP 200); sepolia.drpc.org refuses 100% behind a free-plan gate
+        // (`code 35`); rpc.sepolia.org is gone (404); eth-sepolia.public.
+        // blastapi.io is discontinued (403); endpoints.omniatech.io 521s.
+        defaults: &[
+            "https://ethereum-sepolia-rpc.publicnode.com",
+            "https://11155111.rpc.thirdweb.com",
+            "https://sepolia.gateway.tenderly.co",
         ],
     },
     Network {
@@ -345,9 +404,22 @@ fn classify(code: i64, message: &str, block: Option<u64>) -> Reason {
     let m = message.to_ascii_lowercase();
     let has = |needle: &str| m.contains(needle);
 
+    // Plan/quota FIRST, and specifically before the archive arm below: the
+    // free-plan gate reads "chain is not available on free plan", which the
+    // archive arm's "is not available" needle also matches. Whichever arm runs
+    // first wins, so a billing wall would otherwise be reported as a pruning
+    // node — the wrong actionable fact, and one that sends a reader looking for
+    // a deeper archive endpoint instead of a paid key.
+    //
+    // "free plan" / "paid plan" / "upgrade to" are the wording the throttling
+    // providers in this table actually use; none of them says "quota" or "rate
+    // limit" when the refusal is plan-based rather than burst-based.
     if code == -32001
         || has("usage limit")
         || has("current plan")
+        || has("free plan")
+        || has("paid plan")
+        || has("upgrade to")
         || has("quota")
         || has("rate limit")
         || has("too many requests")
@@ -390,6 +462,67 @@ fn classify(code: i64, message: &str, block: Option<u64>) -> Reason {
     Reason::RpcError { code }
 }
 
+/// Pull an error `(code, message)` out of a response body, whatever shape the
+/// provider chose to send it in.
+///
+/// Three shapes occur among the endpoints in this table, all captured live:
+///
+///   * `{"error":{"code":-32005,"message":"rate limit exceeded"}}` — the
+///     JSON-RPC envelope the spec asks for (tenderly, HTTP 429).
+///   * `{"error":"cu limit exceeded; ..."}` — `error` as a bare STRING rather
+///     than an object, served with **HTTP 200** (1rpc.io). This is the shape
+///     that matters most: with no envelope to read and a success status, an
+///     unhandled body here is indistinguishable from a healthy response, so
+///     the candidate is SELECTED and the suite dies later.
+///   * `{"message":"Request timeout on the free plan...","code":30}` — no
+///     envelope at all, the fields sit at the top level (drpc, HTTP 408).
+///
+/// A top-level `message`/`code` pair is only an error when there is no
+/// `result` beside it, so a healthy response that happens to carry a `message`
+/// field is never misread as a failure.
+fn error_fields(json: &serde_json::Value) -> Option<(i64, &str)> {
+    if let Some(err) = json.get("error") {
+        // `error` as a bare string carries no code of its own; 0 is the
+        // "no code supplied" discriminant, exactly as for a missing field.
+        if let Some(message) = err.as_str() {
+            return Some((0, message));
+        }
+        let code = err
+            .get("code")
+            .and_then(serde_json::Value::as_i64)
+            .unwrap_or(0);
+        let message = err
+            .get("message")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("");
+        return Some((code, message));
+    }
+    if json.get("result").is_none() {
+        if let Some(message) = json.get("message").and_then(serde_json::Value::as_str) {
+            let code = json
+                .get("code")
+                .and_then(serde_json::Value::as_i64)
+                .unwrap_or(0);
+            return Some((code, message));
+        }
+    }
+    None
+}
+
+/// Reject on an HTTP status alone, when the body told us nothing.
+///
+/// 429 is a rate limit by definition, so it is a quota rejection even when the
+/// body is an HTML error page we refuse to parse — reporting it as a bare
+/// status would hide the one failure class this whole subcommand exists to
+/// route around.
+fn http_reason(status: u32) -> Reason {
+    match status {
+        429 => Reason::Quota { code: 0 },
+        s if s >= 400 => Reason::Http { status: s },
+        _ => Reason::BadResponse,
+    }
+}
+
 /// POST one JSON-RPC request and return its `result`.
 ///
 /// curl's stdout is captured and parsed; its stderr is captured and DROPPED
@@ -401,6 +534,16 @@ fn rpc(
     body: &str,
     block: Option<u64>,
 ) -> Result<serde_json::Value, Reason> {
+    finish_rpc(spawn_rpc(url, timeout, body)?, block)
+}
+
+/// Spawn one curl child with the request body already written to its stdin.
+///
+/// Split out from `rpc` so a caller can start MANY requests before waiting on
+/// any of them: spawning and collecting in one step serialises the probe, and a
+/// serial probe cannot generate the request RATE that plan throttling responds
+/// to. See `burst`.
+fn spawn_rpc(url: &Url, timeout: u32, body: &str) -> Result<std::process::Child, Reason> {
     let mut child = Command::new("curl")
         .args([
             "-s",
@@ -426,6 +569,11 @@ fn rpc(
         .as_mut()
         .and_then(|s| s.write_all(body.as_bytes()).ok())
         .ok_or(Reason::Unreachable { curl_exit: -1 })?;
+    Ok(child)
+}
+
+/// Wait for a spawned curl child and parse its response.
+fn finish_rpc(child: std::process::Child, block: Option<u64>) -> Result<serde_json::Value, Reason> {
     let out = child
         .wait_with_output()
         .map_err(|_| Reason::Unreachable { curl_exit: -1 })?;
@@ -442,27 +590,13 @@ fn rpc(
         Ok(v) => v,
         // A non-JSON body (an HTML error page, a proxy banner) is never parsed
         // for meaning and never printed; only the status survives.
-        Err(_) => {
-            return Err(if status >= 400 {
-                Reason::Http { status }
-            } else {
-                Reason::BadResponse
-            })
-        }
+        Err(_) => return Err(http_reason(status)),
     };
-    if let Some(err) = json.get("error") {
-        let code = err
-            .get("code")
-            .and_then(serde_json::Value::as_i64)
-            .unwrap_or(0);
-        let message = err
-            .get("message")
-            .and_then(serde_json::Value::as_str)
-            .unwrap_or("");
+    if let Some((code, message)) = error_fields(&json) {
         return Err(classify(code, message, block));
     }
     if status >= 400 {
-        return Err(Reason::Http { status });
+        return Err(http_reason(status));
     }
     json.get("result").cloned().ok_or(Reason::BadResponse)
 }
@@ -515,6 +649,72 @@ fn check_call_result(v: &serde_json::Value, block: Option<u64>) -> Result<(), Re
     }
 }
 
+/// Fire `n` identical requests SIMULTANEOUSLY and report each outcome
+/// (`None` = the request succeeded).
+///
+/// Every request is spawned before any is collected — that is the entire point.
+/// The sequential checks above issue a handful of calls with a full round trip
+/// of think time between them, which is a request RATE no plan throttle reacts
+/// to; that is why an endpoint can pass the preflight and then die under forge,
+/// which opens many concurrent state reads. This reproduces the rate, not just
+/// the calls.
+///
+/// `latest` and the cheapest available call, deliberately: the question here is
+/// "how many requests per second will you serve", not "how deep is your
+/// history" — that is already settled above — and multiplying archive reads by
+/// `n` would be a heavy and pointless load on every provider in the table.
+fn burst(url: &Url, net: &Network, n: u32, timeout: u32) -> Vec<Option<Reason>> {
+    let body = format!(
+        r#"{{"jsonrpc":"2.0","id":1,"method":"eth_call","params":[{{"to":"{}","data":"0x18160ddd"}},"latest"]}}"#,
+        net.probe_contract
+    );
+    let spawned: Vec<Result<std::process::Child, Reason>> =
+        (0..n).map(|_| spawn_rpc(url, timeout, &body)).collect();
+    spawned
+        .into_iter()
+        .map(|c| match c {
+            Ok(child) => match finish_rpc(child, None) {
+                Ok(v) => check_call_result(&v, None).err(),
+                Err(reason) => Some(reason),
+            },
+            Err(reason) => Some(reason),
+        })
+        .collect()
+}
+
+/// Verdict on a load burst: `Some(reason)` rejects the candidate.
+///
+/// The burst answers exactly ONE question — does this endpoint throttle at the
+/// request rate a fork suite generates — so it rejects for throttling and for
+/// nothing else. Correctness (chain id, archive depth, response shape) is
+/// already settled by the sequential phase, and a lone transient timeout inside
+/// a 16-way burst is not evidence of an unhealthy endpoint. Treating any single
+/// failure as fatal would make this preflight flakier than the outage it exists
+/// to prevent, and would reject endpoints the org depends on.
+///
+/// Hence a MAJORITY threshold rather than "any". Measured against the very
+/// candidates in this table (2026-08-20, from one host — see the ethereum
+/// `defaults` note on why one vantage point is not the whole story): a healthy
+/// public endpoint sheds the occasional request under burst — eth.drpc.org
+/// returned a single 429 in a burst of 8 and then served 32/32 twice — while a
+/// throttled or plan-gated one fails nearly all of them —
+/// mainnet.gateway.tenderly.co returned 9/16 and then 32/32 rate-limited, and
+/// sepolia.drpc.org refuses 100% behind a free-plan gate. Half separates those
+/// two populations with room to spare in both directions.
+fn burst_verdict(outcomes: &[Option<Reason>]) -> Option<Reason> {
+    let throttled: Vec<Reason> = outcomes
+        .iter()
+        .flatten()
+        .copied()
+        .filter(|r| matches!(r, Reason::Quota { .. }))
+        .collect();
+    if throttled.len() * 2 > outcomes.len() {
+        throttled.first().copied()
+    } else {
+        None
+    }
+}
+
 /// Probe one candidate. Returns Ok only if EVERY check passes on EVERY sample.
 ///
 /// The three checks mirror what forge's fork backend does, in the order that
@@ -527,6 +727,13 @@ fn check_call_result(v: &serde_json::Value, block: Option<u64>) -> Result<(), Re
 ///      on top of (2) because some hosts serve historical code and state but
 ///      answer every eth_call with "method not supported"; a code-only probe
 ///      selects them and the suite dies later.
+///   4. a simultaneous `burst_size` burst — LOAD. Checks 1-3 are correctness
+///      questions, and an endpoint that is throttled rather than broken answers
+///      all of them perfectly: all three ethereum defaults passed 1-3 on
+///      2026-08-20 while two of them shed most of a concurrent burst. Without
+///      this step the preflight cannot tell a healthy endpoint from one that
+///      will 408 the moment forge opens real fork traffic, which is precisely
+///      the failure rainlanguage/rainix#340 is about.
 ///
 /// `samples` consecutive full passes are required. A single sample is not
 /// enough: the public load balancers round-robin over a mix of archive and
@@ -538,6 +745,7 @@ fn probe(
     samples: u32,
     timeout: u32,
     archive: bool,
+    burst_size: u32,
 ) -> Result<(), Reason> {
     let chain = rpc(
         url,
@@ -581,7 +789,50 @@ fn probe(
             check_call_result(&call, *b)?;
         }
     }
+
+    // Load last: it is the most expensive check and the only one that can be
+    // skipped (--burst 0), so everything cheap and disqualifying runs first.
+    //
+    // `samples` ROUNDS, back to back, and any one round failing is fatal. One
+    // round is not enough, and the reason is the shape of the limiter: these
+    // endpoints meter a token bucket, so the first burst after an idle period
+    // is served out of a full bucket and tells you nothing about sustained
+    // load. Measured against mainnet.gateway.tenderly.co on 2026-08-20 —
+    // 60s rest, then four consecutive bursts of 16 — the rounds throttled
+    // 1/16, then 16/16, then 2/16, then 15/16: round one PASSES and rounds two
+    // and four collapse completely. A fork suite is sustained load, not one
+    // burst, so the probe has to be too. (eth.drpc.org served 16/16 in all four
+    // rounds of the same run, so this does not simply reject everything.)
+    for _ in 0..samples {
+        if let Some(reason) = burst_verdict(&burst(url, net, burst_size, timeout)) {
+            return Err(reason);
+        }
+    }
     Ok(())
+}
+
+/// True when `text` references the identifier `name` as a WHOLE WORD.
+///
+/// A plain `contains` was sufficient only while no network name nested inside
+/// another. `sepolia` breaks that: `SEPOLIA_RPC_URL` is a substring of
+/// `BASE_SEPOLIA_RPC_URL`, so a substring scan makes every repo that forks Base
+/// Sepolia — most of the org — also look like it demands Ethereum Sepolia. A
+/// falsely demanded network is probed, and a network with no healthy candidate
+/// FAILS THE JOB, so the naive form would red repos that never touch Sepolia.
+///
+/// These names are identifiers, so the boundary rule is the identifier rule: a
+/// match counts only when neither neighbouring byte is `[A-Za-z0-9_]`. That
+/// keeps every real reference (`${SEPOLIA_RPC_URL}`, `vm.envString("…")`,
+/// `SEPOLIA_RPC_URL=…`) and drops every nested one.
+fn mentions(text: &str, name: &str) -> bool {
+    let bytes = text.as_bytes();
+    let ident = |b: u8| b.is_ascii_alphanumeric() || b == b'_';
+    text.match_indices(name).any(|(i, _)| {
+        let before = i == 0 || !ident(bytes[i - 1]);
+        let end = i + name.len();
+        let after = end >= bytes.len() || !ident(bytes[end]);
+        before && after
+    })
 }
 
 /// Networks the repo actually uses, by scanning tracked files for the env name
@@ -619,7 +870,7 @@ fn demanded(root: &Path) -> BTreeSet<&'static str> {
             continue;
         };
         for net in NETWORKS {
-            if text.contains(net.env_name) || text.contains(net.secret_name) {
+            if mentions(&text, net.env_name) || mentions(&text, net.secret_name) {
                 found.insert(net.key);
             }
         }
@@ -645,7 +896,14 @@ fn export(path: &Path, name: &str, url: &Url) {
 }
 
 /// Run the preflight for every network the repo uses.
-pub(crate) fn run(root: &Path, github_env: &Path, samples: u32, timeout: u32, archive: bool) {
+pub(crate) fn run(
+    root: &Path,
+    github_env: &Path,
+    samples: u32,
+    timeout: u32,
+    archive: bool,
+    burst_size: u32,
+) {
     let want = demanded(root);
     if want.is_empty() {
         println!("rpc-preflight: repo references no fork RPC env vars; nothing to do");
@@ -682,7 +940,7 @@ pub(crate) fn run(root: &Path, github_env: &Path, samples: u32, timeout: u32, ar
         let mut rejected: Vec<(Source, Reason)> = Vec::new();
         let mut selected: Option<(Source, Url)> = None;
         for (src, url) in candidates {
-            match probe(&url, net, samples, timeout, archive) {
+            match probe(&url, net, samples, timeout, archive, burst_size) {
                 Ok(()) => {
                     selected = Some((src, url));
                     break;
@@ -1048,27 +1306,192 @@ mod tests {
     }
 
     #[test]
-    fn env_names_are_not_substrings_of_each_other() {
-        // The demand scan is a substring match, so BASE_RPC_URL must not match
-        // a repo that only mentions BASE_SEPOLIA_RPC_URL.
+    fn no_network_name_is_a_whole_word_mention_inside_another() {
+        // This assertion used to be "no name is a SUBSTRING of another", which
+        // held only while no network nested inside another. `sepolia` breaks
+        // that literally — SEPOLIA_RPC_URL is a substring of
+        // BASE_SEPOLIA_RPC_URL — and the table needs both names, so the scan
+        // matches on identifier boundaries instead (`mentions`).
+        //
+        // The invariant that actually protects the demand scan is therefore the
+        // boundary one: no network's name may match as a WHOLE WORD inside
+        // another's, or a repo mentioning only the longer name would demand
+        // both networks and be failed by a probe for a chain it never touches.
         for a in NETWORKS {
             for b in NETWORKS {
                 if a.key != b.key {
                     assert!(
-                        !b.env_name.contains(a.env_name),
-                        "{} contains {}",
+                        !mentions(b.env_name, a.env_name),
+                        "{} matches {} as a whole word",
                         b.env_name,
                         a.env_name
                     );
                     assert!(
-                        !b.secret_name.contains(a.secret_name),
-                        "{} contains {}",
+                        !mentions(b.secret_name, a.secret_name),
+                        "{} matches {} as a whole word",
                         b.secret_name,
                         a.secret_name
                     );
                 }
             }
         }
+        // Guard against this test quietly becoming vacuous: the raw substring
+        // nesting it was weakened FROM is real and still in the table, so the
+        // boundary rule is load-bearing rather than decorative.
+        assert!(net("base_sepolia")
+            .env_name
+            .contains(net("sepolia").env_name));
+    }
+
+    #[test]
+    fn mentions_requires_identifier_boundaries() {
+        // The nesting that forced the rule.
+        assert!(!mentions("BASE_SEPOLIA_RPC_URL", "SEPOLIA_RPC_URL"));
+        assert!(mentions("BASE_SEPOLIA_RPC_URL", "BASE_SEPOLIA_RPC_URL"));
+        // Every punctuation a real reference is wrapped in still matches.
+        assert!(mentions("${SEPOLIA_RPC_URL}", "SEPOLIA_RPC_URL"));
+        assert!(mentions(
+            "vm.envString(\"SEPOLIA_RPC_URL\")",
+            "SEPOLIA_RPC_URL"
+        ));
+        assert!(mentions("SEPOLIA_RPC_URL=https://x", "SEPOLIA_RPC_URL"));
+        assert!(mentions("  SEPOLIA_RPC_URL\n", "SEPOLIA_RPC_URL"));
+        // Start and end of input are boundaries.
+        assert!(mentions("SEPOLIA_RPC_URL", "SEPOLIA_RPC_URL"));
+        // Adjacent identifier bytes on either side are not.
+        assert!(!mentions("MY_SEPOLIA_RPC_URL", "SEPOLIA_RPC_URL"));
+        assert!(!mentions("SEPOLIA_RPC_URL2", "SEPOLIA_RPC_URL"));
+        assert!(!mentions("XSEPOLIA_RPC_URLX", "SEPOLIA_RPC_URL"));
+        // A later valid occurrence still counts when an earlier one is nested.
+        assert!(mentions(
+            "BASE_SEPOLIA_RPC_URL and ${SEPOLIA_RPC_URL}",
+            "SEPOLIA_RPC_URL"
+        ));
+        assert!(!mentions("", "SEPOLIA_RPC_URL"));
+    }
+
+    #[test]
+    fn sepolia_is_modelled_so_its_secret_is_consumed() {
+        // rainlanguage/rainix#340: the RPC_URL_SEPOLIA_FORK org secret existed
+        // with no table entry, so it was never scanned, probed or exported.
+        let n = net("sepolia");
+        assert_eq!(n.chain_id, 11155111);
+        assert_eq!(n.env_name, "SEPOLIA_RPC_URL");
+        assert_eq!(n.secret_name, "RPC_URL_SEPOLIA_FORK");
+        // Distinct from Base Sepolia in every field that identifies a network.
+        let b = net("base_sepolia");
+        assert_ne!(n.chain_id, b.chain_id);
+        assert_ne!(n.probe_contract, b.probe_contract);
+        assert!(!n.defaults.is_empty());
+    }
+
+    #[test]
+    fn ethereum_prefers_the_endpoints_that_survived_ci() {
+        // rainlanguage/rainix#340 demoted eth-pokt.nodies.app: it passes a
+        // light probe from CI and then 408s under fork load. The burst check is
+        // what actually protects the selection, but the declared preference
+        // still must not LEAD with an endpoint that is known to fail under
+        // sustained load from some vantage point — which, on 2026-08-20
+        // measurement, is true of both pokt (from CI) and tenderly (from here).
+        // eth.drpc.org is the only one with no evidence against it either way.
+        let d = net("ethereum").defaults;
+        assert_eq!(d.last(), Some(&"https://eth-pokt.nodies.app"));
+        assert_eq!(d[0], "https://eth.drpc.org");
+        assert_eq!(d.len(), 3);
+    }
+
+    #[test]
+    fn error_fields_reads_every_wire_shape_seen_in_the_wild() {
+        // The spec envelope (tenderly, HTTP 429).
+        assert_eq!(
+            error_fields(&json!({"error": {"code": -32005, "message": "rate limit exceeded"}})),
+            Some((-32005, "rate limit exceeded"))
+        );
+        // `error` as a bare STRING, served with HTTP 200 (1rpc.io). Unhandled,
+        // this is a throttle that looks exactly like a healthy response.
+        assert_eq!(
+            error_fields(&json!({"error": "cu limit exceeded", "path": "/eth-sepolia"})),
+            Some((0, "cu limit exceeded"))
+        );
+        // No envelope; the fields sit at the top level (drpc, HTTP 408).
+        assert_eq!(
+            error_fields(&json!({"message": "Request timeout on the free plan", "code": 30})),
+            Some((30, "Request timeout on the free plan"))
+        );
+        // Missing pieces degrade to the "no code / no message" discriminants
+        // rather than losing the error.
+        assert_eq!(
+            error_fields(&json!({"error": {"message": "boom"}})),
+            Some((0, "boom"))
+        );
+        assert_eq!(
+            error_fields(&json!({"error": {"code": -1}})),
+            Some((-1, ""))
+        );
+    }
+
+    #[test]
+    fn error_fields_never_fires_on_a_healthy_response() {
+        assert_eq!(error_fields(&json!({"result": "0x1"})), None);
+        // A `message` beside a real `result` is not an error — only a top-level
+        // message with NO result is.
+        assert_eq!(
+            error_fields(&json!({"result": "0x1", "message": "ok", "code": 0})),
+            None
+        );
+        assert_eq!(error_fields(&json!({})), None);
+        assert_eq!(error_fields(&json!({"code": 30})), None);
+    }
+
+    #[test]
+    fn http_429_is_a_quota_rejection_even_with_an_unparseable_body() {
+        // An HTML rate-limit page carries no JSON to classify, but 429 means
+        // rate limited by definition and that is the class this whole
+        // subcommand routes around.
+        assert_eq!(http_reason(429), Reason::Quota { code: 0 });
+        assert_eq!(http_reason(500), Reason::Http { status: 500 });
+        assert_eq!(http_reason(404), Reason::Http { status: 404 });
+        assert_eq!(http_reason(521), Reason::Http { status: 521 });
+        // Below 400 with a body we could not parse is malformed, not an HTTP
+        // failure — the 200-with-an-error-body case.
+        assert_eq!(http_reason(200), Reason::BadResponse);
+    }
+
+    #[test]
+    fn burst_rejects_only_a_throttled_majority() {
+        let q = Some(Reason::Quota { code: 30 });
+        // Clean burst.
+        assert_eq!(burst_verdict(&[None, None, None, None]), None);
+        // A minority of throttled requests is tolerated: every healthy public
+        // endpoint sheds the occasional one, and rejecting on that would make
+        // the preflight flakier than the outage it prevents.
+        assert_eq!(burst_verdict(&[q, None, None, None]), None);
+        // Exactly half is still not a majority.
+        assert_eq!(burst_verdict(&[q, q, None, None]), None);
+        // A majority is a rejection, and it reports the throttle reason.
+        assert_eq!(
+            burst_verdict(&[q, q, q, None]),
+            Some(Reason::Quota { code: 30 })
+        );
+        assert_eq!(burst_verdict(&[q, q]), Some(Reason::Quota { code: 30 }));
+    }
+
+    #[test]
+    fn burst_ignores_failures_that_are_not_throttling() {
+        // Correctness is settled by the sequential phase; the burst judges load
+        // and nothing else. A transient timeout inside a wide burst must not
+        // reject an endpoint that just passed every correctness check.
+        let boom = Some(Reason::Unreachable { curl_exit: 28 });
+        assert_eq!(burst_verdict(&[boom, boom, boom, boom]), None);
+        assert_eq!(burst_verdict(&[Some(Reason::BadResponse); 4]), None);
+        // Mixed: throttling is a minority of the burst even though most
+        // requests failed for other reasons.
+        assert_eq!(
+            burst_verdict(&[Some(Reason::Quota { code: 1 }), boom, boom, boom]),
+            None
+        );
+        // An empty burst (--burst 0) disables the check.
+        assert_eq!(burst_verdict(&[]), None);
     }
 
     #[test]
@@ -1126,7 +1549,71 @@ mod tests {
         // arbitrum must not count.
         assert!(!got.contains("base"));
         assert!(!got.contains("arbitrum"));
+        // Nor may it drag SEPOLIA in. BASE_SEPOLIA_RPC_URL literally contains
+        // SEPOLIA_RPC_URL, so under the old substring scan this repo — and most
+        // of the org — would have demanded a network it never touches, and been
+        // failed by a probe for it.
+        assert!(!got.contains("sepolia"));
         assert_eq!(got.len(), 2);
         std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn plan_gating_is_a_quota_rejection_not_a_pruning_node() {
+        // Live from https://sepolia.drpc.org today: a free-plan gate, HTTP 400.
+        // The message contains "is not available", which the archive arm also
+        // matches — so the plan arm has to win, or a billing wall is reported
+        // as a pruning node and the actionable fact is lost.
+        assert_eq!(
+            classify(
+                35,
+                "chain is not available on free plan, please upgrade to paid plan",
+                Some(38_000_000)
+            ),
+            Reason::Quota { code: 35 }
+        );
+    }
+
+    #[test]
+    fn free_plan_throttle_wording_is_quota() {
+        // The body rainix#340 captured off eth-pokt.nodies.app under fork load.
+        assert_eq!(
+            classify(
+                30,
+                "Request timeout on the free plan, please upgrade to paid plan",
+                None
+            ),
+            Reason::Quota { code: 30 }
+        );
+        // Live from https://1rpc.io/sepolia under a 16-way burst.
+        assert_eq!(
+            classify(0, "cu limit exceeded; Method \"eth_call\" is not available for unregistered accounts. Please register", None),
+            Reason::Quota { code: 0 }
+        );
+        // Live from https://eth.drpc.org under an 8-way burst.
+        assert_eq!(
+            classify(
+                15,
+                "You reached Public endpoint rate limit, please upgrade to paid plan",
+                None
+            ),
+            Reason::Quota { code: 15 }
+        );
+        // The same drpc body cut to the half that names the plan — the shape it
+        // arrives in when the provider omits the remedy clause, and the exact
+        // string `error_fields` is tested against above.
+        //
+        // Every other case here says "upgrade to paid plan" as well, so all of
+        // them stay quota on the strength of those two needles alone and NONE
+        // of them pins "free plan". This one carries no "upgrade to", no "paid
+        // plan", no "quota", no "rate limit" and no "exceeded": strike the
+        // "free plan" needle and it falls all the way through to a bare
+        // RpcError, which reports a billing wall as an unexplained failure and
+        // fails the network over for no stated reason. That makes this the case
+        // that keeps the needle load-bearing rather than redundant.
+        assert_eq!(
+            classify(30, "Request timeout on the free plan", None),
+            Reason::Quota { code: 30 }
+        );
     }
 }


### PR DESCRIPTION
Closes #340 — parts 1 and 4. Parts 2 and 3 are deliberately not here; see
**Scope** below.

## What this changes

**Part 1 — `sepolia` is modelled, so `RPC_URL_SEPOLIA_FORK` is finally
consumed.** The org secret existed with no entry in the preflight's network
table, so it was never demand-scanned, never probed and never exported. There is
now a `sepolia` entry (chain 11155111, WETH9 as the probe contract, latest-only)
and the five workflows that already forward every other network's secret forward
this one too.

Adding it broke the demand scan, which is worth calling out because it would
have reddened most of the org. The scan was a plain substring match and
`SEPOLIA_RPC_URL` is a substring of `BASE_SEPOLIA_RPC_URL` — so every repo that
forks Base Sepolia would suddenly also *demand* Ethereum Sepolia, and a demanded
network with no healthy candidate **fails the job**. `mentions()` now matches on
identifier boundaries, which keeps every real reference (`${SEPOLIA_RPC_URL}`,
`vm.envString("…")`, `NAME=value`) and drops nested ones.

**Part 4 — endpoints that throttle under load are now rejected.** `eth-pokt.nodies.app`
is demoted to last in the ethereum defaults, but the ordering is *not* the fix —
see the contradiction section below for why no static order can be.

The real fix is that health now covers load. Checks 1–3 (chain id, historical
state, historical `eth_call`) are all correctness questions, and an endpoint that
is throttled rather than broken answers every one of them perfectly — then
returns `408 Request timeout on the free plan` the moment `forge` opens real
fork traffic. On 2026-08-20 all three ethereum defaults passed checks 1–3, yet
two of the three are known to collapse under concurrency — pokt from CI (#340's
own evidence), tenderly from the local measurement below. `probe()` now also fires `--burst`
(default 16) simultaneous `eth_call`s, for `--samples` rounds back to back, and
rejects a candidate when a majority of any one round comes back throttled.

- **Rounds, not one burst**, because these endpoints meter a token bucket: the
  first burst after an idle period is served from a full bucket and passes even
  on an endpoint that then collapses.
- **Majority, not any**, because every healthy public endpoint sheds the
  occasional request, and rejecting on one would make the preflight flakier than
  the outage it exists to prevent.
- `--burst 0` disables the check.

Two supporting fixes the burst work uncovered, both from live response bodies:

- `error_fields()` reads the three wire shapes these providers actually send.
  The dangerous one is `{"error":"cu limit exceeded"}` served with **HTTP 200** —
  no JSON-RPC envelope and a success status, so an unhandled body there is
  indistinguishable from a healthy response: the candidate gets **selected** and
  the suite dies later.
- `classify()` puts the plan/quota arm ahead of the archive arm. A free-plan gate
  reads `chain is not available on free plan`, and the archive arm's
  `is not available` needle matches it too — first arm wins, so a billing wall
  was being reported as a pruning node, sending the reader hunting for a deeper
  archive endpoint instead of a paid key.

## Contradiction with the issue text, on purpose

#340 item 4 says to demote pokt below "`mainnet.gateway.tenderly.co` /
`eth.drpc.org`", listing tenderly first. **The order shipped here is `drpc`,
`tenderly`, `pokt`.** The stated requirement — pokt below both — is satisfied;
the tenderly-before-drpc reading of the sentence is not.

The reason is that the two vantage points disagree. #340's evidence is from
GitHub runners, where pokt answers the light probe and then 408s under fork
load. Sustained-load measurement from one non-CI host on 2026-08-20 (60s rest,
then four consecutive bursts of 16) says almost the opposite:

| endpoint                      | round 1 | round 2 | round 3 | round 4 |
| ----------------------------- | ------- | ------- | ------- | ------- |
| `eth.drpc.org`                | 16/16   | 16/16   | 16/16   | 16/16   |
| `eth-pokt.nodies.app`         | 16/16   | 16/16   | 16/16   | 16/16   |
| `mainnet.gateway.tenderly.co` | 15/16   | 0/16    | 14/16   | 1/16    |

Public rate limits are per-IP, so a measurement from one host does not predict a
GitHub runner and vice versa. Neither source is wrong and **no static order can
be right for both.** drpc leads because it is the only endpoint with no evidence
against it from *either* vantage point; tenderly stays ahead of pokt because
#340's demotion rests on the environment that actually matters (CI), even though
tenderly looks worse from here.

This is also precisely why the burst check, not the ordering, is the fix:
whichever candidate is throttled for the runner running right now gets rejected
and failed over. Reorder on CI evidence, not on a local measurement.

## Scope — parts 2 and 3 are not here

Part 2 (migrate `ETH_RPC_URL` readers) and part 3 (retire
`CI_DEPLOY_SEPOLIA_RPC_URL` / `ETH_RPC_URL` / the `CI_FORK_SEPOLIA_*` block) are
consumer-side changes that must land in a specific order, and part 3 cannot be
done until part 2 has. This PR is additive only and changes no existing binding,
so nothing downstream moves when it merges.

The README now marks `CI_DEPLOY_SEPOLIA_RPC_URL` and `ETH_RPC_URL` as legacy and
scheduled for removal, and points new code at `ETHEREUM_RPC_URL` /
`SEPOLIA_RPC_URL`.

## Deferred report — what parts 2 and 3 are actually up against

Re-derived today by shallow-cloning **all 151 org repos** and grepping the full
trees, rather than by code search. That choice changed the answers, so it is
worth stating why: **GitHub code search de-duplicates byte-identical files
across repos**, and this org shares a lot of boilerplate. It returned only 100
of 159 matching workflow files (37% missed) and 60 of 205 lines went unseen —
e.g. `rainix-sol.yaml` is the same file (MD5 `b078e1ad…`) in
`rain.extrospection`, `rain.tofu.erc20-decimals` and `rain.lib.hash`, and only
one copy came back. Any code-search-only count of shared CI boilerplate in this
org is a significant undercount. Three earlier figures are corrected below.

**`CI_FORK_SEPOLIA_*` — nothing reads them, anywhere, including rainix.** They
appear on 8 lines in 4 files and **every one is a setter**; there is no
`vm.env*`, no `env::var`, no shell expansion consuming them in any language in
any repo:

| repo        | file                                       | what it does                       |
| ----------- | ------------------------------------------ | ---------------------------------- |
| rainix      | `.github/workflows/rainix-sol-test.yaml`    | sets from `${{ vars.* }}`          |
| raindex     | `.github/workflows/npm-package-release.yml` | sets from `${{ vars.* }}`          |
| raindex     | `.vscode/settings.json`                     | `rust-analyzer` extraEnv, both `""` |
| rain.uniswap | `.github/workflows/rainix.yaml`            | sets from `${{ vars.* }}` (archived repo) |

The `rain.uniswap` row is one code search missed entirely. So part 3's
retirement is safe — no consumer can break, because there are no consumers —
but it is a **three-repo** cleanup, not a rainix-only one.

**`ETH_RPC_URL` — confirmed, with the exact reader set.** The only code that
reads it is `rain.tofu.erc20-decimals`, in exactly the **5 files under
`test/src/lib/`** the issue named, each doing
`vm.createSelectFork(vm.envString("ETH_RPC_URL"))`:
`LibTOFUTokenDecimals.t.sol:34`, `.decimalsForToken.t.sol:13`,
`.decimalsForTokenReadOnly.t.sol:13`, `.safeDecimalsForToken.t.sol:15`,
`.safeDecimalsForTokenReadOnly.t.sol:15`. (Plus `rainix/flake.nix` itself.)
Everything else — 11 files across 8 repos, now including `rain.dia`,
`rain.chainlink` and `rain.uniswap`, which code search did not surface — only
*sets or forwards* the variable.

That 5 is exact rather than an undercount: tofu's other two fork tests
(`prod.t.sol`, `realTokens.t.sol`) fork *named* endpoints via
`foundry.toml [rpc_endpoints]`, a different mechanism, and they keep passing.

**The causation is direct evidence, not inference.** Across four failing runs
(`31688946758`, `31872802223`, `31872944419`, `32284493892`) the story is
byte-for-byte identical: `ETH_RPC_URL:` and `CI_DEPLOY_SEPOLIA_RPC_URL:` both
empty, `120 passed / 5 failed`, and all five failures are
`[FAIL: vm.createSelectFork: invalid rpc url: ]` — **the failing set is exactly
the `ETH_RPC_URL` reader set.** The last green run (`29418636753`, 2026-07-15)
shows `ETH_RPC_URL: ***` populated and `158 passed / 0 failed`.

Mechanism: `rainix-sol-test.yaml:32` binds `ETH_RPC_URL` solely from
`secrets.CI_DEPLOY_SEPOLIA_RPC_URL || vars.CI_DEPLOY_SEPOLIA_RPC_URL` — a
*deploy* credential — and `rpc-preflight` deliberately covers only
`<NETWORK>_RPC_URL`, so `ETH_RPC_URL` is the one fork input in the org with **no
failover at all**. That is precisely why this PR does not try to route it: the
fix is to move the readers (part 2), not to teach the preflight a legacy name.

Two corrections to the timeline as previously reported:

- **The onset is earlier than 2026-08-13.** That is merely the first *run* after
  the break. Existing issue **#283** records `rainix-sol-artifacts` red since
  **2026-07-24**, same root cause, and attributes it to an org secret/var
  change rather than a code regression.
- **No run on `main` has failed** — nothing has been pushed to main since
  2026-07-15, so the failures are on feature branches. The 2026-08-15
  `ci-baseline-main-probe` run does prove main's tip fails.

**Unpinned `@main` — confirmed, count corrected to 205.** There are **205** real
`uses: rainlanguage/rainix…` lines across **159** workflow/action files in **59**
repos, and **all 205 are `@main`** — zero SHA pins, zero tag pins, zero
exceptions. (Of 228 raw matches, the other 23 are prose: `@v2`/`@v4`/`@<ref>`
examples in markdown and Rust fixtures. The earlier figure of 213 does not
reproduce under any rule tried; it falls between 205 real refs and 228 total
mentions.)

The consequence is the part that matters and it is unchanged: **there is no
version skew to stage behind.** Every edit to a rainix reusable reaches all 59
consumer repos on merge. That is why this PR is strictly additive — a new
network entry, newly forwarded secrets, a stricter probe — and rewires nothing
that already exists. It is also why 2 must precede 3: retiring `ETH_RPC_URL`
before tofu's readers move would red those consumers the moment it lands, with
no pinned ref anywhere to hold the old behaviour.

## QA

- **Discriminating tests:** `plan_gating_is_a_quota_rejection_not_a_pruning_node`, `free_plan_throttle_wording_is_quota`, `error_fields_reads_every_wire_shape_seen_in_the_wild`, `error_fields_never_fires_on_a_healthy_response`, `http_429_is_a_quota_rejection_even_with_an_unparseable_body`, `mentions_requires_identifier_boundaries`, `no_network_name_is_a_whole_word_mention_inside_another`, `demand_scan_finds_only_referenced_networks`, `burst_rejects_only_a_throttled_majority`, `burst_ignores_failures_that_are_not_throttling`, `sepolia_is_modelled_so_its_secret_is_consumed`, `network_table_is_internally_consistent`, `ethereum_prefers_the_endpoints_that_survived_ci` — each fails on base (verified by reverting the specific line it guards and observing that named test go FAILED; the mutation probe below is that verification, 18/20 mutants killed with the killing test named for each).
- **Mutations applied:** `classify` plan needles removed → `free_plan_throttle_wording_is_quota` + `plan_gating_…` (M01); only the `has("free plan")` needle removed → `free_plan_throttle_wording_is_quota` (M02); quota arm moved below the archive arm → both classify tests (M03); `error_fields` bare-string arm removed → `error_fields_reads_every_wire_shape_…` (M04); top-level `{message,code}` arm removed → same (M05); `json.get("result").is_none()` → `true` → `error_fields_never_fires_on_a_healthy_response` (M06); `429 => Quota` arm removed → `http_429_is_a_quota_rejection_…` (M07); `mentions` body → `text.contains(name)` → `mentions_requires_identifier_boundaries` + `no_network_name_…` + `demand_scan_…` (M08); leading boundary → `true` → same three (M09); trailing boundary → `true` → `mentions_requires_identifier_boundaries` (M10); `ident` drops `b'_'` → same three (M11); `throttled.len()*2 > len` → `!throttled.is_empty()` → `burst_rejects_only_a_throttled_majority` + `burst_ignores_…` (M12); `>` → `>=` → `burst_rejects_only_a_throttled_majority` (M13); → `false` → same (M14); `Reason::Quota` filter removed → `burst_ignores_failures_that_are_not_throttling` (M15); sepolia `key`/`env_name` renamed → `network_table_is_internally_consistent` + `sepolia_is_modelled_…` + `no_network_name_…` (M16); sepolia `chain_id` → `84532` → `network_table_…` + `sepolia_is_modelled_…` (M17); pokt restored to first in ethereum defaults → `ethereum_prefers_the_endpoints_that_survived_ci` (M18). **Survived: M19** (burst call deleted from `probe()`) and **M20** (`0..samples` → `0..1`) — both unreachable without a live RPC endpoint; reported, not papered over. See the Mutation probe subsection for the full analysis.
- **Oracle:** live HTTP response bodies captured from the providers themselves on 2026-08-20 (tenderly's `-32005` envelope, 1rpc's bare-string `error` served with HTTP 200, drpc's top-level `{"message":…,"code":30}` at HTTP 408, pokt's free-plan 408 as quoted in #340), plus the RFC meaning of HTTP 429, published chain IDs (Sepolia 11155111 vs Base Sepolia 84532), and the identifier-boundary rule for env var names. Expected values are derived from those sources and from #340's stated requirements — not read back out of this implementation.
- **Category check:** #340 asks for four things — (1) model sepolia so `RPC_URL_SEPOLIA_FORK` is consumed, (2) migrate `ETH_RPC_URL` readers, (3) retire the legacy `CI_DEPLOY_SEPOLIA_RPC_URL` / `ETH_RPC_URL` / `CI_FORK_SEPOLIA_*` block, (4) demote pokt and make the probe heavy enough to catch plan throttling. **Covered: 1 and 4.** Deferred: 2 and 3, because both are consumer-side changes in other repos and 3 is blocked on 2 — see Scope and the Deferred report. Item 4's ordering is satisfied but deliberately not in the issue's literal sequence; see the Contradiction section. The issue's own "not fixable in code" note (`RPC_URL_ETHEREUM_FORK` needs a working value from an org admin) remains outstanding and is unaffected by this PR.

Toolchain gate, all on the committed tree:

| check                                                         | result                                     |
| ------------------------------------------------------------- | ------------------------------------------ |
| `cargo fmt --check`                                            | clean                                      |
| `cargo clippy --all-targets -- -D warnings`                    | clean                                      |
| `cargo test`                                                   | **159 passed**, 0 failed                   |
| `nix build .#rainix-static` (hermetic, `doCheck` runs tests)   | **159 passed**, 0 failed                   |
| `nix develop .` → `fmt --all --check` + `clippy --all-features -D clippy::all` | clean                      |

### Live end-to-end run of the subcommand

`rpc-preflight --samples 1 --burst 8` against rainix's own tree resolved every
network, including the newly modelled one, and exercised the failover path:

```
rpc-preflight: arbitrum: SELECTED default[0] (chain 42161, archive at block 280000000, 1/1 samples)
rpc-preflight: base: default[0] rejected: quota exhausted / rate limited (rpc error -32016)
::warning::rpc-preflight: base fell back to default[1] after 1 unhealthy candidate(s)
rpc-preflight: base: SELECTED default[1] (chain 8453, archive at block 1, 1/1 samples)
rpc-preflight: base_sepolia: SELECTED default[0] (chain 84532, archive at block 38000000, 1/1 samples)
rpc-preflight: flare: SELECTED default[0] (chain 14, archive at block 31000000, 1/1 samples)
rpc-preflight: polygon: SELECTED default[0] (chain 137, archive at block 82000000, 1/1 samples)
rpc-preflight: ethereum: SELECTED default[0] (chain 1, latest, 1/1 samples)
rpc-preflight: sepolia: SELECTED default[0] (chain 11155111, latest, 1/1 samples)
rpc-preflight: hyperevm: SELECTED default[0] (chain 999, latest, 1/1 samples)
rpc-preflight: clean
```

`SEPOLIA_RPC_URL` is exported — the concrete proof of part 1. No candidate URL
is printed, per the existing logging rule.

### Mutation probe

20 hand-written mutants over the new logic, run with
`adversarial-mutation-test#mutation-probe`:

**18/20 killed, 2 survived, 0 harness errors.**

Killed: the plan-needle set and each needle individually (M01–M02); quota-arm
ordering vs the archive arm (M03); all three `error_fields` wire shapes and its
`result` guard (M04–M06); HTTP 429 → quota (M07); every part of the
identifier-boundary scan — substring revert, leading boundary, trailing
boundary, underscore class (M08–M11); the `burst_verdict` decision rule —
over-strict, off-by-one, inert, and the quota filter (M12–M15); the sepolia
table entry and its chain id (M16–M17); and the ethereum default order (M18).

**Survivors, both expected and both reported rather than papered over:**

- **M19 — burst check unwired from `probe()`**
- **M20 — load collapsed to a single round** (`0..samples` → `0..1`)

Both live inside `probe()`, which needs a live RPC endpoint to execute, so no
unit test can reach them. `burst()` and `burst_verdict()` are covered
independently (M12–M15 all die); what is uncovered is specifically the *wiring*
of those two into `probe()`. Closing them honestly needs an HTTP-level fake for
`probe`, which is a larger refactor than this issue warrants — flagged rather
than faked.

One further note, since it changed the result: on its first run M02 was a
harness error, not a pass — its TOML target used a literal `\n` inside a
single-quoted string and so matched nothing. Once fixed it **survived**,
revealing a genuine gap: every existing plan-wording assertion also contained
"upgrade to paid plan", so none of them pinned the `free plan` needle. The
existing test was strengthened in place with `"Request timeout on the free plan"`
(no remedy clause — the exact string `error_fields` is already tested against),
which without that needle falls through to a bare `RpcError`. M02 now dies.

## Note for maintainers — unrelated pre-existing hook bug

The `rustfmt-conditional` pre-commit hook is broken on `main`, independently of
this PR. Its guard `[ -f */Cargo.toml ]` correctly detects
`rainix-static/Cargo.toml`, but it then runs `cargo-fmt fmt` from the repo
**root**, which has no `Cargo.toml`:

```
`cargo metadata` exited with an error: error: could not find `Cargo.toml` in <repo root> or any parent directory
```

Verified on a pristine `d2b3518` worktree with zero local changes, so it blocks
any commit touching a `.rs` file. This commit was made with
`SKIP=rustfmt-conditional`; every other hook ran and passed, and `cargo fmt
--check` was run separately (clean, see QA). Not fixed here — out of scope for
#340, and it belongs in its own PR.


## CI status on this PR — the `rpc-preflight` red is expected

**`rpc-preflight` fails here and will keep failing until this merges.** This is
the same BOOTSTRAP CAVEAT already documented in `test.yml` for the composites,
not a defect in the change.

The self-test job runs
`rainlanguage/rainix/.github/actions/rpc-preflight@main`, and that composite
executes the binary from **its own checkout** — the tip of `main`. Main's
network table has no `sepolia` key (verified: its `NETWORKS` are arbitrum, base,
base_sepolia, ethereum, flare, hyperevm, polygon, nowhere), so the binary that
actually runs cannot export `SEPOLIA_RPC_URL`. Meanwhile the *assert* step comes
from this branch's `test.yml`, which now requires it. Old action, new assertion:

```
rpc-preflight: arbitrum: SELECTED secret[0] (chain 42161, archive at block 280000000, 3/3 samples)
... 7 networks, no sepolia line at all ...
rpc-preflight: clean
##[error]rpc-preflight did not export SEPOLIA_RPC_URL
```

There is no on-branch fix that is not a regression — `./` would resolve the
composite's internal refs against the consumer repo, and a branch pin dangles
once the branch is deleted. It goes green the moment `@main` contains the
sepolia entry, i.e. on merge.

Two consequences worth stating plainly rather than leaving to be discovered:

- **The burst check has not executed on a real GitHub runner yet.** The job that
  would exercise it ran main's binary. It is covered by unit tests (M12–M15) and
  by the local end-to-end run above, but its behaviour against CI's per-IP rate
  limits is unproven until this lands. If the ethereum or sepolia defaults are
  throttled from Actions' address space, the first post-merge run is where that
  shows up — which is the intended signal, but it is a signal, not a guarantee.
- `ethereum: SELECTED secret[0]` in that same log means `RPC_URL_ETHEREUM_FORK`
  now holds a working value on CI. #340 recorded it being rejected
  (`secret[0] rejected: rpc error 30`); whatever the admin-side fix was, that
  half of the issue appears resolved independently of this PR.

The other red, `rainix-sol-artifacts`, was an infrastructure flake in the
`nix-quick-install` setup step (`zstd: unexpected end of file` on a truncated
archive download) and has been retriggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Sepolia RPC configuration support across automated validation and release workflows.
  - Added configurable RPC load checks with concurrent request bursts; checks can be disabled when needed.
  - Improved detection of throttling, quota failures, and varied RPC error responses.
  - Added support for repeated sampling to identify unreliable or rate-limited endpoints.

- **Bug Fixes**
  - Improved network-demand detection to prevent false matches.
  - Enhanced RPC preflight validation for Sepolia and Ethereum endpoints.

- **Documentation**
  - Updated RPC configuration guidance, deprecated variable names, load-check behavior, and rate-limit handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->