### PR TITLE
fix(tag-release): determinism check that never removes the frozen record

### DIFF
--- a/.github/actions/frozen-snapshots-append-only/action.yml
+++ b/.github/actions/frozen-snapshots-append-only/action.yml
@@ -1,6 +1,6 @@
 name: frozen-snapshots-append-only
 description: >-
-  Fails when a branch modifies or deletes an existing per-tag deploy-pin snapshot under src/generated/<tag>/ (tag = three underscore-separated numbers, e.g. 0_1_4). These snapshots are frozen once on the base branch — downstream consumers pin the address/codehash constants they hold, so a release ADDS a new tag (bump the version), never edits an existing snapshot. No-op for repos with no such snapshots.
+  Fails when a branch modifies or deletes an existing per-tag deploy-pin snapshot under src/generated/<tag>/ (tag = three underscore-separated numbers, e.g. 0_1_4). These snapshots are frozen once on the base branch — downstream consumers pin the address/codehash constants they hold, so a release ADDS a new tag (bump the version), never edits an existing snapshot. No-op for a repo that carries no src/generated/ record at all.
 runs:
   using: composite
   steps:
@@ -8,9 +8,25 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        # Nothing to enforce if the repo has no per-tag snapshots.
-        if ! ls src/generated/*/*.pointers.sol >/dev/null 2>&1; then
-          echo "snapshots-append-only: no per-tag snapshots; skip"
+        # Nothing to enforce if the repo carries no generated record at all — a
+        # library repo, which has no per-tag deploy-pin snapshots. A presence test
+        # on ONE directory, deliberately: the `src/generated/*/*.pointers.sol`
+        # glob this replaces asserted a FILENAME inside the record, and no deploy
+        # repo has ever written that name (frozen records are
+        # `src/generated/<tag>/<Name>.sol`), so the gate skipped silently in
+        # exactly the repos it exists for — a no-op org-wide
+        # (rainlanguage/rainix#341). Which entries under the root are releases is
+        # the Rust check's call, via the same `is_tag` the release guard uses; bash
+        # only decides whether there is a record to look at.
+        #
+        # A branch that deletes the ENTIRE src/generated/ tree still skips here.
+        # Distinguishing that from a repo that never had one needs the BASE branch,
+        # which is what the fetch below exists to get — so closing it would mean
+        # fetching in every sol repo in the org, including the ones whose default
+        # branch is not `main`. Left as is, narrowly: deleting one frozen snapshot,
+        # or the tag dir holding it, is caught.
+        if [ ! -d src/generated ]; then
+          echo "snapshots-append-only: no generated record; skip"
           exit 0
         fi
         # The three-dot diff needs the merge-base with the base branch, but the

--- a/.github/actions/frozen-snapshots-append-only/action.yml
+++ b/.github/actions/frozen-snapshots-append-only/action.yml
@@ -11,13 +11,19 @@ runs:
         # Nothing to enforce if the repo carries no generated record at all — a
         # library repo, which has no per-tag deploy-pin snapshots. A presence test
         # on ONE directory, deliberately: the `src/generated/*/*.pointers.sol`
-        # glob this replaces asserted a FILENAME inside the record, and no deploy
-        # repo has ever written that name (frozen records are
-        # `src/generated/<tag>/<Name>.sol`), so the gate skipped silently in
-        # exactly the repos it exists for — a no-op org-wide
-        # (rainlanguage/rainix#341). Which entries under the root are releases is
-        # the Rust check's call, via the same `is_tag` the release guard uses; bash
-        # only decides whether there is a record to look at.
+        # glob this replaces asserted a FILENAME inside the record, and no repo in
+        # the org writes that name today (frozen records are
+        # `src/generated/<tag>/<Name>.sol`), so the gate skips silently in exactly
+        # the repos it exists for — a no-op org-wide (rainlanguage/rainix#341).
+        # It was not always unmatched, and the history is the sharper argument:
+        # rain.factory.deploy carried src/generated/0_1_{3,4,5}/CloneFactory.pointers.sol
+        # from its genesis commit until 39d1cfd (2026-08-20) renamed the scheme,
+        # and that PR deleted all three while this gate reported success — the
+        # skip test reads the HEAD tree, so a branch removing every snapshot
+        # switches off the check that would have caught the removal.
+        # Which entries under the root are releases is the Rust check's call, via
+        # the same `is_tag` the release guard uses; bash only decides whether
+        # there is a record to look at.
         #
         # A branch that deletes the ENTIRE src/generated/ tree still skips here.
         # Distinguishing that from a repo that never had one needs the BASE branch,

--- a/.github/workflows/rainix-tag-release.yaml
+++ b/.github/workflows/rainix-tag-release.yaml
@@ -38,8 +38,10 @@ name: rainix-tag-release
 #   3. A human merges the PR (normal protected-merge) and pushes a
 #      `sol-v<version>` tag on the merged commit.
 #   4. This workflow runs on that tag: it re-derives the version from the tag,
-#      re-runs the snapshot generator to prove the tagged commit's snapshot is a
-#      fresh deterministic regeneration (the fail-closed publish guard below),
+#      re-runs the repo's NON-freezing generator and requires both a clean tree
+#      and a frozen snapshot byte-identical to the regenerated rolling one, to
+#      prove the tagged commit's snapshot is a fresh deterministic regeneration
+#      (the fail-closed publish guard below),
 #      re-attests the live chain matches the pins, then publishes to Soldeer and
 #      creates the GitHub release. main already carries the snapshot (from the
 #      merged PR), so the daily drift sweep and the repo's own snapshot tests keep
@@ -76,12 +78,6 @@ on:
         required: false
         type: string
         default: sol-v
-      snapshot-generate-cmd:
-        description: >-
-          Command that cuts the release: it regenerates the rolling `src/generated/candidate/` pins from the current source and freezes a copy of them as `src/generated/<tag>/`, in that order and in one call, then formats. `BuildScript.cutRelease()` is that call, so the default is the whole of it for a deploy repo whose `script/Build.sol` extends `BuildScript` and such a repo passes nothing. Run after `[package].version` is set to the release version, so the tag the freeze derives from it is the one being released.
-        required: false
-        type: string
-        default: 'forge script ./script/Build.sol --sig "cutRelease()" && forge fmt'
       test-cmd:
         description: >-
           Pre-publish verification gate. Run against the regenerated snapshot; for a deploy repo this is the fork suite that reads the live chain and asserts it matches the fresh pins, so a release that snapshots addresses the chain does not actually carry fails loud BEFORE publishing. Default `forge test`.
@@ -238,48 +234,70 @@ jobs:
         # candidate that is healthy right now, which a static one-URL mapping
         # cannot do.
         run: nix develop github:rainlanguage/rainix/${{ env.RAINIX_SHA }}#sol-shell -c bash -c '${{ inputs.test-cmd }}'
-      - name: Regenerate the release snapshot (read-only determinism check)
+      - name: Regenerate the generated sources (read-only determinism check)
         # Option A lands the frozen src/generated/<version>/ snapshot on main via a
         # reviewed PR; this workflow does NOT cut it. To prove the tagged commit
-        # carries a snapshot that IS a fresh deterministic regeneration — not stale,
-        # hand-edited, or never cut — regenerate it here and let the publish guard
-        # below require a clean tree. The generator freezes a NEW <version>/ dir and
-        # may refuse to overwrite an existing one (e.g. cut-release.sh), so remove
-        # the committed dir first; git still holds it, and the guard checks presence
-        # against HEAD and diffs the regenerated tree against HEAD. Nothing is
-        # committed or pushed — the runner tree is thrown away. Deterministic from
-        # bytecode (address = f(bytecode) under CREATE2), so no chain access here;
-        # the on-chain attestation is the fork suite above.
+        # carries a snapshot that IS a fresh deterministic regeneration — not
+        # stale, hand-edited, or never cut — regenerate everything the repo
+        # generates here and let the publish guard below require BOTH a clean tree
+        # and a frozen release byte-identical to the regenerated rolling snapshot.
+        #
+        # This regenerates WITHOUT freezing and removes NOTHING
+        # (rainlanguage/rainix#341). The old check `rm -rf`'d
+        # src/generated/<version>/ first, because a generator may refuse to
+        # overwrite a frozen dir (rain.deploy's freeze reverts
+        # SnapshotAlreadyFrozen). But a deploy repo's generated released-suites lib
+        # IMPORTS every frozen record — LibCloneFactoryReleased.sol imports
+        # ../generated/0_1_9/CloneFactory.sol — so removing the directory makes the
+        # tree uncompilable and the generator that was meant to re-create it cannot
+        # run at all. No such repo could ever release.
+        #
+        # `forge script ./script/Build.sol` runs the NON-freezing `run()` entry
+        # point: the exact regeneration rainix-copy-artifacts currency-checks every
+        # PR with, so the release-time and PR-time checks prove the same thing
+        # about the same command. It is not a caller input for that reason — a
+        # per-repo override there is how the freezing form got wired in.
+        #
+        # The guarantee is unchanged, and checked more directly: a freeze COPIES
+        # the rolling snapshot verbatim, so "the frozen record equals the freshly
+        # regenerated candidate" IS "a freeze run right now writes these bytes".
+        #
+        # Nothing is committed or pushed — the runner tree is thrown away.
+        # Deterministic from bytecode (address = f(bytecode) under CREATE2), so no
+        # chain access here; the on-chain attestation is the fork suite above.
         #
         # This runs AFTER the fork suite (test-cmd), immediately before publish, so
         # the guard's clean-tree check covers any tracked file the suite may have
         # touched too — nothing runs between the guard and `forge soldeer push`, so
         # what publishes is exactly what the guard verified.
-        env:
-          # Via env, not interpolated into the script body: a workflow input
-          # spliced into `run:` text is a template-injection surface. The
-          # expansion is one word, which bash then reads as the script.
-          SNAPSHOT_GENERATE_CMD: ${{ inputs.snapshot-generate-cmd }}
-        # `set -euo pipefail` so a command written as `a; b` cannot hide a's
-        # failure behind b's success.
         run: |
           set -euo pipefail
-          # VERSION is validated strict X.Y.Z above, so DIR is [0-9_]+.
-          DIR="${VERSION//./_}"
-          rm -rf "src/generated/${DIR}"
-          nix develop github:rainlanguage/rainix/${{ env.RAINIX_SHA }}#sol-shell -c bash -c "set -euo pipefail; $SNAPSHOT_GENERATE_CMD"
+          # The codegen script is script/Build.sol, matched exactly — the same
+          # contract rainix-copy-artifacts holds every repo to. A repo that renamed
+          # or dropped it goes red rather than skipping the regeneration and
+          # leaving the guard to verify a tree nothing regenerated.
+          if [ ! -f script/Build.sol ]; then
+            echo "::error::script/Build.sol not found, so the release snapshot cannot be determinism checked. The codegen script must be script/Build.sol." >&2
+            exit 1
+          fi
+          nix develop github:rainlanguage/rainix/${{ env.RAINIX_SHA }}#sol-shell -c bash -c 'set -euo pipefail; forge script ./script/Build.sol && forge fmt'
       - name: Publish guard (fail-closed)
         # The point of the push-free change: refuse to publish a tag whose commit
         # did not actually cut this release's snapshot. Runs immediately before
-        # publish so what it verifies is what publishes. All three must hold or the
-        # release fails loud and publishes NOTHING — foundry.toml [package].version
-        # == the tag version; src/generated/<version>/ present in the tagged commit;
-        # and the regeneration above changed nothing (git status clean → the
-        # committed snapshot is a deterministic regeneration, not stale/hand-edited,
-        # and the fork suite left no tracked file dirty). Logic is Rust (rainix-static
-        # release-guard), unit-tested and mutation-covered; the append-only gate ran
-        # at PR time (rainix-sol-static). VERSION comes from $GITHUB_ENV, never a
-        # ${{ }} splice, so it cannot inject into the command.
+        # publish so what it verifies is what publishes. Every invariant must hold
+        # or the release fails loud and publishes NOTHING — foundry.toml
+        # [package].version == the tag version; src/generated/<version>/ present in
+        # the tagged commit; no LATER release already frozen (the append-only
+        # record's monotonicity, which cutRelease() used to enforce at tag time);
+        # the regeneration above changed nothing (git status clean → every
+        # generated file is what this source regenerates to, and the fork suite
+        # left no tracked file dirty); and src/generated/<version>/ is
+        # byte-identical to the freshly regenerated src/generated/candidate/ →
+        # the frozen release is exactly what freezing it now would write, so
+        # stale, hand-edited and never-cut all fail here. Logic is Rust
+        # (rainix-static release-guard), unit-tested and mutation-covered; the
+        # append-only gate ran at PR time (rainix-sol-static). VERSION comes from
+        # $GITHUB_ENV, never a ${{ }} splice, so it cannot inject into the command.
         run: nix develop github:rainlanguage/rainix/${{ env.RAINIX_SHA }}#sol-shell -c rainix-static release-guard --version "$VERSION"
       - name: Publish to Soldeer
         # Pushes the working tree — the tagged commit's tree, whose snapshot the

--- a/README.md
+++ b/README.md
@@ -147,7 +147,10 @@ Solidity artifacts from source and asserts `git diff --exit-code` — failing th
 PR if a maintainer changed source without committing the regenerated files. In a
 single job it runs whichever of these the repo has:
 
-- `./script/BuildPointers.sol` → `src/generated/*.pointers.sol`
+- `./script/Build.sol` → `src/generated/` (the rolling `candidate/` deploy pins,
+  plus the alias and released-suites libs generated from the record). The same
+  regeneration `rainix-tag-release` re-runs at publish time to prove the tagged
+  commit's frozen snapshot is a fresh one.
 - `forge build` + `./script/CopyArtifacts.sol --ffi` → committed ABI JSON
 
 then `forge fmt` and the `git diff` assert.

--- a/flake.nix
+++ b/flake.nix
@@ -448,6 +448,7 @@
             bats test/bats/devshell/default/prettier-bundle.test.bats
             bats test/bats/action/rpc-preflight.test.bats
             bats test/bats/action/prompt-cap.test.bats
+            bats test/bats/action/frozen-snapshots-append-only.test.bats
             bats test/bats/task/skip-simulation.test.bats
             bats test/bats/task/subgraph-build.test.bats
             bats test/bats/task/subgraph-deploy-version.test.bats

--- a/rainix-static/src/frozen_snapshots.rs
+++ b/rainix-static/src/frozen_snapshots.rs
@@ -112,17 +112,17 @@ mod tests {
     fn snapshot_paths() {
         let root = "src/generated";
         assert!(is_snapshot(
-            "src/generated/0_1_4/CloneFactory.pointers.sol",
+            "src/generated/0_1_4/CloneFactory.sol",
             root
         ));
         assert!(is_snapshot(
-            "src/generated/0_1_10/StoxReceipt.pointers.sol",
+            "src/generated/0_1_10/StoxReceipt.sol",
             root
         ));
         // the mutable current-pin libs live directly under root, not in a tag dir
         assert!(!is_snapshot("src/generated/LibProdDeployCurrent.sol", root));
         assert!(!is_snapshot(
-            "src/generated/CloneFactory.pointers.sol",
+            "src/generated/CloneFactory.sol",
             root
         ));
         // a bare tag dir (no file) is not a snapshot file
@@ -135,23 +135,23 @@ mod tests {
     #[test]
     fn flags_only_modified_or_deleted_snapshots() {
         let root = "src/generated";
-        let diff = "A\tsrc/generated/0_1_5/CloneFactory.pointers.sol\n\
-                    M\tsrc/generated/0_1_4/CloneFactory.pointers.sol\n\
-                    D\tsrc/generated/0_1_3/CloneFactory.pointers.sol\n\
+        let diff = "A\tsrc/generated/0_1_5/CloneFactory.sol\n\
+                    M\tsrc/generated/0_1_4/CloneFactory.sol\n\
+                    D\tsrc/generated/0_1_3/CloneFactory.sol\n\
                     M\tsrc/generated/LibProdDeployCurrent.sol\n\
                     M\tsrc/lib/LibCloneFactoryDeploy.sol\n";
         let off = parse_offenders(diff, root);
         assert_eq!(off.len(), 2);
         assert!(off[0]
-            .contains("modified frozen snapshot src/generated/0_1_4/CloneFactory.pointers.sol"));
+            .contains("modified frozen snapshot src/generated/0_1_4/CloneFactory.sol"));
         assert!(off[1]
-            .contains("deleted frozen snapshot src/generated/0_1_3/CloneFactory.pointers.sol"));
+            .contains("deleted frozen snapshot src/generated/0_1_3/CloneFactory.sol"));
     }
 
     #[test]
     fn clean_when_only_adding_a_new_tag() {
         let root = "src/generated";
-        let diff = "A\tsrc/generated/0_1_5/CloneFactory.pointers.sol\n\
+        let diff = "A\tsrc/generated/0_1_5/CloneFactory.sol\n\
                     M\tsrc/generated/LibProdDeployCurrent.sol\n";
         assert!(parse_offenders(diff, root).is_empty());
     }

--- a/rainix-static/src/main.rs
+++ b/rainix-static/src/main.rs
@@ -61,10 +61,16 @@
 //       Fail-closed publish guard for rainix-tag-release's push-free deploy flow:
 //       refuse to publish a tag whose commit did not actually cut this release's
 //       snapshot. Verifies foundry.toml's [package].version equals the tag
-//       version, that <root>/<version>/ (dots→underscores) exists in the tagged
-//       commit, and — after the caller re-runs the snapshot generator on the tree
-//       — that `git status` is empty (the committed snapshot is a deterministic
-//       regeneration, not stale/hand-edited). Runs where git is on PATH.
+//       version; that <root>/<version>/ (dots→underscores) exists in the tagged
+//       commit and no LATER release is already frozen beside it; and — after the
+//       caller re-runs the repo's NON-freezing generator on the tree — that
+//       `git status` is empty AND <root>/<version>/ is byte-identical to the
+//       freshly regenerated <root>/candidate/. A freeze copies the rolling
+//       snapshot verbatim, so an equal record is exactly what freezing now would
+//       write: stale, hand-edited and never-cut all fail. The frozen dir is never
+//       removed — a deploy repo's generated released-suites lib imports it, so
+//       removing it makes the tree uncompilable (rainlanguage/rainix#341). Runs
+//       where git is on PATH.
 
 mod agent_context_cap;
 mod context_bytes;

--- a/rainix-static/src/release_guard.rs
+++ b/rainix-static/src/release_guard.rs
@@ -528,12 +528,12 @@ mod tests {
     #[test]
     fn dirty_offenders_lists_every_change() {
         // A modified frozen snapshot and an untracked new file both count.
-        let porcelain = " M src/generated/0_1_5/CloneFactory.pointers.sol\n\
-                          ?? src/generated/0_1_5/Extra.pointers.sol\n";
+        let porcelain = " M src/generated/0_1_5/CloneFactory.sol\n\
+                          ?? src/generated/0_1_5/Extra.sol\n";
         let off = dirty_offenders(porcelain);
         assert_eq!(off.len(), 2);
-        assert!(off[0].contains("0_1_5/CloneFactory.pointers.sol"));
-        assert!(off[1].contains("0_1_5/Extra.pointers.sol"));
+        assert!(off[0].contains("0_1_5/CloneFactory.sol"));
+        assert!(off[1].contains("0_1_5/Extra.sol"));
     }
 
     // ---- tag_dirs -----------------------------------------------------

--- a/rainix-static/src/release_guard.rs
+++ b/rainix-static/src/release_guard.rs
@@ -8,7 +8,7 @@
 //! freshly-cut snapshot for this version — a mistag, a stale PR, or a hand-edited
 //! snapshot would otherwise publish silently. This guard closes that hole: run
 //! immediately before `forge soldeer push`, it fails loud (publishing NOTHING)
-//! unless all three hold on the tagged commit:
+//! unless all of the following hold on the tagged commit.
 //!
 //!   1. Version identity — `foundry.toml`'s first `version = "…"` (the
 //!      `[package].version` the old flow used to write from the tag) equals the
@@ -17,22 +17,58 @@
 //!   2. Snapshot present — `src/generated/<version>/` exists in the tagged commit
 //!      (`<version>` with `.` → `_`, matching the frozen-snapshot dir convention).
 //!      A missing dir means this version was never cut/frozen.
-//!   3. Snapshot is a deterministic regeneration — the caller re-runs the repo's
-//!      `snapshot-generate-cmd` on the tagged tree (having first removed the
-//!      target dir, because a generator may refuse to overwrite a frozen dir),
-//!      then this guard requires `git status --porcelain` to be empty: any change
-//!      means the committed snapshot is stale, hand-edited, or was never
-//!      regenerated for this commit. Deterministic-from-bytecode, so no chain
-//!      access is needed; the on-chain attestation is a separate step.
+//!   3. The release follows the record — no LARGER tag is already frozen. A
+//!      release is appended to an append-only record, so re-tagging a version the
+//!      record has already moved past is not a release. `cutRelease()` refused
+//!      this at tag time (`NonMonotonicRelease`) back when the workflow re-cut the
+//!      snapshot; the guard is where that invariant lives now.
+//!   4. Snapshot is a deterministic regeneration. Two facts together, because a
+//!      release freeze is a COPY of the rolling snapshot: rain.deploy's `freeze`
+//!      writes `<tag>/` from the bytes it just regenerated into `candidate/` and
+//!      reads back off disk, so "the record matches the candidate" is what being
+//!      freshly cut MEANS. So:
+//!        a. the caller re-runs the repo's generator on the tagged tree (the
+//!           NON-freezing entry point — `forge script ./script/Build.sol`, the same
+//!           regeneration `rainix-copy-artifacts` currency-checks with) and this
+//!           guard requires `git status --porcelain` to be empty. That proves the
+//!           rolling `candidate/` snapshot and every file generated from it — the
+//!           alias libs, the released-suites libs — are what the tagged source
+//!           regenerates to.
+//!        b. `<root>/<version>/` is byte-identical to `<root>/candidate/`. That
+//!           proves the frozen record is exactly what a freeze run right now would
+//!           write. Stale, hand-edited or never-cut all fail here.
+//!
+//! (4) deliberately does NOT remove `<root>/<version>/` and re-freeze it
+//! (rainlanguage/rainix#341). A deploy repo's generated released-suites lib
+//! IMPORTS every frozen record — `LibCloneFactoryReleased.sol` imports
+//! `../generated/0_1_9/CloneFactory.sol` — so deleting the directory makes the
+//! tree uncompilable and the generator that was supposed to re-create it cannot
+//! run at all. Comparing the record against the freshly regenerated candidate
+//! proves the same thing without ever mutating the tree, and proves it more
+//! directly: it checks the bytes rather than re-running the copy that produced
+//! them.
+//!
+//! Deterministic-from-bytecode (address = f(bytecode) under CREATE2), so no chain
+//! access is needed here; the on-chain attestation is a separate step.
 //!
 //! The version/dir checks read the tagged commit via git (`HEAD`), independent of
-//! the working-tree regeneration; the determinism check reads the working tree
-//! after regeneration. The decisions live in the small pure functions below so
-//! they are unit-tested and mutation-covered; `run` only wires git and the
-//! filesystem to them.
+//! the working-tree regeneration; the determinism checks read the working tree
+//! after regeneration, which the clean-tree check has just pinned to `HEAD`. The
+//! decisions live in the small pure functions below so they are unit-tested and
+//! mutation-covered; `run` only wires git and the filesystem to them.
 
 use crate::fail;
+use crate::frozen_snapshots::is_tag;
+use std::cmp::Ordering;
+use std::collections::BTreeMap;
+use std::path::Path;
 use std::process::Command;
+
+/// The rolling snapshot directory a release is frozen FROM, under the record
+/// root — rain.deploy's `LibRainDeploySnapshot.CANDIDATE`. It is regenerated
+/// from source on every build, so it is the fresh side of the determinism
+/// comparison while `<tag>/` is the frozen side.
+pub(crate) const CANDIDATE: &str = "candidate";
 
 /// True iff `v` is a strict `MAJOR.MINOR.PATCH` where each part is one or more
 /// ASCII digits. Anything else (pre-release suffixes, extra components, empty
@@ -92,22 +128,150 @@ pub(crate) fn foundry_version(content: &str) -> Option<String> {
     None
 }
 
-/// True iff `git ls-tree HEAD -- <dir>` listed anything, i.e. the directory
-/// exists in the tagged commit. Empty output means it does not.
-pub(crate) fn dir_present(ls_tree_output: &str) -> bool {
-    !ls_tree_output.trim().is_empty()
+/// The release-tag directory names sitting DIRECTLY under `root` in the tagged
+/// commit, from `git ls-tree --name-only HEAD -- <root>/` (which prints one
+/// `<root>/<entry>` line per entry, and nothing at all when the commit carries
+/// no such path).
+///
+/// Filtered through `frozen_snapshots::is_tag`, so what counts as a release here
+/// is what the append-only gate counts as one — the rolling `candidate/` dir and
+/// any loose file under the root are not releases, and one rule decides that for
+/// both.
+pub(crate) fn tag_dirs(ls_tree_names: &str, root: &str) -> Vec<String> {
+    ls_tree_names
+        .lines()
+        .filter_map(|line| {
+            let entry = line.trim().strip_prefix(root)?.strip_prefix('/')?;
+            // `is_tag` also settles depth: every part of a tag is all-digits, so
+            // a path separator anywhere in the entry fails it. A file INSIDE a
+            // tag dir is therefore not itself a tag dir, and needs no separate
+            // check to say so.
+            if !is_tag(entry) {
+                return None;
+            }
+            Some(entry.to_string())
+        })
+        .collect()
 }
 
-/// Working-tree changes reported by `git status --porcelain` as offender lines.
-/// Any non-blank line is a change (modified, added, deleted, or untracked); an
-/// empty result means the tree is clean. `.git/info/exclude` already hides the
-/// devShell's generated `.pre-commit-config.yaml`, so it never appears here.
-pub(crate) fn dirty_offenders(porcelain: &str) -> Vec<String> {
-    porcelain
-        .lines()
-        .filter(|l| !l.trim().is_empty())
-        .map(str::to_string)
+/// Numeric ordering of two all-digit strings, without parsing them into a
+/// fixed-width integer.
+///
+/// The tag-prefix check upstream admits any run of digits, so a version
+/// component can be longer than `u64`/`u128` holds; parsing would overflow or
+/// panic inside a publish guard. Once leading zeros are gone, more digits is
+/// strictly larger and equal digit counts order lexicographically, which is
+/// exact for any length.
+fn digits_cmp(a: &str, b: &str) -> Ordering {
+    let a = a.trim_start_matches('0');
+    let b = b.trim_start_matches('0');
+    a.len().cmp(&b.len()).then_with(|| a.cmp(b))
+}
+
+/// Release ordering of two `_`-separated tag names: most significant component
+/// first, each compared numerically.
+fn tag_cmp(a: &str, b: &str) -> Ordering {
+    let ap: Vec<&str> = a.split('_').collect();
+    let bp: Vec<&str> = b.split('_').collect();
+    for (x, y) in ap.iter().zip(bp.iter()) {
+        match digits_cmp(x, y) {
+            Ordering::Equal => continue,
+            other => return other,
+        }
+    }
+    ap.len().cmp(&bp.len())
+}
+
+/// Every tag in `tags` that is a LATER release than `dir` — the releases this
+/// one would have to be appended in front of. Empty means `dir` is the newest
+/// frozen release, which is the only thing a tag may publish.
+pub(crate) fn newer_tags(tags: &[String], dir: &str) -> Vec<String> {
+    tags.iter()
+        .filter(|t| tag_cmp(t, dir) == Ordering::Greater)
+        .cloned()
         .collect()
+}
+
+/// Every way the frozen record differs from what a fresh regeneration produced.
+/// Empty means the frozen release IS the current regeneration, byte for byte.
+///
+/// A freeze copies the rolling snapshot verbatim, so an equal record is exactly
+/// what freezing right now would write. Both directions are checked (a file only
+/// one side holds is a difference), and an EMPTY candidate is flagged rather than
+/// silently matching an empty record: two empty directories compare equal, and a
+/// release with no record is not a release.
+pub(crate) fn record_mismatches(
+    frozen: &BTreeMap<String, Vec<u8>>,
+    candidate: &BTreeMap<String, Vec<u8>>,
+    frozen_dir: &str,
+    candidate_dir: &str,
+) -> Vec<String> {
+    let mut out = Vec::new();
+    if candidate.is_empty() {
+        out.push(format!(
+            "{candidate_dir}/ holds no files — the generator regenerated nothing, so there is \
+             nothing to check the frozen release against"
+        ));
+    }
+    if frozen.is_empty() {
+        out.push(format!(
+            "{frozen_dir}/ holds no files — a release with an empty record is not a release"
+        ));
+    }
+    for (name, bytes) in frozen {
+        match candidate.get(name) {
+            None => out.push(format!(
+                "{frozen_dir}/{name} is in the frozen release but a fresh regeneration does not \
+                 produce it"
+            )),
+            Some(fresh) if fresh != bytes => out.push(format!(
+                "{frozen_dir}/{name} differs from the freshly regenerated {candidate_dir}/{name}"
+            )),
+            Some(_) => {}
+        }
+    }
+    for name in candidate.keys() {
+        if !frozen.contains_key(name) {
+            out.push(format!(
+                "{candidate_dir}/{name} is freshly regenerated but the frozen release does not \
+                 hold it"
+            ));
+        }
+    }
+    out
+}
+
+/// Every file under `dir`, keyed by its path relative to `dir`. `None` when
+/// `dir` does not exist. Recursive, so a record that grows a subdirectory is
+/// compared rather than ignored.
+fn read_record(dir: &Path) -> Option<BTreeMap<String, Vec<u8>>> {
+    if !dir.is_dir() {
+        return None;
+    }
+    let mut out = BTreeMap::new();
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(current) = stack.pop() {
+        let entries = std::fs::read_dir(&current)
+            .unwrap_or_else(|e| fail(&format!("release-guard: cannot read {}: {e}", current.display())));
+        for entry in entries {
+            let path = entry
+                .unwrap_or_else(|e| fail(&format!("release-guard: cannot read {}: {e}", current.display())))
+                .path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            let rel = path
+                .strip_prefix(dir)
+                .unwrap_or(&path)
+                .to_string_lossy()
+                .into_owned();
+            let bytes = std::fs::read(&path)
+                .unwrap_or_else(|e| fail(&format!("release-guard: cannot read {}: {e}", path.display())));
+            out.insert(rel, bytes);
+        }
+    }
+    Some(out)
 }
 
 /// Run a git command and return its stdout; fail loud (with stderr) on spawn
@@ -126,6 +290,15 @@ fn git_stdout(args: &[&str]) -> String {
         ));
     }
     String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+/// Print every offender under one `::error::` headline and exit nonzero.
+fn fail_with(headline: &str, offenders: &[String]) -> ! {
+    eprintln!("::error::{headline}");
+    for o in offenders {
+        eprintln!("  {o}");
+    }
+    std::process::exit(1);
 }
 
 /// The publish guard. `version` is the tag's version, `root` the snapshot root
@@ -156,38 +329,90 @@ pub(crate) fn run(version: &str, root: &str, foundry: &str) {
         Some(_) => {}
     }
 
-    // 2. Snapshot present in the tagged commit (read via HEAD, not the
-    //    regenerated working tree, so a dir the generator just recreated cannot
-    //    hide a commit that never carried it).
+    // 2/3. The record as the TAGGED COMMIT carries it, read via HEAD rather than
+    //      the working tree, so nothing the regeneration wrote can stand in for a
+    //      commit that never carried it.
     let dir = version_dir(version);
     let path = format!("{root}/{dir}");
-    let listed = git_stdout(&["ls-tree", "HEAD", "--", &path]);
-    if !dir_present(&listed) {
+    let frozen_tags = tag_dirs(&git_stdout(&["ls-tree", "--name-only", "HEAD", "--", &format!("{root}/")]), root);
+    if !frozen_tags.iter().any(|t| *t == dir) {
         fail(&format!(
             "release-guard: {path}/ is not present in the tagged commit — this version was \
              never cut/frozen; land the snapshot in a PR before tagging"
         ));
     }
-
-    // 3. Deterministic regeneration: the caller already re-ran the generator on
-    //    the tagged tree; any working-tree change means the committed snapshot is
-    //    not what a fresh regeneration produces (stale, hand-edited, or never cut
-    //    for this commit).
-    let porcelain = git_stdout(&["status", "--porcelain", "--untracked-files=all"]);
-    let offenders = dirty_offenders(&porcelain);
-    if !offenders.is_empty() {
-        eprintln!(
-            "::error::release-guard: re-running the snapshot generator changed the tree — the \
-             committed snapshot for {version} is stale, hand-edited, or was never regenerated for \
-             this commit. Regenerate it in a PR and re-tag the merged commit. Offending paths:"
+    let newer = newer_tags(&frozen_tags, &dir);
+    if !newer.is_empty() {
+        fail_with(
+            &format!(
+                "release-guard: {root}/ already holds a release later than {version} — the record \
+                 is append-only, so a tag may only publish its newest release. Later releases:"
+            ),
+            &newer,
         );
-        for o in offenders {
-            eprintln!("  {o}");
-        }
-        std::process::exit(1);
     }
 
-    println!("release-guard: clean — {foundry} version, {path}/ present, snapshot deterministic");
+    // 4a. The caller re-ran the repo's NON-freezing generator on the tagged tree.
+    //     Any working-tree change means the tagged source does not regenerate to
+    //     the files the commit carries. This runs BEFORE the record comparison
+    //     below, because a clean tree is what makes the on-disk record equal to
+    //     the one in the tagged commit.
+    let porcelain = git_stdout(&["status", "--porcelain", "--untracked-files=all"]);
+    let dirty = dirty_offenders(&porcelain);
+    if !dirty.is_empty() {
+        fail_with(
+            &format!(
+                "release-guard: re-running the snapshot generator changed the tree — the tagged \
+                 commit's generated files are not what {version}'s source regenerates to. \
+                 Regenerate them in a PR and re-tag the merged commit. Offending paths:"
+            ),
+            &dirty,
+        );
+    }
+
+    // 4b. The frozen release is byte-identical to the rolling snapshot that was
+    //     just regenerated, which is precisely what freezing it now would write.
+    let candidate_path = format!("{root}/{CANDIDATE}");
+    let frozen = read_record(Path::new(&path)).unwrap_or_else(|| {
+        fail(&format!(
+            "release-guard: {path}/ is in the tagged commit but not on disk — the working tree \
+             must carry the release being published"
+        ))
+    });
+    let candidate = read_record(Path::new(&candidate_path)).unwrap_or_else(|| {
+        fail(&format!(
+            "release-guard: {candidate_path}/ not found — a release freezes the rolling snapshot, \
+             so there is nothing to prove {version} is a fresh regeneration of"
+        ))
+    });
+    let mismatches = record_mismatches(&frozen, &candidate, &path, &candidate_path);
+    if !mismatches.is_empty() {
+        fail_with(
+            &format!(
+                "release-guard: the frozen release {path}/ is not what a fresh regeneration \
+                 produces — it is stale, hand-edited, or was never cut from this source. Cut it \
+                 in a PR and re-tag the merged commit. Differences:"
+            ),
+            &mismatches,
+        );
+    }
+
+    println!(
+        "release-guard: clean — {foundry} version, {path}/ present and newest, tree regenerates \
+         unchanged, frozen release matches {candidate_path}/"
+    );
+}
+
+/// Working-tree changes reported by `git status --porcelain` as offender lines.
+/// Any non-blank line is a change (modified, added, deleted, or untracked); an
+/// empty result means the tree is clean. `.git/info/exclude` already hides the
+/// devShell's generated `.pre-commit-config.yaml`, so it never appears here.
+pub(crate) fn dirty_offenders(porcelain: &str) -> Vec<String> {
+    porcelain
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(str::to_string)
+        .collect()
 }
 
 #[cfg(test)]
@@ -285,10 +510,13 @@ mod tests {
     }
 
     #[test]
-    fn dir_present_true_only_on_nonempty_listing() {
-        assert!(dir_present("040000 tree abc123\tsrc/generated/0_1_5\n"));
-        assert!(!dir_present(""));
-        assert!(!dir_present("   \n  \n"));
+    fn tag_dirs_decides_whether_the_release_being_published_is_present() {
+        // Invariant 2 reads the same listing invariant 3 does: the release is
+        // present in the tagged commit iff its tag dir is one of the entries.
+        let tags = tag_dirs("src/generated/0_1_5\nsrc/generated/candidate\n", "src/generated");
+        assert!(tags.iter().any(|t| t == "0_1_5"));
+        assert!(!tags.iter().any(|t| t == "0_1_9"));
+        assert!(tag_dirs("", "src/generated").iter().all(|t| t != "0_1_5"));
     }
 
     #[test]
@@ -306,5 +534,156 @@ mod tests {
         assert_eq!(off.len(), 2);
         assert!(off[0].contains("0_1_5/CloneFactory.pointers.sol"));
         assert!(off[1].contains("0_1_5/Extra.pointers.sol"));
+    }
+
+    // ---- tag_dirs -----------------------------------------------------
+
+    #[test]
+    fn tag_dirs_lists_only_release_tags_directly_under_root() {
+        let listing = "src/generated/0_1_9\n\
+                       src/generated/0_1_10\n\
+                       src/generated/candidate\n\
+                       src/generated/README.md\n\
+                       src/generated/0_1_9/CloneFactory.sol\n";
+        assert_eq!(
+            tag_dirs(listing, "src/generated"),
+            vec!["0_1_9".to_string(), "0_1_10".to_string()]
+        );
+    }
+
+    #[test]
+    fn tag_dirs_empty_when_nothing_is_generated() {
+        // `git ls-tree` on a path the commit does not carry prints nothing.
+        assert!(tag_dirs("", "src/generated").is_empty());
+        assert!(tag_dirs("   \n\n", "src/generated").is_empty());
+    }
+
+    #[test]
+    fn tag_dirs_ignores_entries_outside_root() {
+        let listing = "src/lib/0_1_9\nother/generated/0_1_9\n";
+        assert!(tag_dirs(listing, "src/generated").is_empty());
+    }
+
+    // ---- newer_tags ---------------------------------------------------
+
+    #[test]
+    fn newer_tags_empty_when_the_release_is_the_newest_frozen() {
+        let tags = vec!["0_1_3".to_string(), "0_1_9".to_string()];
+        assert!(newer_tags(&tags, "0_1_9").is_empty());
+    }
+
+    #[test]
+    fn newer_tags_flags_a_release_that_does_not_follow_the_record() {
+        // Re-tagging an older version once a newer one is frozen: the old
+        // cut-at-tag-time flow refused this via NonMonotonicRelease.
+        let tags = vec!["0_1_5".to_string(), "0_1_9".to_string()];
+        assert_eq!(newer_tags(&tags, "0_1_5"), vec!["0_1_9".to_string()]);
+    }
+
+    #[test]
+    fn newer_tags_orders_components_numerically_not_lexically() {
+        // "0_1_10" sorts BEFORE "0_1_9" as a string; as a release it follows it.
+        let tags = vec!["0_1_9".to_string(), "0_1_10".to_string()];
+        assert!(newer_tags(&tags, "0_1_10").is_empty());
+        assert_eq!(newer_tags(&tags, "0_1_9"), vec!["0_1_10".to_string()]);
+    }
+
+    #[test]
+    fn newer_tags_compares_the_most_significant_component_first() {
+        let tags = vec!["1_0_0".to_string(), "0_99_99".to_string()];
+        assert_eq!(newer_tags(&tags, "0_99_99"), vec!["1_0_0".to_string()]);
+        assert!(newer_tags(&tags, "1_0_0").is_empty());
+    }
+
+    #[test]
+    fn newer_tags_handles_components_too_long_for_a_fixed_width_integer() {
+        // The tag-prefix regex admits any digit run, so a component can exceed
+        // u64/u128. Comparison must stay exact rather than overflow or panic.
+        let big = format!("0_1_{}", "9".repeat(40));
+        let bigger = format!("0_1_1{}", "0".repeat(40));
+        let tags = vec![big.clone(), bigger.clone()];
+        assert_eq!(newer_tags(&tags, &big), vec![bigger.clone()]);
+        assert!(newer_tags(&tags, &bigger).is_empty());
+    }
+
+    #[test]
+    fn newer_tags_ignores_leading_zeros_when_comparing() {
+        let tags = vec!["0_1_9".to_string()];
+        assert!(newer_tags(&tags, "0_01_009").is_empty());
+        // And the other way round: a padded spelling of the SAME release is not
+        // a later release. Comparing digit runs without stripping the padding
+        // would call the longer string the bigger number and flag it.
+        assert!(newer_tags(&["0_1_09".to_string()], "0_1_9").is_empty());
+    }
+
+    // ---- record_mismatches --------------------------------------------
+
+    fn record(entries: &[(&str, &str)]) -> BTreeMap<String, Vec<u8>> {
+        entries
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.as_bytes().to_vec()))
+            .collect()
+    }
+
+    #[test]
+    fn record_mismatches_clean_when_the_frozen_record_is_the_fresh_regeneration() {
+        let frozen = record(&[("CloneFactory.sol", "pins"), ("Other.sol", "more")]);
+        let candidate = record(&[("CloneFactory.sol", "pins"), ("Other.sol", "more")]);
+        assert!(
+            record_mismatches(&frozen, &candidate, "src/generated/0_1_9", "src/generated/candidate")
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn record_mismatches_flags_a_frozen_file_whose_content_drifted() {
+        let frozen = record(&[("CloneFactory.sol", "old pins")]);
+        let candidate = record(&[("CloneFactory.sol", "new pins")]);
+        let off =
+            record_mismatches(&frozen, &candidate, "src/generated/0_1_9", "src/generated/candidate");
+        assert_eq!(off.len(), 1);
+        assert!(off[0].contains("src/generated/0_1_9/CloneFactory.sol"));
+        assert!(off[0].contains("differs"));
+    }
+
+    #[test]
+    fn record_mismatches_flags_a_file_only_the_frozen_record_holds() {
+        let frozen = record(&[("A.sol", "x"), ("Ghost.sol", "y")]);
+        let candidate = record(&[("A.sol", "x")]);
+        let off =
+            record_mismatches(&frozen, &candidate, "src/generated/0_1_9", "src/generated/candidate");
+        assert_eq!(off.len(), 1);
+        assert!(off[0].contains("Ghost.sol"));
+    }
+
+    #[test]
+    fn record_mismatches_flags_a_file_only_a_fresh_regeneration_produces() {
+        let frozen = record(&[("A.sol", "x")]);
+        let candidate = record(&[("A.sol", "x"), ("New.sol", "y")]);
+        let off =
+            record_mismatches(&frozen, &candidate, "src/generated/0_1_9", "src/generated/candidate");
+        assert_eq!(off.len(), 1);
+        assert!(off[0].contains("New.sol"));
+    }
+
+    #[test]
+    fn record_mismatches_flags_an_empty_candidate_rather_than_matching_an_empty_record() {
+        // Two empty dirs are "equal"; a release with no record is not a release.
+        let empty = record(&[]);
+        let off = record_mismatches(&empty, &empty, "src/generated/0_1_9", "src/generated/candidate");
+        assert_eq!(off.len(), 2);
+        assert!(off
+            .iter()
+            .any(|o| o.contains("src/generated/candidate/ holds no files")));
+        assert!(off
+            .iter()
+            .any(|o| o.contains("src/generated/0_1_9/ holds no files")));
+    }
+
+    #[test]
+    fn record_mismatches_compares_bytes_not_lengths() {
+        let frozen = record(&[("A.sol", "abc")]);
+        let candidate = record(&[("A.sol", "abd")]);
+        assert_eq!(record_mismatches(&frozen, &candidate, "f", "c").len(), 1);
     }
 }

--- a/rainix-static/src/soldeer_gate.rs
+++ b/rainix-static/src/soldeer_gate.rs
@@ -612,7 +612,7 @@ mod tests {
         let mut with_gen = vec![
             base,
             (
-                "src/generated/0.1.0/A.pointers.sol".to_string(),
+                "src/generated/0_1_0/A.sol".to_string(),
                 b"address constant X = 1;".to_vec(),
             ),
         ];

--- a/test/bats/action/frozen-snapshots-append-only.test.bats
+++ b/test/bats/action/frozen-snapshots-append-only.test.bats
@@ -1,0 +1,116 @@
+# The append-only gate's SKIP predicate. It shipped globbing
+# `src/generated/*/*.pointers.sol` — a filename no deploy repo has ever written,
+# since frozen records are `src/generated/<tag>/<Name>.sol` — so the gate skipped
+# in exactly the repos it exists for and was a no-op org-wide
+# (rainlanguage/rainix#341). These cover which trees reach the check and which do
+# not, against the record shape deploy repos actually carry.
+
+setup() {
+  repo_root="$BATS_TEST_DIRNAME/../../.."
+  action="$repo_root/.github/actions/frozen-snapshots-append-only/action.yml"
+  action_script="$(yq -r '.runs.steps[0].run' "$action")"
+  work="$(mktemp -d)"
+}
+
+teardown() {
+  rm -rf "$work"
+}
+
+# The action script run against $work as the repo, with `git` and `nix` stubbed
+# to echo their argv — so what reaches the binary is asserted without a network
+# fetch or a build.
+run_gate() {
+  cd "$work" || return 1
+  GITHUB_BASE_REF="${1:-}" \
+    GITHUB_ACTION_PATH="$repo_root/.github/actions/frozen-snapshots-append-only" \
+    ACTION_SCRIPT="$action_script" \
+    bash -c '
+      git() {
+        # Report a non-shallow checkout so the unshallow branch stays out of the
+        # way; everything else just records that it was called.
+        if [ "$1 $2" = "rev-parse --git-dir" ]; then
+          printf "%s\n" "$PWD/.git"
+          return 0
+        fi
+        printf "git"
+        printf " <%s>" "$@"
+        printf "\n"
+      }
+      nix() {
+        printf "nix"
+        printf " <%s>" "$@"
+        printf "\n"
+      }
+      export -f git nix
+      bash -c "$ACTION_SCRIPT"
+    '
+}
+
+@test "a deploy repo's real record shape reaches the check instead of skipping" {
+  # THE regression: this is the tree rain.factory.deploy carries, and the
+  # `*.pointers.sol` glob skipped it.
+  mkdir -p "$work/src/generated/0_1_9" "$work/src/generated/candidate"
+  touch "$work/src/generated/0_1_9/CloneFactory.sol"
+  touch "$work/src/generated/candidate/CloneFactory.sol"
+
+  run run_gate
+
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"skip"* ]]
+  [[ "$output" == *"<snapshots-append-only> <--base> <origin/main>"* ]]
+}
+
+@test "a repo with no generated record skips without fetching or checking" {
+  run run_gate
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no generated record; skip"* ]]
+  [[ "$output" != *"<--base>"* ]]
+  [[ "$output" != *"<fetch>"* ]]
+}
+
+@test "a record holding only the rolling candidate still reaches the check" {
+  # A deploy repo before its first release. A snapshot deleted from such a
+  # branch is still a deletion the check must see.
+  mkdir -p "$work/src/generated/candidate"
+  touch "$work/src/generated/candidate/MetaBoard.sol"
+
+  run run_gate
+
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"skip"* ]]
+  [[ "$output" == *"<snapshots-append-only>"* ]]
+}
+
+@test "the legacy pointers filename is still checked, not newly skipped" {
+  mkdir -p "$work/src/generated/0_1_4"
+  touch "$work/src/generated/0_1_4/CloneFactory.pointers.sol"
+
+  run run_gate
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"<snapshots-append-only>"* ]]
+}
+
+@test "the pull_request base ref is the ref the check is pointed at" {
+  mkdir -p "$work/src/generated/0_1_9"
+  touch "$work/src/generated/0_1_9/CloneFactory.sol"
+
+  run run_gate release-2026
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"<--base> <origin/release-2026>"* ]]
+  [[ "$output" == *"git <fetch> <--no-tags> <origin> <release-2026>"* ]]
+}
+
+@test "a src/generated FILE rather than a directory is not mistaken for a record" {
+  # `-d` and not `-e`: a stray file named src/generated is not a record tree,
+  # and fetching the base to diff it would fail for nothing.
+  mkdir -p "$work/src"
+  touch "$work/src/generated"
+
+  run run_gate
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no generated record; skip"* ]]
+}


### PR DESCRIPTION
`rainix-tag-release`'s determinism check `rm -rf`'d `src/generated/<tag>/` and re-ran
the repo's **freezing** generator (`cutRelease()`) to prove the frozen snapshot was a
fresh regeneration. In a deploy repo whose generated released-suites lib IMPORTS that
directory, the removal makes the tree uncompilable, so the generator that was meant to
re-create it cannot run at all — and no such repo can ever release.

Observed at rain.factory.deploy `sol-v0.1.9`: `LibCloneFactoryReleased.sol` imports
`../generated/0_1_9/CloneFactory.sol`, so deleting the directory fails the compile
before the generator starts. Not repo-specific — every deploy repo on the Option A
model with a generated released-suites lib inherits it.

## The fix removes nothing

The check no longer mutates the tree at all, and the guarantee is unchanged — checked
more directly, against the bytes rather than by re-running the copy that produced them.

- **The workflow runs the NON-freezing `run()` entry point** — `forge script
  ./script/Build.sol && forge fmt`. That is the exact regeneration
  `rainix-copy-artifacts` currency-checks every PR with, so the release-time and
  PR-time checks now prove the same thing about the same command.
- **The guard compares `src/generated/<version>/` byte-for-byte against the freshly
  regenerated `src/generated/candidate/`.** A freeze COPIES the rolling snapshot
  verbatim, so "the record equals the candidate" *is* "a freeze run right now would
  write these bytes". Stale, hand-edited and never-cut all fail here. Both directions
  are compared, and an empty record or empty regeneration is flagged rather than
  matching vacuously.
- **A monotonicity check preserves what `cutRelease()` used to enforce** at tag time
  (`NonMonotonicRelease`): no LATER release may already be frozen beside this one.
  Dropping the freezing generator would otherwise have retired that invariant
  silently. Ordering is numeric per component and tolerates components longer than a
  fixed-width integer, so a publish guard cannot panic on overflow.

The decisions live in small pure functions (`tag_dirs`, `newer_tags`,
`record_mismatches`, `foundry_version`, `dirty_offenders`) so they are unit-tested and
mutation-covered; `run` only wires git and the filesystem to them.

Also fixed, per the issue's "adjacent" note: the `frozen-snapshots-append-only` gate
globbed `src/generated/*/*.pointers.sol`. No repo in the org writes that name today
(records are `src/generated/<tag>/<Name>.sol`), so the gate skips in exactly the repos
it exists for and is **a silent no-op org-wide** — but only since 2026-08-20, and the
history is the sharper argument. rain.factory.deploy carried
`src/generated/0_1_{3,4,5}/CloneFactory.pointers.sol` from its genesis commit until
`39d1cfd` renamed the scheme, and that PR deleted all three while the gate reported
`success`: the skip test reads the HEAD tree, so a branch removing every snapshot
switches off the check that exists to catch the removal. The predicate is now a
presence test on `src/generated/`, with which entries count as releases left to the
same `is_tag` the release guard uses; the residual delete-everything form is documented
in place as a deliberate narrow limit.

## BREAKING — five caller repos must drop `snapshot-generate-cmd`

The `snapshot-generate-cmd` input is **REMOVED**, deliberately: a per-repo override is
precisely how the freezing form got wired in, and the release-time regeneration must be
the same command the PR-time currency check uses. It is no longer a caller input.

All five callers pass it explicitly today, and all five reference this workflow at
`@main`:

| repo | value passed today |
| --- | --- |
| `rain.factory.deploy` | `forge script ./script/Build.sol --sig "cutRelease()" && forge fmt` |
| `rain.metadata.deploy` | `forge script ./script/Build.sol --sig "cutRelease()" && forge fmt` |
| `rain.deploy` | `forge script ./script/Build.sol --sig "cutRelease()" && forge fmt` |
| `rain.extrospection.deploy` | `forge script ./script/Build.sol --sig "cutRelease()" && forge fmt` |
| `rain.math.float.deploy` | `forge script ./script/Build.sol && forge fmt` |

Each must delete that line from `.github/workflows/package-release.yaml`. GitHub
rejects an input a reusable workflow does not declare (`Invalid input, … is not
defined in the referenced workflow`), so because they track `@main` these break on
merge until the line is gone. Sequence the caller PRs accordingly.

Note `rain.math.float.deploy` already passes the non-freezing form — identical to what
the workflow now hardcodes, so dropping the line is behaviour-neutral there; the line
must still go, since the input no longer exists.

## Follow-up required after merge: bump `RAINIX_SHA`

The workflow runs `rainix-static release-guard` out of the pinned
`RAINIX_SHA` (`864816f`), not out of this branch. That pinned build predates this
change: its guard has no `newer_tags` and no record comparison. So on merge the
crash in #341 is fixed (nothing is removed any more) but the byte-comparison and
monotonicity checks stay inert until `RAINIX_SHA` is bumped to the merge commit. That
bump is a separate commit, as it was for the previous guard fixes.

## Residual hole, stated rather than hidden

A branch that deletes the **entire** `src/generated/` tree still skips the append-only
gate. Distinguishing that from a repo that never had a record needs the BASE branch,
which is what the fetch exists to get — so closing it means fetching in every sol repo
in the org, including those whose default branch is not `main`. Measured today:
**20 non-archived `rainlanguage` repos have a default branch other than `main`** (16 of
them `master`); 33 counting archived. Left as is, narrowly and on purpose: deleting one
frozen snapshot, or the tag dir holding it, is caught.

## QA

- **Discriminating tests:** `frozen-snapshots-append-only.test.bats` — "a deploy repo's
  real record shape reaches the check instead of skipping", "a repo with no generated
  record skips without fetching or checking", "a record holding only the rolling
  candidate still reaches the check", "the pull_request base ref is the ref the check is
  pointed at", "a src/generated FILE rather than a directory is not mistaken for a
  record" — each fails on base (verified by running the new test file against base
  commit `d2b3518` in a worktree carrying the base `action.yml`: 5 of 6 `not ok`, exit
  1; on this branch 6 of 6 `ok`). The 6th, "the legacy pointers filename is still
  checked, not newly skipped", passes on base **by design** — it is the non-regression
  guard that the new predicate must not newly skip what the old glob did catch.
  `release_guard::tests::{newer_tags_*, record_mismatches_*, tag_dirs_*}` fail on base
  by not compiling: `newer_tags`, `record_mismatches` and `tag_dirs` do not exist there
  (the base guard exposes only `is_semver`, `version_dir`, `foundry_version`,
  `dir_present`, `dirty_offenders`). End-to-end, the tampered-record case PASSES the
  base guard and FAILS this one, verified live (item 3 below).
- **Mutations applied:** 16 applied, **16 killed, 0 survived, 0 no-run**.
  `a.len().cmp(&b.len()).then_with(…)` → `a.cmp(b)` → killed by
  `newer_tags_orders_components_numerically_not_lexically`;
  `trim_start_matches('0')` → identity → `newer_tags_ignores_leading_zeros_when_comparing`;
  `ap.iter().zip(bp.iter())` → `.rev().zip(.rev())` → `newer_tags_compares_the_most_significant_component_first`;
  `tag_cmp(t, dir) == Greater` → `== Less`, and → `false` →
  `newer_tags_flags_a_release_that_does_not_follow_the_record`;
  `if !is_tag(entry)` → `if false` → `tag_dirs_lists_only_release_tags_directly_under_root`;
  `strip_prefix(root)?.strip_prefix('/')?` → `line.trim()` → `tag_dirs_decides_whether_the_release_being_published_is_present`;
  `fresh != bytes` → `&& false` → `record_mismatches_flags_a_frozen_file_whose_content_drifted`;
  `for (name, bytes) in frozen` → `in candidate` → `record_mismatches_flags_a_file_only_the_frozen_record_holds`;
  `if candidate.is_empty()` and `if frozen.is_empty()` → `if false` → `record_mismatches_flags_an_empty_candidate_rather_than_matching_an_empty_record`;
  `if !frozen.contains_key(name)` → `if false` → `record_mismatches_flags_a_file_only_a_fresh_regeneration_produces`.
  On the gate predicate `[ ! -d src/generated ]` → the shipped `! ls
  src/generated/*/*.pointers.sol` glob (the original bug), → `[ -d … ]` (inverted), →
  `[ ! -e … ]` (file counts as record), and `BASE_REF="${GITHUB_BASE_REF:-main}"` →
  `"main"` (ignores the PR base) — all four killed by the bats file above.
- **Oracle:** expected behaviour is derived independently of this implementation — from
  issue #341's reported compile error at rain.factory.deploy `sol-v0.1.9`
  (`Source "src/generated/0_1_9/CloneFactory.sol" not found` in
  `LibCloneFactoryReleased.sol`); from rain.deploy's `freeze` semantics, which copy the
  rolling `candidate/` verbatim and read back off disk, and so *define* what "freshly
  cut" means; from `cutRelease()`'s `NonMonotonicRelease` revert, which defines the
  release ordering this guard now carries; and from the real on-disk record shape deploy
  repos carry (`src/generated/<tag>/<Name>.sol`), which is what showed the shipped glob
  matched nothing.
- **Category check:** issue asks (A) stop the determinism check removing
  `src/generated/<tag>/`, so a repo whose generated released-suites lib imports it can
  release, and (B) the adjacent finding that the append-only gate's glob matches no
  deploy repo and is a silent no-op org-wide. Covered A and B. The issue's fix-shape (1)
  ("do the check without mutating the working tree") is the shape taken.

Everything below was run on this branch; commands and configs are in the QA scratch,
not committed.

**Unit + mutation.** The mutants each break one behaviour the fix depends on.

- `cargo test` (rainix-static): **164 passed, 0 failed**.
- Rust mutation probe over the guard's decisions: **12/12 KILLED, 0 survived, 0
  no-run** — covering digit-run ordering, leading-zero stripping, most-significant-first
  comparison, `newer_tags` inversion/silencing, `tag_dirs` release-filtering and
  record-root anchoring, and all five `record_mismatches` behaviours (byte comparison,
  comparing the record rather than the candidate against itself, empty candidate, empty
  record, files only a fresh regeneration produces).
- Bats mutation probe over the gate's SKIP predicate: **4/4 KILLED, 0 survived, 0
  no-run** — including A01, the shipped `*.pointers.sol` glob itself, so the regression
  that made the gate a no-op is now held down by a test.

*Instrument note:* the bats probe first reported A03/A04 as NO-RUN. That was the
probe's `proof` regex requiring `N failures` while bats prints the singular `1
failure`; the run tails showed the mutants genuinely failing the suite. Relaxing the
regex to `failure` (a measurement fix, no test touched) gives the 4/4 above.

**Gate.**

- `nix flake check --impure` — **all checks passed**.
- `default-shell-test` — the 6 new gate tests all pass. 3 pre-existing failures in
  `prettier-bundle.test.bats` (`status 127`, `$prettier_entry` unset in this sandbox);
  confirmed identical on an unmodified `HEAD` worktree, so unrelated to this change.
  Worth noting separately: `mkTask` bodies carry no `set -e`, so `default-shell-test`
  exits on its **last** bats file only and masked these three — the full log has to be
  read, not the exit code.
- `reuse lint` — compliant, 112/112 files carry copyright and licence.

**End-to-end against the real failing release** (rain.factory.deploy at `sol-v0.1.9`,
the tag in the issue):

1. *New flow, positive* — non-freezing regenerate exits 0, `git status` clean,
   `release-guard` exits **0**: "clean — foundry.toml version, `src/generated/0_1_9/`
   present and newest, tree regenerates unchanged, frozen release matches
   `src/generated/candidate/`".
2. *Old flow, reproduces #341* — `rm -rf src/generated/0_1_9` + `cutRelease()` exits
   **1** with the issue's exact error: `Source "src/generated/0_1_9/CloneFactory.sol"
   not found` at `src/lib/LibCloneFactoryReleased.sol:9`.
3. *Tampered record is caught* — one byte of `BYTECODE_HASH` hand-edited in the frozen
   record and **committed so the tree is clean**. The non-freezing regeneration leaves
   the tree clean, so the old clean-tree check alone would have PASSED this; the new
   guard exits **1**, naming `src/generated/0_1_9/CloneFactory.sol differs from the
   freshly regenerated src/generated/candidate/CloneFactory.sol`. This is the case the
   byte comparison exists for.

Closes #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Release validation now verifies version alignment, snapshot presence, append-only ordering, and byte-for-byte consistency between frozen and regenerated snapshots.
  - Snapshot generation is standardized through the project build script during releases.

- **Bug Fixes**
  - Snapshot checks no longer silently skip when individual records or tag directories are deleted.
  - Release generation preserves required frozen snapshots and detects mismatched or empty records.

- **Documentation**
  - Updated guidance explains snapshot generation, release verification, and frozen snapshot requirements.

- **Tests**
  - Added coverage for snapshot integrity checks and release validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->