### PR TITLE
ci: bump RAINIX_SHA to 833e8a7 so #343's checks actually run

### DIFF
--- a/.github/workflows/rainix-autopublish.yaml
+++ b/.github/workflows/rainix-autopublish.yaml
@@ -49,7 +49,7 @@ on:
       SOLDEER_API_TOKEN:
         required: false
 env:
-  RAINIX_SHA: 833e8a719305bdba7ae178942913f411fe521c95
+  RAINIX_SHA: 3d1c85eca08ef5a852215f77c8f3684c8313a8b3
 jobs:
   release:
     if: ${{ !startsWith(github.event.head_commit.message, 'Package Release') }}

--- a/.github/workflows/rainix-autopublish.yaml
+++ b/.github/workflows/rainix-autopublish.yaml
@@ -49,7 +49,7 @@ on:
       SOLDEER_API_TOKEN:
         required: false
 env:
-  RAINIX_SHA: 864816f68b114f7596f8e1f6f00315ef48783072
+  RAINIX_SHA: 833e8a719305bdba7ae178942913f411fe521c95
 jobs:
   release:
     if: ${{ !startsWith(github.event.head_commit.message, 'Package Release') }}

--- a/.github/workflows/rainix-copy-artifacts.yaml
+++ b/.github/workflows/rainix-copy-artifacts.yaml
@@ -2,7 +2,7 @@ name: rainix-copy-artifacts
 on:
   workflow_call:
 env:
-  RAINIX_SHA: 833e8a719305bdba7ae178942913f411fe521c95
+  RAINIX_SHA: 3d1c85eca08ef5a852215f77c8f3684c8313a8b3
 jobs:
   copy-artifacts:
     runs-on: ubuntu-latest

--- a/.github/workflows/rainix-copy-artifacts.yaml
+++ b/.github/workflows/rainix-copy-artifacts.yaml
@@ -2,7 +2,7 @@ name: rainix-copy-artifacts
 on:
   workflow_call:
 env:
-  RAINIX_SHA: 864816f68b114f7596f8e1f6f00315ef48783072
+  RAINIX_SHA: 833e8a719305bdba7ae178942913f411fe521c95
 jobs:
   copy-artifacts:
     runs-on: ubuntu-latest

--- a/.github/workflows/rainix-manual-sol-artifacts.yaml
+++ b/.github/workflows/rainix-manual-sol-artifacts.yaml
@@ -85,7 +85,7 @@ on:
       CI_DEPLOY_FLARE_ETHERSCAN_API_KEY:
         required: false
 env:
-  RAINIX_SHA: 833e8a719305bdba7ae178942913f411fe521c95
+  RAINIX_SHA: 3d1c85eca08ef5a852215f77c8f3684c8313a8b3
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/rainix-manual-sol-artifacts.yaml
+++ b/.github/workflows/rainix-manual-sol-artifacts.yaml
@@ -85,7 +85,7 @@ on:
       CI_DEPLOY_FLARE_ETHERSCAN_API_KEY:
         required: false
 env:
-  RAINIX_SHA: 864816f68b114f7596f8e1f6f00315ef48783072
+  RAINIX_SHA: 833e8a719305bdba7ae178942913f411fe521c95
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/rainix-manual-sol-verify.yaml
+++ b/.github/workflows/rainix-manual-sol-verify.yaml
@@ -65,7 +65,7 @@ on:
       CI_DEPLOY_FLARE_ETHERSCAN_API_KEY:
         required: false
 env:
-  RAINIX_SHA: 864816f68b114f7596f8e1f6f00315ef48783072
+  RAINIX_SHA: 833e8a719305bdba7ae178942913f411fe521c95
 jobs:
   verify:
     runs-on: ubuntu-latest

--- a/.github/workflows/rainix-manual-sol-verify.yaml
+++ b/.github/workflows/rainix-manual-sol-verify.yaml
@@ -65,7 +65,7 @@ on:
       CI_DEPLOY_FLARE_ETHERSCAN_API_KEY:
         required: false
 env:
-  RAINIX_SHA: 833e8a719305bdba7ae178942913f411fe521c95
+  RAINIX_SHA: 3d1c85eca08ef5a852215f77c8f3684c8313a8b3
 jobs:
   verify:
     runs-on: ubuntu-latest

--- a/.github/workflows/rainix-rs-static.yaml
+++ b/.github/workflows/rainix-rs-static.yaml
@@ -2,7 +2,7 @@ name: rainix-rs-static
 on:
   workflow_call:
 env:
-  RAINIX_SHA: 833e8a719305bdba7ae178942913f411fe521c95
+  RAINIX_SHA: 3d1c85eca08ef5a852215f77c8f3684c8313a8b3
 jobs:
   rs-static:
     runs-on: ubuntu-latest

--- a/.github/workflows/rainix-rs-static.yaml
+++ b/.github/workflows/rainix-rs-static.yaml
@@ -2,7 +2,7 @@ name: rainix-rs-static
 on:
   workflow_call:
 env:
-  RAINIX_SHA: 864816f68b114f7596f8e1f6f00315ef48783072
+  RAINIX_SHA: 833e8a719305bdba7ae178942913f411fe521c95
 jobs:
   rs-static:
     runs-on: ubuntu-latest

--- a/.github/workflows/rainix-rs-test.yaml
+++ b/.github/workflows/rainix-rs-test.yaml
@@ -2,7 +2,7 @@ name: rainix-rs-test
 on:
   workflow_call:
 env:
-  RAINIX_SHA: 833e8a719305bdba7ae178942913f411fe521c95
+  RAINIX_SHA: 3d1c85eca08ef5a852215f77c8f3684c8313a8b3
 jobs:
   rs-test:
     strategy:

--- a/.github/workflows/rainix-rs-test.yaml
+++ b/.github/workflows/rainix-rs-test.yaml
@@ -2,7 +2,7 @@ name: rainix-rs-test
 on:
   workflow_call:
 env:
-  RAINIX_SHA: 864816f68b114f7596f8e1f6f00315ef48783072
+  RAINIX_SHA: 833e8a719305bdba7ae178942913f411fe521c95
 jobs:
   rs-test:
     strategy:

--- a/.github/workflows/rainix-rs-wasm-test.yaml
+++ b/.github/workflows/rainix-rs-wasm-test.yaml
@@ -2,7 +2,7 @@ name: rainix-rs-wasm-test
 on:
   workflow_call:
 env:
-  RAINIX_SHA: 864816f68b114f7596f8e1f6f00315ef48783072
+  RAINIX_SHA: 833e8a719305bdba7ae178942913f411fe521c95
 jobs:
   rs-wasm-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/rainix-rs-wasm-test.yaml
+++ b/.github/workflows/rainix-rs-wasm-test.yaml
@@ -2,7 +2,7 @@ name: rainix-rs-wasm-test
 on:
   workflow_call:
 env:
-  RAINIX_SHA: 833e8a719305bdba7ae178942913f411fe521c95
+  RAINIX_SHA: 3d1c85eca08ef5a852215f77c8f3684c8313a8b3
 jobs:
   rs-wasm-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/rainix-rs-wasm.yaml
+++ b/.github/workflows/rainix-rs-wasm.yaml
@@ -2,7 +2,7 @@ name: rainix-rs-wasm
 on:
   workflow_call:
 env:
-  RAINIX_SHA: 833e8a719305bdba7ae178942913f411fe521c95
+  RAINIX_SHA: 3d1c85eca08ef5a852215f77c8f3684c8313a8b3
 jobs:
   rs-wasm:
     runs-on: ubuntu-latest

--- a/.github/workflows/rainix-rs-wasm.yaml
+++ b/.github/workflows/rainix-rs-wasm.yaml
@@ -2,7 +2,7 @@ name: rainix-rs-wasm
 on:
   workflow_call:
 env:
-  RAINIX_SHA: 864816f68b114f7596f8e1f6f00315ef48783072
+  RAINIX_SHA: 833e8a719305bdba7ae178942913f411fe521c95
 jobs:
   rs-wasm:
     runs-on: ubuntu-latest

--- a/.github/workflows/rainix-sol-legal.yaml
+++ b/.github/workflows/rainix-sol-legal.yaml
@@ -2,7 +2,7 @@ name: rainix-sol-legal
 on:
   workflow_call:
 env:
-  RAINIX_SHA: 864816f68b114f7596f8e1f6f00315ef48783072
+  RAINIX_SHA: 833e8a719305bdba7ae178942913f411fe521c95
 jobs:
   legal:
     runs-on: ubuntu-latest

--- a/.github/workflows/rainix-sol-legal.yaml
+++ b/.github/workflows/rainix-sol-legal.yaml
@@ -2,7 +2,7 @@ name: rainix-sol-legal
 on:
   workflow_call:
 env:
-  RAINIX_SHA: 833e8a719305bdba7ae178942913f411fe521c95
+  RAINIX_SHA: 3d1c85eca08ef5a852215f77c8f3684c8313a8b3
 jobs:
   legal:
     runs-on: ubuntu-latest

--- a/.github/workflows/rainix-sol-static.yaml
+++ b/.github/workflows/rainix-sol-static.yaml
@@ -2,7 +2,7 @@ name: rainix-sol-static
 on:
   workflow_call:
 env:
-  RAINIX_SHA: 833e8a719305bdba7ae178942913f411fe521c95
+  RAINIX_SHA: 3d1c85eca08ef5a852215f77c8f3684c8313a8b3
 jobs:
   static:
     runs-on: ubuntu-latest

--- a/.github/workflows/rainix-sol-static.yaml
+++ b/.github/workflows/rainix-sol-static.yaml
@@ -2,7 +2,7 @@ name: rainix-sol-static
 on:
   workflow_call:
 env:
-  RAINIX_SHA: 864816f68b114f7596f8e1f6f00315ef48783072
+  RAINIX_SHA: 833e8a719305bdba7ae178942913f411fe521c95
 jobs:
   static:
     runs-on: ubuntu-latest

--- a/.github/workflows/rainix-sol-test.yaml
+++ b/.github/workflows/rainix-sol-test.yaml
@@ -25,7 +25,7 @@ on:
       RPC_URL_SEPOLIA_FORK:
         required: false
 env:
-  RAINIX_SHA: 833e8a719305bdba7ae178942913f411fe521c95
+  RAINIX_SHA: 3d1c85eca08ef5a852215f77c8f3684c8313a8b3
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/rainix-sol-test.yaml
+++ b/.github/workflows/rainix-sol-test.yaml
@@ -25,7 +25,7 @@ on:
       RPC_URL_SEPOLIA_FORK:
         required: false
 env:
-  RAINIX_SHA: 864816f68b114f7596f8e1f6f00315ef48783072
+  RAINIX_SHA: 833e8a719305bdba7ae178942913f411fe521c95
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/rainix-subgraph-test.yaml
+++ b/.github/workflows/rainix-subgraph-test.yaml
@@ -2,7 +2,7 @@ name: rainix-subgraph-test
 on:
   workflow_call:
 env:
-  RAINIX_SHA: 864816f68b114f7596f8e1f6f00315ef48783072
+  RAINIX_SHA: 833e8a719305bdba7ae178942913f411fe521c95
 jobs:
   subgraph-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/rainix-subgraph-test.yaml
+++ b/.github/workflows/rainix-subgraph-test.yaml
@@ -2,7 +2,7 @@ name: rainix-subgraph-test
 on:
   workflow_call:
 env:
-  RAINIX_SHA: 833e8a719305bdba7ae178942913f411fe521c95
+  RAINIX_SHA: 3d1c85eca08ef5a852215f77c8f3684c8313a8b3
 jobs:
   subgraph-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/rainix-tag-release.yaml
+++ b/.github/workflows/rainix-tag-release.yaml
@@ -124,7 +124,7 @@ on:
       RPC_URL_SEPOLIA_FORK:
         required: false
 env:
-  RAINIX_SHA: 833e8a719305bdba7ae178942913f411fe521c95
+  RAINIX_SHA: 3d1c85eca08ef5a852215f77c8f3684c8313a8b3
 jobs:
   # The release tag must point at a commit already merged to the release branch.
   # `on: push: tags` fires for ANY tag, including one cut from an unmerged branch;

--- a/.github/workflows/rainix-tag-release.yaml
+++ b/.github/workflows/rainix-tag-release.yaml
@@ -124,7 +124,7 @@ on:
       RPC_URL_SEPOLIA_FORK:
         required: false
 env:
-  RAINIX_SHA: 864816f68b114f7596f8e1f6f00315ef48783072
+  RAINIX_SHA: 833e8a719305bdba7ae178942913f411fe521c95
 jobs:
   # The release tag must point at a commit already merged to the release branch.
   # `on: push: tags` fires for ANY tag, including one cut from an unmerged branch;


### PR DESCRIPTION
#343 landed the release-determinism guard and the rewritten `frozen-snapshots-append-only`
predicate, but every reusable workflow still pinned `864816f` — the rainix shell and
`rainix-static` binary from before that merge. Until this bump the new `release-guard`
subcommand and the new gate predicate sit on `main` and run nowhere.

13 workflow files, one `RAINIX_SHA` line each, `864816f…` → `833e8a7…` (the merge commit
of #343).

## QA

- Discriminating tests: n/a — the diff is 13 identical one-line pin changes in workflow
  YAML and contains no executable code. The discriminating check is CI itself: this PR's
  own jobs resolve the new SHA, so a bad pin fails to fetch the shell and the run goes red
  rather than silently continuing on the old one. Verified the replacement is exact and
  total: 13 files matched `864816f68b114f7596f8e1f6f00315ef48783072` before, 13 carry
  `833e8a719305bdba7ae178942913f411fe521c95` after, and zero occurrences of the old SHA
  remain anywhere under `.github/workflows/`. `yamlfmt` and the full pre-commit bundle pass.
- Mutations applied: n/a — no executable code in the diff to mutate. `mutation-probe` needs
  a `mutants.toml` and a suite; there is no behaviour here to break. The logic this pin
  activates was mutation-covered in #343.
- Oracle: rainlanguage/rainix#341 and #343 — a reusable workflow pins the rainix it runs
  from via `RAINIX_SHA`, so shipping a check to `main` does not deploy it; the pin bump is
  what deploys it. `833e8a719305bdba7ae178942913f411fe521c95` read from
  `gh api repos/rainlanguage/rainix/commits/main`, not assumed from the PR page.
- Category check: the ask is "make #343's checks live". Covered exactly — every pin in the
  repo, nothing else touched. Consumer repos reference the reusables at `@main`, so they
  inherit this without their own change; the five repos in #344 still need their
  `snapshot-generate-cmd` PRs merged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pinned Rainix revision used by automated build, test, verification, artifact, and release workflows.
  * Ensured workflow jobs consistently use the newer Rainix version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->