### PR TITLE
Delete the "load-bearing" filler

### DIFF
--- a/rainix-static/src/rpc_preflight.rs
+++ b/rainix-static/src/rpc_preflight.rs
@@ -1339,8 +1339,8 @@ mod tests {
             }
         }
         // Guard against this test quietly becoming vacuous: the raw substring
-        // nesting it was weakened FROM is real and still in the table, so the
-        // boundary rule is load-bearing rather than decorative.
+        // nesting it was weakened FROM is real and still in the table, so
+        // dropping the boundary rule would make `base_sepolia` match `sepolia`.
         assert!(net("base_sepolia")
             .env_name
             .contains(net("sepolia").env_name));
@@ -1618,8 +1618,8 @@ mod tests {
         // plan", no "quota", no "rate limit" and no "exceeded": strike the
         // "free plan" needle and it falls all the way through to a bare
         // RpcError, which reports a billing wall as an unexplained failure and
-        // fails the network over for no stated reason. That makes this the case
-        // that keeps the needle load-bearing rather than redundant.
+        // fails the network over for no stated reason. That makes this the one
+        // case that fails when the needle is removed.
         assert_eq!(
             classify(30, "Request timeout on the free plan", None),
             Reason::Quota { code: 30 }


### PR DESCRIPTION
Removes the banned `load-bearing` filler from this repo's committed source.

The phrase rates a finding instead of stating one, and the reader can do the rating.
Where the surrounding sentence already named the consequence, the phrase is simply
deleted; otherwise it is replaced by the consequence it was standing in for. No
substitute rating word ("crucial", "key", "critical", "the crux", "significant",
"notably") was introduced anywhere in the diff.

Closes nothing — no issue exists for this. Part of an org-wide sweep; one PR per
affected repo. GitHub code search finds only some of the forms, so the sweep was run
against fresh clones of all 151 org repos, matching `load[-_ ]?bearing` case-insensitively
plus a check for the phrase wrapped across two comment lines.

### Occurrences removed

| File | Count |
| --- | --- |
| `rainix-static/src/rpc_preflight.rs` | 2 |

## QA

- Discriminating tests: n/a — nothing in the diff changes behaviour, so there is no
  behaviour for a test to discriminate.
- Mutations applied: n/a — the diff is comments and prose only. `mutation-probe` mutates
  source lines and asks whether the suite kills them; this diff changes no source line,
  so every mutant it could generate is a mutant of code this PR did not touch.
- Oracle: the code each comment describes. Every rewrite states the consequence the
  phrase was gesturing at, read off the surrounding implementation rather than invented.
- Category check: the request is "remove every occurrence from committed source";
  this repo's occurrences are all removed and a re-grep over the branch finds none.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified test comments describing identifier-boundary matching behavior.
  * Documented the expected classification behavior for free-plan timeout messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->