### PR TITLE
feat(sol-shell): add yq-go, so a Solidity test can read a YAML record

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -109,12 +109,10 @@
           # forge build artifacts via `vm.ffi` in CopyArtifacts.sol-style
           # scripts.
           pkgs.jq
-          # yq-go is the same tool for YAML, and the sol lane now has YAML to
-          # assert over: a subgraph manifest is a deploy-shaped record a Solidity
-          # test needs to read (rain.metadata#148). Without it the alternative is
-          # substring matching on raw text, which a comment or a reformatted key
-          # defeats, or a hand-rolled YAML parser in Solidity — a maintenance
-          # liability in a test. Cheaper than either: one small Go binary.
+          # yq-go is the same for YAML. A subgraph manifest is a structured
+          # record a Solidity test reads over `vm.ffi`; a text search over it
+          # cannot tell a live key from one inside a `#` comment, nor see a key
+          # spelled `address :`, `"address"`, or inside a flow mapping.
           pkgs.yq-go
         ];
 

--- a/flake.nix
+++ b/flake.nix
@@ -109,6 +109,13 @@
           # forge build artifacts via `vm.ffi` in CopyArtifacts.sol-style
           # scripts.
           pkgs.jq
+          # yq-go is the same tool for YAML, and the sol lane now has YAML to
+          # assert over: a subgraph manifest is a deploy-shaped record a Solidity
+          # test needs to read (rain.metadata#148). Without it the alternative is
+          # substring matching on raw text, which a comment or a reformatted key
+          # defeats, or a hand-rolled YAML parser in Solidity — a maintenance
+          # liability in a test. Cheaper than either: one small Go binary.
+          pkgs.yq-go
         ];
 
         node-build-inputs = [
@@ -476,6 +483,7 @@
             bats test/bats/devshell/sol-shell/reuse.test.bats
             bats test/bats/devshell/sol-shell/gh.test.bats
             bats test/bats/devshell/sol-shell/jq.test.bats
+            bats test/bats/devshell/sol-shell/yq.test.bats
             bats test/bats/devshell/sol-shell/sol-tasks.test.bats
             bats test/bats/devshell/sol-shell/slim.test.bats
             bats test/bats/devshell/sol-shell/closure.test.bats

--- a/test/bats/devshell/sol-shell/yq.test.bats
+++ b/test/bats/devshell/sol-shell/yq.test.bats
@@ -1,0 +1,4 @@
+@test "yq should be available on PATH" {
+  run yq --version
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
`jq` has been in `sol-build-inputs` since the shell existed, for reading forge build
artifacts over `vm.ffi`. The sol lane now has YAML to read as well: a subgraph manifest is
a deploy-shaped record a Solidity test needs to assert over
(rainlanguage/rain.metadata#148).

Without `yq` the options are substring matching on raw text, or a hand-rolled YAML parser
in Solidity. This adds `pkgs.yq-go` to `sol-build-inputs` and a bats test asserting it on
PATH, matching the `jq` pattern exactly.

## Why substring matching is not enough — measured, not argued

Nine mutants were written against the substring form of rain.metadata#148's manifest
checks and probed with `mutation-probe`. **All nine SURVIVED** (8/17 killed overall, the 8
being the pre-existing mutants):

| | mutation | why it slips through |
| --- | --- | --- |
| M09 | handler entry commented out entirely | the event signature survives inside the `#` comment and satisfies the search |
| M10 | live entry re-typed to `MetaV1_2(address,bytes32,bytes32)`, correct one left as a comment | same disguise; the untyped variant of this bug IS caught |
| M11 | the `abis` entry `source.abi` names repointed at a different interface, real path parked on an unwired second entry | codegen would decode with the wrong ABI |
| M12 | `source.abi` names no entry at all | caught by codegen in the docker lane, but not by this one |
| M13 | `address : "0xfb8437Ae…"` — space before the colon | key spelling differs from the searched string |
| M14 | `"startBlock": 82855948` — quoted key | same |
| M15 | `source: { abi: MetaBoard, "address": …, "startBlock": … }` — flow mapping | same |
| M16 | `# network: template` as a comment, `network: matic` live below | the positive check finds the commented copy |
| M17 | a second data source carrying address and startBlock in those spellings | index-0 checks never look at it |

Every one is a real defect the manifest must not carry, and every one is invisible to a
text search. The parser alternative — YAML parsing hand-written in Solidity — is a
maintenance liability living in a test.

`yq-go` is a single small Go binary, already present in the default shell. This puts it in
`sol-shell` too.

## QA

- Discriminating tests: `test/bats/devshell/sol-shell/yq.test.bats` asserts `yq --version`
  exits 0 on PATH, wired into `sol-shell-test` beside `jq.test.bats`. It fails on base —
  `yq` is not in `sol-build-inputs` before this change, only in the default shell's input
  list. `slim.test.bats` and `closure.test.bats` continue to pass: they guard chromium,
  node and the rust toolchain, none of which `yq-go` pulls in.
- Mutations applied: n/a — the diff is a nix input list entry, a four-line bats file and
  one line wiring it into a task body. There is no executable line whose mutant a test
  could kill. The mutation evidence that motivates the change is the nine-survivor table
  above, produced by `nix run github:rainlanguage/adversarial-mutation-test#mutation-probe`
  against rain.metadata#148 rather than against this diff.
- Oracle: the `jq` entry immediately above it in `sol-build-inputs` and its comment — jq is
  there because a Solidity test needs to read a structured file over `vm.ffi`. YAML is the
  same requirement in a different format, and `sol-shell`'s stated slimness rule names
  browser, node, rust and wasm as what to keep out, not small CLI tools.
- Category check: the ask is "a Solidity test in the sol lane can read YAML". Covered
  exactly — one input, one test, one wiring line. Nothing else changed. Consumer repos pick
  this up on the next `RAINIX_SHA` bump, which is a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a validation check confirming that `yq` is available in the Solidity development shell.
  * Included the new check in the Solidity shell test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->