### PR TITLE
docs(append-only): state the rule, not the incident that produced it

### DIFF
--- a/.github/actions/frozen-snapshots-append-only/action.yml
+++ b/.github/actions/frozen-snapshots-append-only/action.yml
@@ -9,28 +9,23 @@ runs:
       run: |
         set -euo pipefail
         # Nothing to enforce if the repo carries no generated record at all — a
-        # library repo, which has no per-tag deploy-pin snapshots. A presence test
-        # on ONE directory, deliberately: the `src/generated/*/*.pointers.sol`
-        # glob this replaces asserted a FILENAME inside the record, and no repo in
-        # the org writes that name today (frozen records are
-        # `src/generated/<tag>/<Name>.sol`), so the gate skips silently in exactly
-        # the repos it exists for — a no-op org-wide (rainlanguage/rainix#341).
-        # It was not always unmatched, and the history is the sharper argument:
-        # rain.factory.deploy carried src/generated/0_1_{3,4,5}/CloneFactory.pointers.sol
-        # from its genesis commit until 39d1cfd (2026-08-20) renamed the scheme,
-        # and that PR deleted all three while this gate reported success — the
-        # skip test reads the HEAD tree, so a branch removing every snapshot
-        # switches off the check that would have caught the removal.
-        # Which entries under the root are releases is the Rust check's call, via
-        # the same `is_tag` the release guard uses; bash only decides whether
-        # there is a record to look at.
+        # library repo, which has no per-tag deploy-pin snapshots.
         #
-        # A branch that deletes the ENTIRE src/generated/ tree still skips here.
-        # Distinguishing that from a repo that never had one needs the BASE branch,
-        # which is what the fetch below exists to get — so closing it would mean
-        # fetching in every sol repo in the org, including the ones whose default
-        # branch is not `main`. Left as is, narrowly: deleting one frozen snapshot,
-        # or the tag dir holding it, is caught.
+        # A presence test on ONE directory, deliberately. Asserting a filename
+        # inside the record instead would make the gate skip wherever the
+        # generator's naming differs from the assertion, which is silent: a skip
+        # and a pass are the same green. Which entries under the root are
+        # releases is the Rust check's call, via the same `is_tag` the release
+        # guard uses; bash only decides whether there is a record to look at.
+        #
+        # A branch that deletes the ENTIRE src/generated/ tree still skips here,
+        # because the test reads the HEAD tree — so removing every snapshot
+        # switches off the check that would catch the removal. Distinguishing
+        # that from a repo that never had a record needs the BASE branch, which
+        # is what the fetch below exists to get, so closing it would mean
+        # fetching in every sol repo in the org, including the ones whose
+        # default branch is not `main`. Left as is, narrowly: deleting one
+        # frozen snapshot, or the tag dir holding it, is caught.
         if [ ! -d src/generated ]; then
           echo "snapshots-append-only: no generated record; skip"
           exit 0


### PR DESCRIPTION
The `frozen-snapshots-append-only` comment narrated a specific repo's file names, a
specific commit, the date it landed and what CI reported at the time. None of that tells a
reader what the predicate does or why it is shaped that way — git carries it, and
rainlanguage/rainix#341 and #343 carry the argument.

What survives is the reasoning that still constrains the code:

- **why the test is on the directory, not a filename inside it** — asserting a filename
  makes the gate skip wherever the generator's naming differs from the assertion, and a
  skip is indistinguishable from a pass.
- **why the delete-everything hole is left open** — the test reads the HEAD tree, so
  removing every snapshot switches off the check that would catch the removal. Closing it
  needs the base branch, which would mean fetching in every sol repo in the org, including
  the ones whose default branch is not `main`.

21 lines removed, 16 added. Comment only.

## QA

- Discriminating tests: n/a - the diff changes only `#` comment lines inside a composite
  action's `run:` block. No shell statement, no condition and no command is touched, so
  there is no behaviour for a test to discriminate. Verified by inspection of the diff:
  every changed line begins with `#` after its indentation, and the surrounding
  `if [ ! -d src/generated ]` guard, the fetch block and the `nix run` invocation are
  byte-identical.
- Mutations applied: n/a - no executable line in the diff to mutate. The predicate this
  comment describes was mutation-covered when it was written (#343).
- Oracle: the org rule that a migration carries the current shape forward only, and that
  consumers have git. A comment's job is to say what the code does and why it is shaped
  that way, not to record how it came to be that way.
- Category check: the ask is "remove historicals from the comment". Covered exactly — the
  file names, the commit hash, the date and the CI-reported-success anecdote are gone; both
  live constraints are kept and stated as rules rather than as consequences of an incident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
