### PR TITLE
ci: bump RAINIX_SHA to c4cf22d so yq reaches the sol lane

### DIFF
--- a/.github/workflows/rainix-autopublish.yaml
+++ b/.github/workflows/rainix-autopublish.yaml
@@ -49,7 +49,7 @@ on:
       SOLDEER_API_TOKEN:
         required: false
 env:
-  RAINIX_SHA: 3d1c85eca08ef5a852215f77c8f3684c8313a8b3
+  RAINIX_SHA: c4cf22d9b76600a4ad33b5552f4083f80d9b83de
 jobs:
   release:
     if: ${{ !startsWith(github.event.head_commit.message, 'Package Release') }}

--- a/.github/workflows/rainix-copy-artifacts.yaml
+++ b/.github/workflows/rainix-copy-artifacts.yaml
@@ -2,7 +2,7 @@ name: rainix-copy-artifacts
 on:
   workflow_call:
 env:
-  RAINIX_SHA: 3d1c85eca08ef5a852215f77c8f3684c8313a8b3
+  RAINIX_SHA: c4cf22d9b76600a4ad33b5552f4083f80d9b83de
 jobs:
   copy-artifacts:
     runs-on: ubuntu-latest

--- a/.github/workflows/rainix-manual-sol-artifacts.yaml
+++ b/.github/workflows/rainix-manual-sol-artifacts.yaml
@@ -85,7 +85,7 @@ on:
       CI_DEPLOY_FLARE_ETHERSCAN_API_KEY:
         required: false
 env:
-  RAINIX_SHA: 3d1c85eca08ef5a852215f77c8f3684c8313a8b3
+  RAINIX_SHA: c4cf22d9b76600a4ad33b5552f4083f80d9b83de
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/rainix-manual-sol-verify.yaml
+++ b/.github/workflows/rainix-manual-sol-verify.yaml
@@ -65,7 +65,7 @@ on:
       CI_DEPLOY_FLARE_ETHERSCAN_API_KEY:
         required: false
 env:
-  RAINIX_SHA: 3d1c85eca08ef5a852215f77c8f3684c8313a8b3
+  RAINIX_SHA: c4cf22d9b76600a4ad33b5552f4083f80d9b83de
 jobs:
   verify:
     runs-on: ubuntu-latest

--- a/.github/workflows/rainix-rs-static.yaml
+++ b/.github/workflows/rainix-rs-static.yaml
@@ -2,7 +2,7 @@ name: rainix-rs-static
 on:
   workflow_call:
 env:
-  RAINIX_SHA: 3d1c85eca08ef5a852215f77c8f3684c8313a8b3
+  RAINIX_SHA: c4cf22d9b76600a4ad33b5552f4083f80d9b83de
 jobs:
   rs-static:
     runs-on: ubuntu-latest

--- a/.github/workflows/rainix-rs-test.yaml
+++ b/.github/workflows/rainix-rs-test.yaml
@@ -2,7 +2,7 @@ name: rainix-rs-test
 on:
   workflow_call:
 env:
-  RAINIX_SHA: 3d1c85eca08ef5a852215f77c8f3684c8313a8b3
+  RAINIX_SHA: c4cf22d9b76600a4ad33b5552f4083f80d9b83de
 jobs:
   rs-test:
     strategy:

--- a/.github/workflows/rainix-rs-wasm-test.yaml
+++ b/.github/workflows/rainix-rs-wasm-test.yaml
@@ -2,7 +2,7 @@ name: rainix-rs-wasm-test
 on:
   workflow_call:
 env:
-  RAINIX_SHA: 3d1c85eca08ef5a852215f77c8f3684c8313a8b3
+  RAINIX_SHA: c4cf22d9b76600a4ad33b5552f4083f80d9b83de
 jobs:
   rs-wasm-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/rainix-rs-wasm.yaml
+++ b/.github/workflows/rainix-rs-wasm.yaml
@@ -2,7 +2,7 @@ name: rainix-rs-wasm
 on:
   workflow_call:
 env:
-  RAINIX_SHA: 3d1c85eca08ef5a852215f77c8f3684c8313a8b3
+  RAINIX_SHA: c4cf22d9b76600a4ad33b5552f4083f80d9b83de
 jobs:
   rs-wasm:
     runs-on: ubuntu-latest

--- a/.github/workflows/rainix-sol-legal.yaml
+++ b/.github/workflows/rainix-sol-legal.yaml
@@ -2,7 +2,7 @@ name: rainix-sol-legal
 on:
   workflow_call:
 env:
-  RAINIX_SHA: 3d1c85eca08ef5a852215f77c8f3684c8313a8b3
+  RAINIX_SHA: c4cf22d9b76600a4ad33b5552f4083f80d9b83de
 jobs:
   legal:
     runs-on: ubuntu-latest

--- a/.github/workflows/rainix-sol-static.yaml
+++ b/.github/workflows/rainix-sol-static.yaml
@@ -2,7 +2,7 @@ name: rainix-sol-static
 on:
   workflow_call:
 env:
-  RAINIX_SHA: 3d1c85eca08ef5a852215f77c8f3684c8313a8b3
+  RAINIX_SHA: c4cf22d9b76600a4ad33b5552f4083f80d9b83de
 jobs:
   static:
     runs-on: ubuntu-latest

--- a/.github/workflows/rainix-sol-test.yaml
+++ b/.github/workflows/rainix-sol-test.yaml
@@ -25,7 +25,7 @@ on:
       RPC_URL_SEPOLIA_FORK:
         required: false
 env:
-  RAINIX_SHA: 3d1c85eca08ef5a852215f77c8f3684c8313a8b3
+  RAINIX_SHA: c4cf22d9b76600a4ad33b5552f4083f80d9b83de
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/rainix-subgraph-test.yaml
+++ b/.github/workflows/rainix-subgraph-test.yaml
@@ -2,7 +2,7 @@ name: rainix-subgraph-test
 on:
   workflow_call:
 env:
-  RAINIX_SHA: 3d1c85eca08ef5a852215f77c8f3684c8313a8b3
+  RAINIX_SHA: c4cf22d9b76600a4ad33b5552f4083f80d9b83de
 jobs:
   subgraph-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/rainix-tag-release.yaml
+++ b/.github/workflows/rainix-tag-release.yaml
@@ -124,7 +124,7 @@ on:
       RPC_URL_SEPOLIA_FORK:
         required: false
 env:
-  RAINIX_SHA: 3d1c85eca08ef5a852215f77c8f3684c8313a8b3
+  RAINIX_SHA: c4cf22d9b76600a4ad33b5552f4083f80d9b83de
 jobs:
   # The release tag must point at a commit already merged to the release branch.
   # `on: push: tags` fires for ANY tag, including one cut from an unmerged branch;


### PR DESCRIPTION
#350 put `pkgs.yq-go` in `sol-build-inputs`, but every reusable workflow still pins
`3d1c85e` — the shell from before that merge. Until this bump, `yq` is on `main` and on
PATH nowhere.

13 workflow files, one `RAINIX_SHA` line each,
`3d1c85eca08ef5a852215f77c8f3684c8313a8b3` → `c4cf22d9b76600a4ad33b5552f4083f80d9b83de`
(the merge commit of #350).

## QA

- Discriminating tests: n/a - the diff is 13 identical one-line pin changes in workflow
  YAML and contains no executable code. The discriminating check is CI itself: this PR's
  own `rainix-check-shell` job resolves the new SHA and runs `sol-shell-test`, which now
  includes `yq.test.bats` — so a bad pin either fails to fetch the shell or lands on a
  shell without `yq`, and goes red rather than silently continuing on the old one.
  Verified the replacement is exact and total: 13 files matched the old SHA before, 13
  carry the new one after, and zero occurrences of `3d1c85e` remain under
  `.github/workflows/`.
- Mutations applied: n/a - no executable code in the diff to mutate. `mutation-probe`
  needs a suite and a source line; a pin string has neither. The shell contents this pin
  activates are covered by `yq.test.bats` and `slim.test.bats` in #350.
- Oracle: a reusable workflow pins the rainix it runs from via `RAINIX_SHA`, so merging a
  shell change to `main` does not deploy it — the pin bump is what deploys it.
  `c4cf22d9b76600a4ad33b5552f4083f80d9b83de` read from
  `gh api repos/rainlanguage/rainix/commits/main`, not assumed from the PR page.
- Category check: the ask is "make #350's `yq` reachable from the sol lane". Covered
  exactly — every pin in the repo, nothing else touched. Consumer repos reference the
  reusables at `@main`, so they inherit this without a change of their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
